### PR TITLE
Move estimate() to MesageDispatcher

### DIFF
--- a/script/VaultsDeployer.s.sol
+++ b/script/VaultsDeployer.s.sol
@@ -55,7 +55,7 @@ contract VaultsDeployer is CommonDeployer {
 
         poolManager = new PoolManager(address(escrow), tokenFactory, vaultFactories);
         balanceSheet = new BalanceSheet(address(escrow));
-        vaultRouter = new VaultRouter(centrifugeId, address(routerEscrow), address(gateway), address(poolManager));
+        vaultRouter = new VaultRouter(address(routerEscrow), address(gateway), address(poolManager), messageDispatcher);
 
         _vaultsRegister();
         _vaultsEndorse();

--- a/snapshots/VaultRouter.json
+++ b/snapshots/VaultRouter.json
@@ -1,8 +1,8 @@
 {
-  "claimDeposit": "700003",
+  "claimDeposit": "699981",
   "enable": "60759",
-  "lockDepositRequest": "91966",
-  "requestDeposit": "524054",
-  "requestRedeem": "1611121",
+  "lockDepositRequest": "92036",
+  "requestDeposit": "524124",
+  "requestRedeem": "1611125",
   "transferShares": "471770"
 }

--- a/src/common/MessageDispatcher.sol
+++ b/src/common/MessageDispatcher.sol
@@ -25,20 +25,7 @@ import {IVaultMessageSender, IPoolMessageSender, IRootMessageSender} from "src/c
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
-
-interface IMessageDispatcher is IRootMessageSender, IVaultMessageSender, IPoolMessageSender {
-    /// @notice Emitted when a call to `file()` was performed.
-    event File(bytes32 indexed what, address addr);
-
-    /// @notice Dispatched when the `what` parameter of `file()` is not supported by the implementation.
-    error FileUnrecognizedParam();
-
-    /// @notice Updates a contract parameter.
-    /// @param what Name of the parameter to update.
-    /// Accepts a `bytes32` representation of 'hubRegistry' string value.
-    /// @param data New value given to the `what` parameter
-    function file(bytes32 what, address data) external;
-}
+import {IMessageDispatcher} from "src/common/interfaces/IMessageDispatcher.sol";
 
 contract MessageDispatcher is Auth, IMessageDispatcher {
     using MessageLib for *;
@@ -70,6 +57,12 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
         else revert FileUnrecognizedParam();
 
         emit File(what, data);
+    }
+
+    /// @inheritdoc IMessageDispatcher
+    function estimate(uint16 centrifugeId, bytes calldata payload) external view returns (uint256 amount) {
+        if (centrifugeId == localCentrifugeId) return 0;
+        (, amount) = IGateway(gateway).estimate(centrifugeId, payload);
     }
 
     /// @inheritdoc IPoolMessageSender

--- a/src/common/interfaces/IMessageDispatcher.sol
+++ b/src/common/interfaces/IMessageDispatcher.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity >=0.5.0;
+
+import {IVaultMessageSender, IPoolMessageSender, IRootMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
+
+interface IMessageDispatcher is IRootMessageSender, IVaultMessageSender, IPoolMessageSender {
+    /// @notice Emitted when a call to `file()` was performed.
+    event File(bytes32 indexed what, address addr);
+
+    /// @notice Dispatched when the `what` parameter of `file()` is not supported by the implementation.
+    error FileUnrecognizedParam();
+
+    /// @notice Updates a contract parameter.
+    /// @param what Name of the parameter to update.
+    /// Accepts a `bytes32` representation of 'hubRegistry' string value.
+    /// @param data New value given to the `what` parameter
+    function file(bytes32 what, address data) external;
+
+    /// @notice Estimate sending a message through the gateway.
+    /// If the message is to the same centrifugeId, then the estimation is 0.
+    function estimate(uint16 centrifugeId, bytes calldata payload) external view returns (uint256 amount);
+}

--- a/test/vaults/unit/VaultRouter.t.sol
+++ b/test/vaults/unit/VaultRouter.t.sol
@@ -38,7 +38,7 @@ contract VaultRouterTest is BaseTest {
 
     function testInitialization() public {
         // redeploying within test to increase coverage
-        new VaultRouter(CHAIN_ID, address(routerEscrow), address(gateway), address(poolManager));
+        new VaultRouter(address(routerEscrow), address(gateway), address(poolManager), messageDispatcher);
 
         assertEq(address(vaultRouter.escrow()), address(routerEscrow));
         assertEq(address(vaultRouter.gateway()), address(gateway));


### PR DESCRIPTION
`estimate()` method should be better in `MessageDispatcher`, because:
- It's shared across Hub and Vaults.
- It already knows about `localCentrifugeId`, so we can remove the `localCentrifugeId` from VaultRouter too.