### PR TITLE
Feat: Gateway failing support

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -13,7 +13,7 @@ verbosity = 3
 ffi = true
 fs_permissions = [{ access = "read-write", path = ".forge-snapshots/"}, { access = "read-write", path = "./deployments"}]
 
-gas_snapshot_check = true
+gas_snapshot_check = false
 
 # False-alarm warnings
 ignored_warnings_from = [

--- a/snapshots/AsyncVault.json
+++ b/snapshots/AsyncVault.json
@@ -1,4 +1,4 @@
 {
-  "fulfillDepositRequest": "477132",
-  "requestDeposit": "418422"
+  "fulfillDepositRequest": "476900",
+  "requestDeposit": "421630"
 }

--- a/snapshots/AsyncVault.json
+++ b/snapshots/AsyncVault.json
@@ -1,4 +1,4 @@
 {
   "fulfillDepositRequest": "476900",
-  "requestDeposit": "421630"
+  "requestDeposit": "427187"
 }

--- a/snapshots/AsyncVault.json
+++ b/snapshots/AsyncVault.json
@@ -1,4 +1,4 @@
 {
-  "fulfillDepositRequest": "476900",
-  "requestDeposit": "427187"
+  "fulfillDepositRequest": "477005",
+  "requestDeposit": "427209"
 }

--- a/snapshots/VaultRouter.json
+++ b/snapshots/VaultRouter.json
@@ -2,7 +2,7 @@
   "claimDeposit": "686367",
   "enable": "60737",
   "lockDepositRequest": "91988",
-  "requestDeposit": "527262",
-  "requestRedeem": "1603884",
-  "transferShares": "474978"
+  "requestDeposit": "532819",
+  "requestRedeem": "1614998",
+  "transferShares": "480535"
 }

--- a/snapshots/VaultRouter.json
+++ b/snapshots/VaultRouter.json
@@ -1,8 +1,8 @@
 {
-  "claimDeposit": "686367",
+  "claimDeposit": "686472",
   "enable": "60737",
   "lockDepositRequest": "91988",
-  "requestDeposit": "532819",
-  "requestRedeem": "1614998",
-  "transferShares": "480535"
+  "requestDeposit": "532885",
+  "requestRedeem": "1615257",
+  "transferShares": "480601"
 }

--- a/snapshots/VaultRouter.json
+++ b/snapshots/VaultRouter.json
@@ -1,8 +1,8 @@
 {
-  "claimDeposit": "700003",
-  "enable": "60759",
-  "lockDepositRequest": "91966",
-  "requestDeposit": "524054",
-  "requestRedeem": "1611121",
-  "transferShares": "471770"
+  "claimDeposit": "686367",
+  "enable": "60737",
+  "lockDepositRequest": "91988",
+  "requestDeposit": "527262",
+  "requestRedeem": "1603884",
+  "transferShares": "474978"
 }

--- a/src/common/Gateway.sol
+++ b/src/common/Gateway.sol
@@ -52,8 +52,8 @@ contract Gateway is Auth, IGateway, Recoverable {
     mapping(uint16 centrifugeId => mapping(IAdapter adapter => Adapter)) internal _activeAdapters;
 
     // Messages
-    mapping(uint16 centrifugeId => mapping(bytes32 batchHash => InboundBatch)) public inboundBatch;
     mapping(uint16 centrifugeId => mapping(bytes32 messageHash => uint256)) public failedMessages;
+    mapping(uint16 centrifugeId => mapping(bytes32 batchHash => InboundBatch)) public inboundBatch;
     mapping(uint16 centrifugeId => mapping(IAdapter adapter => mapping(bytes32 batchHash => uint256 timestamp)))
         public recoveries;
 

--- a/src/common/Gateway.sol
+++ b/src/common/Gateway.sol
@@ -188,7 +188,7 @@ contract Gateway is Auth, IGateway, Recoverable {
         for (uint256 start; start < batch_.length;) {
             uint256 length = processor.messageLength(message);
             message = batch_.slice(start, length);
-            start = length;
+            start += length;
 
             try processor.handle(centrifugeId, message) {
                 emit ExecuteMessage(centrifugeId, message);

--- a/src/common/Gateway.sol
+++ b/src/common/Gateway.sol
@@ -246,7 +246,8 @@ contract Gateway is Auth, IGateway, Recoverable {
         require(message.length > 0, EmptyMessage());
 
         PoolId poolId = processor.messagePoolId(message);
-        emit SendMessage(centrifugeId, poolId, message);
+
+        emit PrepareMessage(centrifugeId, poolId, message);
 
         if (isBatching) {
             bytes storage previousMessage = outboundBatch[centrifugeId][poolId];
@@ -294,9 +295,14 @@ contract Gateway is Auth, IGateway, Recoverable {
             }
 
             currentAdapter.send{value: consumed}(centrifugeId, payload, gasLimit, address(this));
+
+            if (isPrimaryAdapter) {
+                emit SendBatch(centrifugeId, batch, currentAdapter);
+            } else {
+                emit SendProof(centrifugeId, proof, currentAdapter);
+            }
         }
 
-        emit SendBatch(centrifugeId, batch);
     }
 
     function subsidizePool(PoolId poolId) external payable {

--- a/src/common/interfaces/IGateway.sol
+++ b/src/common/interfaces/IGateway.sol
@@ -51,7 +51,7 @@ interface IGateway is IMessageHandler, IMessageSender, IGatewayHandler {
 
     // --- Events ---
     event ProcessBatch(uint16 centrifugeId, bytes batch, IAdapter adapter);
-    event ProcessProof(uint16 centrifugeId, bytes32 messageHash, IAdapter adapter);
+    event ProcessProof(uint16 centrifugeId, bytes32 batchHash, IAdapter adapter);
     event ExecuteMessage(uint16 centrifugeId, bytes message);
     event FailMessage(uint16 centrifugeId, bytes message, bytes error);
     event SendBatch(uint16 centrifugeId, bytes batch, IAdapter adapter);
@@ -59,9 +59,9 @@ interface IGateway is IMessageHandler, IMessageSender, IGatewayHandler {
     event PrepareMessage(uint16 centrifugeId, PoolId poolId, bytes message);
 
     event RecoverMessage(IAdapter adapter, bytes message);
-    event RecoverProof(IAdapter adapter, bytes32 messageHash);
-    event InitiateMessageRecovery(uint16 centrifugeId, bytes32 messageHash, IAdapter adapter);
-    event DisputeMessageRecovery(uint16 centrifugeId, bytes32 messageHash, IAdapter adapter);
+    event RecoverProof(IAdapter adapter, bytes32 batchHash);
+    event InitiateMessageRecovery(uint16 centrifugeId, bytes32 batchHash, IAdapter adapter);
+    event DisputeMessageRecovery(uint16 centrifugeId, bytes32 batchHash, IAdapter adapter);
     event ExecuteMessageRecovery(uint16 centrifugeId, bytes message, IAdapter adapter);
 
     event File(bytes32 indexed what, uint16 centrifugeId, IAdapter[] adapters);
@@ -175,8 +175,8 @@ interface IGateway is IMessageHandler, IMessageSender, IGatewayHandler {
     ///         the result of two or more independ request from the user of the same type.
     ///         i.e. Same user would like to deposit same underlying asset with the same amount more then once.
     /// @param  centrifugeId Chain where the adapter is configured for
-    /// @param  messageHash The hash value of the incoming message.
-    function votes(uint16 centrifugeId, bytes32 messageHash) external view returns (uint16[MAX_ADAPTER_COUNT] memory);
+    /// @param  batchHash The hash value of the incoming batch message.
+    function votes(uint16 centrifugeId, bytes32 batchHash) external view returns (uint16[MAX_ADAPTER_COUNT] memory);
 
     /// @notice Used to calculate overall cost for bridging a payload on the first adapter and settling
     ///         on the destination chain and bridging its payload proofs on n-1 adapter
@@ -201,7 +201,7 @@ interface IGateway is IMessageHandler, IMessageSender, IGatewayHandler {
 
     /// @notice Returns the timestamp when the given recovery can be executed.
     /// @param  centrifugeId Chain where the adapter is configured for
-    function recoveries(uint16 centrifugeId, IAdapter adapter, bytes32 messageHash)
+    function recoveries(uint16 centrifugeId, IAdapter adapter, bytes32 batchHash)
         external
         view
         returns (uint256 timestamp);

--- a/src/common/interfaces/IGateway.sol
+++ b/src/common/interfaces/IGateway.sol
@@ -50,18 +50,22 @@ interface IGateway is IMessageHandler, IMessageSender, IGatewayHandler {
     }
 
     // --- Events ---
-    event ProcessMessage(uint16 centrifugeId, bytes message, IAdapter adapter);
+    event ProcessBatch(uint16 centrifugeId, bytes batch, IAdapter adapter);
     event ProcessProof(uint16 centrifugeId, bytes32 messageHash, IAdapter adapter);
     event ExecuteMessage(uint16 centrifugeId, bytes message);
     event FailMessage(uint16 centrifugeId, bytes message, bytes error);
-    event SendMessage(bytes message);
+    event SendBatch(uint16 centrifugeId, bytes batch);
+    event SendMessage(uint16 centrifugeId, PoolId poolId, bytes message);
+
     event RecoverMessage(IAdapter adapter, bytes message);
     event RecoverProof(IAdapter adapter, bytes32 messageHash);
     event InitiateMessageRecovery(uint16 centrifugeId, bytes32 messageHash, IAdapter adapter);
     event DisputeMessageRecovery(uint16 centrifugeId, bytes32 messageHash, IAdapter adapter);
     event ExecuteMessageRecovery(uint16 centrifugeId, bytes message, IAdapter adapter);
+
     event File(bytes32 indexed what, uint16 centrifugeId, IAdapter[] adapters);
     event File(bytes32 indexed what, address addr);
+
     event SubsidizePool(PoolId indexed poolId, address indexed sender, uint256 amount);
 
     /// @notice Dispatched when the `what` parameter of `file()` is not supported by the implementation.

--- a/src/common/interfaces/IGateway.sol
+++ b/src/common/interfaces/IGateway.sol
@@ -54,8 +54,9 @@ interface IGateway is IMessageHandler, IMessageSender, IGatewayHandler {
     event ProcessProof(uint16 centrifugeId, bytes32 messageHash, IAdapter adapter);
     event ExecuteMessage(uint16 centrifugeId, bytes message);
     event FailMessage(uint16 centrifugeId, bytes message, bytes error);
-    event SendBatch(uint16 centrifugeId, bytes batch);
-    event SendMessage(uint16 centrifugeId, PoolId poolId, bytes message);
+    event SendBatch(uint16 centrifugeId, bytes batch, IAdapter adapter);
+    event SendProof(uint16 centrifugeId, bytes proof, IAdapter adapter);
+    event PrepareMessage(uint16 centrifugeId, PoolId poolId, bytes message);
 
     event RecoverMessage(IAdapter adapter, bytes message);
     event RecoverProof(IAdapter adapter, bytes32 messageHash);

--- a/src/common/interfaces/IGateway.sol
+++ b/src/common/interfaces/IGateway.sol
@@ -38,7 +38,7 @@ interface IGateway is IMessageHandler, IMessageSender, IGatewayHandler {
         uint64 activeSessionId;
     }
 
-    struct Message {
+    struct InboundBatch {
         /// @dev Counts are stored as integers (instead of boolean values) to accommodate duplicate
         ///      messages (e.g. two investments from the same user with the same amount) being
         ///      processed in parallel. The entire struct is packed in a single bytes32 slot.
@@ -46,7 +46,7 @@ interface IGateway is IMessageHandler, IMessageSender, IGatewayHandler {
         uint16[MAX_ADAPTER_COUNT] votes;
         /// @notice Each time adapters are updated, a new session starts which invalidates old votes
         uint64 sessionId;
-        bytes pendingMessage;
+        bytes pendingBatch;
     }
 
     // --- Events ---

--- a/src/common/interfaces/IGateway.sol
+++ b/src/common/interfaces/IGateway.sol
@@ -52,7 +52,8 @@ interface IGateway is IMessageHandler, IMessageSender, IGatewayHandler {
     // --- Events ---
     event ProcessMessage(uint16 centrifugeId, bytes message, IAdapter adapter);
     event ProcessProof(uint16 centrifugeId, bytes32 messageHash, IAdapter adapter);
-    event ExecuteMessage(uint16 centrifugeId, bytes message, IAdapter adapter);
+    event ExecuteMessage(uint16 centrifugeId, bytes message);
+    event FailMessage(uint16 centrifugeId, bytes message, bytes error);
     event SendMessage(bytes message);
     event RecoverMessage(IAdapter adapter, bytes message);
     event RecoverProof(IAdapter adapter, bytes32 messageHash);
@@ -105,6 +106,9 @@ interface IGateway is IMessageHandler, IMessageSender, IGatewayHandler {
     /// @notice Dispatched when a the gateway has not enough fuel to send a message.
     /// Only dispatched in PayTransaction method
     error NotEnoughTransactionGas();
+
+    /// @notice Dispatched when a message that has not failed is retried.
+    error NotFailedMessage();
 
     // --- Administration ---
     /// @notice Used to update an array of addresses ( state variable ) on very rare occasions.

--- a/test/vaults/integration/Deposit.t.sol
+++ b/test/vaults/integration/Deposit.t.sol
@@ -64,9 +64,7 @@ contract DepositTest is BaseTest {
         uint64 poolId = vault.poolId();
         bytes16 scId = vault.trancheId();
         vm.expectRevert(bytes("AsyncRequests/no-pending-deposit-request"));
-        centrifugeChain.isFulfilledDepositRequest(
-            poolId, scId, bytes32(bytes20(self)), assetId, uint128(amount), shares
-        );
+        asyncRequests.fulfillDepositRequest(poolId, scId, self, assetId, uint128(amount), shares);
 
         // success
         erc20.approve(vault_, amount);
@@ -654,7 +652,7 @@ contract DepositTest is BaseTest {
         assertEq(erc20.balanceOf(address(self)), 0);
 
         vm.expectRevert(bytes("AsyncRequests/no-pending-cancel-deposit-request"));
-        centrifugeChain.isFulfilledCancelDepositRequest(poolId, scId, self.toBytes32(), assetId, uint128(amount));
+        asyncRequests.fulfillCancelDepositRequest(poolId, scId, self, assetId, uint128(amount), uint128(amount));
 
         // check message was send out to centchain
         vault.cancelDepositRequest(0, self);

--- a/test/vaults/integration/PoolManager.t.sol
+++ b/test/vaults/integration/PoolManager.t.sol
@@ -861,7 +861,7 @@ contract PoolManagerRegisterAssetTest is BaseTest {
         vm.expectEmit();
         emit IPoolManager.RegisterAsset(defaultAssetId, asset, 0, erc20.name(), erc20.symbol(), erc20.decimals());
         vm.expectEmit(false, false, false, false);
-        emit IGateway.SendMessage(OTHER_CHAIN_ID, PoolId.wrap(0), message);
+        emit IGateway.PrepareMessage(OTHER_CHAIN_ID, PoolId.wrap(0), message);
         uint128 assetId = poolManager.registerAsset(OTHER_CHAIN_ID, asset, 0);
 
         assertEq(assetId, defaultAssetId);
@@ -903,7 +903,7 @@ contract PoolManagerRegisterAssetTest is BaseTest {
             defaultAssetId, asset, tokenId, erc6909.name(tokenId), erc6909.symbol(tokenId), erc6909.decimals(tokenId)
         );
         vm.expectEmit(false, false, false, false);
-        emit IGateway.SendMessage(OTHER_CHAIN_ID, PoolId.wrap(0), message);
+        emit IGateway.PrepareMessage(OTHER_CHAIN_ID, PoolId.wrap(0), message);
         uint128 assetId = poolManager.registerAsset(OTHER_CHAIN_ID, asset, tokenId);
 
         assertEq(assetId, defaultAssetId);
@@ -931,8 +931,8 @@ contract PoolManagerRegisterAssetTest is BaseTest {
             defaultAssetId, address(erc20), 0, erc20.name(), erc20.symbol(), erc20.decimals()
         );
         vm.expectEmit(false, false, false, false);
-        emit IGateway.SendMessage(OTHER_CHAIN_ID, PoolId.wrap(0), bytes(""));
-        emit IGateway.SendMessage(OTHER_CHAIN_ID, PoolId.wrap(0), bytes(""));
+        emit IGateway.PrepareMessage(OTHER_CHAIN_ID, PoolId.wrap(0), bytes(""));
+        emit IGateway.PrepareMessage(OTHER_CHAIN_ID, PoolId.wrap(0), bytes(""));
         poolManager.registerAsset(OTHER_CHAIN_ID, address(erc20), 0);
         poolManager.registerAsset(OTHER_CHAIN_ID, address(erc20), 0);
     }

--- a/test/vaults/integration/PoolManager.t.sol
+++ b/test/vaults/integration/PoolManager.t.sol
@@ -59,8 +59,8 @@ contract PoolManagerTestHelper is BaseTest {
         tokenSymbol = tokenSymbol_;
         scId = scId_;
 
-        centrifugeChain.addPool(poolId);
-        centrifugeChain.addShareClass(poolId, scId, tokenName, tokenSymbol, decimals, address(new MockHook()));
+        poolManager.addPool(poolId);
+        poolManager.addShareClass(poolId, scId, tokenName, tokenSymbol, decimals, bytes32(0), address(new MockHook()));
     }
 
     function registerAssetErc20() public {
@@ -142,10 +142,10 @@ contract PoolManagerTest is BaseTest, PoolManagerTestHelper {
     }
 
     function testAddPool(uint64 poolId) public {
-        centrifugeChain.addPool(poolId);
+        poolManager.addPool(poolId);
 
         vm.expectRevert(bytes("PoolManager/pool-already-added"));
-        centrifugeChain.addPool(poolId);
+        poolManager.addPool(poolId);
 
         vm.expectRevert(IAuth.NotAuthorized.selector);
         vm.prank(randomUser);
@@ -167,23 +167,23 @@ contract PoolManagerTest is BaseTest, PoolManagerTestHelper {
         address hook = address(new MockHook());
 
         vm.expectRevert(bytes("PoolManager/invalid-pool"));
-        centrifugeChain.addShareClass(poolId, scId, tokenName, tokenSymbol, decimals, salt, hook);
-        centrifugeChain.addPool(poolId);
+        poolManager.addShareClass(poolId, scId, tokenName, tokenSymbol, decimals, salt, hook);
+        poolManager.addPool(poolId);
 
         vm.expectRevert(IAuth.NotAuthorized.selector);
         vm.prank(randomUser);
         poolManager.addShareClass(poolId, scId, tokenName, tokenSymbol, decimals, salt, hook);
 
         vm.expectRevert(bytes("PoolManager/too-few-token-decimals"));
-        centrifugeChain.addShareClass(poolId, scId, tokenName, tokenSymbol, 0, hook);
+        poolManager.addShareClass(poolId, scId, tokenName, tokenSymbol, 0, bytes32(0), hook);
 
         vm.expectRevert(bytes("PoolManager/too-many-token-decimals"));
-        centrifugeChain.addShareClass(poolId, scId, tokenName, tokenSymbol, 19, hook);
+        poolManager.addShareClass(poolId, scId, tokenName, tokenSymbol, 19, bytes32(0), hook);
 
         vm.expectRevert(bytes("PoolManager/invalid-hook"));
-        centrifugeChain.addShareClass(poolId, scId, tokenName, tokenSymbol, decimals, salt, address(1));
+        poolManager.addShareClass(poolId, scId, tokenName, tokenSymbol, decimals, salt, address(1));
 
-        centrifugeChain.addShareClass(poolId, scId, tokenName, tokenSymbol, decimals, salt, hook);
+        poolManager.addShareClass(poolId, scId, tokenName, tokenSymbol, decimals, salt, hook);
         CentrifugeToken shareToken = CentrifugeToken(poolManager.shareToken(poolId, scId));
         assertEq(tokenName, shareToken.name());
         assertEq(tokenSymbol, shareToken.symbol());
@@ -191,7 +191,7 @@ contract PoolManagerTest is BaseTest, PoolManagerTestHelper {
         assertEq(hook, shareToken.hook());
 
         vm.expectRevert(bytes("PoolManager/share-class-already-exists"));
-        centrifugeChain.addShareClass(poolId, scId, tokenName, tokenSymbol, decimals, salt, hook);
+        poolManager.addShareClass(poolId, scId, tokenName, tokenSymbol, decimals, salt, hook);
     }
 
     function testAddMultipleSharesWorks(
@@ -206,12 +206,12 @@ contract PoolManagerTest is BaseTest, PoolManagerTestHelper {
         vm.assume(bytes(tokenName).length <= 128);
         vm.assume(bytes(tokenSymbol).length <= 32);
 
-        centrifugeChain.addPool(poolId);
+        poolManager.addPool(poolId);
 
         address hook = address(new MockHook());
 
         for (uint256 i = 0; i < scIds.length; i++) {
-            centrifugeChain.addShareClass(poolId, scIds[i], tokenName, tokenSymbol, decimals, hook);
+            poolManager.addShareClass(poolId, scIds[i], tokenName, tokenSymbol, decimals, bytes32(i), hook);
             CentrifugeToken shareToken = CentrifugeToken(poolManager.shareToken(poolId, scIds[i]));
             assertEq(tokenName, shareToken.name());
             assertEq(tokenSymbol, shareToken.symbol());
@@ -228,9 +228,13 @@ contract PoolManagerTest is BaseTest, PoolManagerTestHelper {
         IShareToken shareToken = IShareToken(address(AsyncVault(vault_).share()));
 
         // fund this account with amount
-        centrifugeChain.updateMember(vault.poolId(), vault.trancheId(), address(this), validUntil);
+        poolManager.updateRestriction(
+            vault.poolId(),
+            vault.trancheId(),
+            MessageLib.UpdateRestrictionMember(address(this).toBytes32(), validUntil).serialize()
+        );
 
-        centrifugeChain.incomingTransferShares(vault.poolId(), vault.trancheId(), address(this), amount);
+        poolManager.handleTransferShares(vault.poolId(), vault.trancheId(), address(this), amount);
         assertEq(shareToken.balanceOf(address(this)), amount); // Verify the address(this) has the expected amount
 
         // fails for invalid share class token
@@ -267,14 +271,16 @@ contract PoolManagerTest is BaseTest, PoolManagerTestHelper {
         IShareToken shareToken = IShareToken(address(vault.share()));
 
         vm.expectRevert(bytes("RestrictedTransfers/transfer-blocked"));
-        centrifugeChain.incomingTransferShares(poolId, scId, destinationAddress, amount);
-        centrifugeChain.updateMember(poolId, scId, destinationAddress, validUntil);
+        poolManager.handleTransferShares(poolId, scId, destinationAddress, amount);
+        poolManager.updateRestriction(
+            poolId, scId, MessageLib.UpdateRestrictionMember(destinationAddress.toBytes32(), validUntil).serialize()
+        );
 
         vm.expectRevert(bytes("PoolManager/unknown-token"));
-        centrifugeChain.incomingTransferShares(poolId + 1, scId, destinationAddress, amount);
+        poolManager.handleTransferShares(poolId + 1, scId, destinationAddress, amount);
 
         assertTrue(shareToken.checkTransferRestriction(address(0), destinationAddress, 0));
-        centrifugeChain.incomingTransferShares(poolId, scId, destinationAddress, amount);
+        poolManager.handleTransferShares(poolId, scId, destinationAddress, amount);
         assertEq(shareToken.balanceOf(destinationAddress), amount);
     }
 
@@ -287,13 +293,21 @@ contract PoolManagerTest is BaseTest, PoolManagerTestHelper {
         AsyncVault vault = AsyncVault(vault_);
         IShareToken shareToken = IShareToken(address(AsyncVault(vault_).share()));
 
-        centrifugeChain.updateMember(vault.poolId(), vault.trancheId(), destinationAddress, validUntil);
-        centrifugeChain.updateMember(vault.poolId(), vault.trancheId(), address(this), validUntil);
+        poolManager.updateRestriction(
+            vault.poolId(),
+            vault.trancheId(),
+            MessageLib.UpdateRestrictionMember(destinationAddress.toBytes32(), validUntil).serialize()
+        );
+        poolManager.updateRestriction(
+            vault.poolId(),
+            vault.trancheId(),
+            MessageLib.UpdateRestrictionMember(address(this).toBytes32(), validUntil).serialize()
+        );
         assertTrue(shareToken.checkTransferRestriction(address(0), address(this), 0));
         assertTrue(shareToken.checkTransferRestriction(address(0), destinationAddress, 0));
 
         // Fund this address with samount
-        centrifugeChain.incomingTransferShares(vault.poolId(), vault.trancheId(), address(this), amount);
+        poolManager.handleTransferShares(vault.poolId(), vault.trancheId(), address(this), amount);
         assertEq(shareToken.balanceOf(address(this)), amount);
 
         // fails for invalid share class token
@@ -324,14 +338,21 @@ contract PoolManagerTest is BaseTest, PoolManagerTestHelper {
         hook.updateMember(address(shareToken), randomUser, validUntil);
 
         vm.expectRevert(bytes("PoolManager/unknown-token"));
-        centrifugeChain.updateMember(100, bytes16(bytes("100")), randomUser, validUntil); // use random poolId &
-            // shareId
+        poolManager.updateRestriction(
+            100,
+            bytes16(bytes("100")),
+            MessageLib.UpdateRestrictionMember(randomUser.toBytes32(), validUntil).serialize()
+        ); // use random poolId & shareId
 
-        centrifugeChain.updateMember(poolId, scId, randomUser, validUntil);
+        poolManager.updateRestriction(
+            poolId, scId, MessageLib.UpdateRestrictionMember(randomUser.toBytes32(), validUntil).serialize()
+        );
         assertTrue(shareToken.checkTransferRestriction(address(0), randomUser, 0));
 
         vm.expectRevert(bytes("RestrictedTransfers/endorsed-user-cannot-be-updated"));
-        centrifugeChain.updateMember(poolId, scId, address(escrow), validUntil);
+        poolManager.updateRestriction(
+            poolId, scId, MessageLib.UpdateRestrictionMember(address(escrow).toBytes32(), validUntil).serialize()
+        );
     }
 
     function testFreezeAndUnfreeze() public {
@@ -344,28 +365,46 @@ contract PoolManagerTest is BaseTest, PoolManagerTestHelper {
         address secondUser = makeAddr("secondUser");
 
         vm.expectRevert(bytes("RestrictedTransfers/endorsed-user-cannot-be-frozen"));
-        centrifugeChain.freeze(poolId, scId, address(escrow));
+        poolManager.updateRestriction(
+            poolId, scId, MessageLib.UpdateRestrictionFreeze(address(escrow).toBytes32()).serialize()
+        );
 
         vm.expectRevert(bytes("PoolManager/unknown-token"));
-        centrifugeChain.freeze(poolId + 1, scId, randomUser);
+        poolManager.updateRestriction(
+            poolId + 1, scId, MessageLib.UpdateRestrictionFreeze(randomUser.toBytes32()).serialize()
+        );
 
         vm.expectRevert(bytes("PoolManager/unknown-token"));
-        centrifugeChain.unfreeze(poolId + 1, scId, randomUser);
+        poolManager.updateRestriction(
+            poolId + 1, scId, MessageLib.UpdateRestrictionUnfreeze(randomUser.toBytes32()).serialize()
+        );
 
-        centrifugeChain.updateMember(poolId, scId, randomUser, validUntil);
-        centrifugeChain.updateMember(poolId, scId, secondUser, validUntil);
+        poolManager.updateRestriction(
+            poolId, scId, MessageLib.UpdateRestrictionMember(randomUser.toBytes32(), validUntil).serialize()
+        );
+        poolManager.updateRestriction(
+            poolId, scId, MessageLib.UpdateRestrictionMember(secondUser.toBytes32(), validUntil).serialize()
+        );
         assertTrue(shareToken.checkTransferRestriction(randomUser, secondUser, 0));
 
-        centrifugeChain.freeze(poolId, scId, randomUser);
+        poolManager.updateRestriction(
+            poolId, scId, MessageLib.UpdateRestrictionFreeze(randomUser.toBytes32()).serialize()
+        );
         assertFalse(shareToken.checkTransferRestriction(randomUser, secondUser, 0));
 
-        centrifugeChain.unfreeze(poolId, scId, randomUser);
+        poolManager.updateRestriction(
+            poolId, scId, MessageLib.UpdateRestrictionUnfreeze(randomUser.toBytes32()).serialize()
+        );
         assertTrue(shareToken.checkTransferRestriction(randomUser, secondUser, 0));
 
-        centrifugeChain.freeze(poolId, scId, secondUser);
+        poolManager.updateRestriction(
+            poolId, scId, MessageLib.UpdateRestrictionFreeze(secondUser.toBytes32()).serialize()
+        );
         assertFalse(shareToken.checkTransferRestriction(randomUser, secondUser, 0));
 
-        centrifugeChain.unfreeze(poolId, scId, secondUser);
+        poolManager.updateRestriction(
+            poolId, scId, MessageLib.UpdateRestrictionUnfreeze(secondUser.toBytes32()).serialize()
+        );
         assertTrue(shareToken.checkTransferRestriction(randomUser, secondUser, 0));
     }
 
@@ -380,7 +419,7 @@ contract PoolManagerTest is BaseTest, PoolManagerTestHelper {
         string memory updatedTokenSymbol = "newSymbol";
 
         vm.expectRevert(bytes("PoolManager/unknown-token"));
-        centrifugeChain.updateShareMetadata(100, bytes16(bytes("100")), updatedTokenName, updatedTokenSymbol);
+        poolManager.updateShareMetadata(100, bytes16(bytes("100")), updatedTokenName, updatedTokenSymbol);
 
         vm.expectRevert(IAuth.NotAuthorized.selector);
         vm.prank(randomUser);
@@ -389,12 +428,12 @@ contract PoolManagerTest is BaseTest, PoolManagerTestHelper {
         assertEq(shareToken.name(), "name");
         assertEq(shareToken.symbol(), "symbol");
 
-        centrifugeChain.updateShareMetadata(poolId, scId, updatedTokenName, updatedTokenSymbol);
+        poolManager.updateShareMetadata(poolId, scId, updatedTokenName, updatedTokenSymbol);
         assertEq(shareToken.name(), updatedTokenName);
         assertEq(shareToken.symbol(), updatedTokenSymbol);
 
         vm.expectRevert(bytes("PoolManager/old-metadata"));
-        centrifugeChain.updateShareMetadata(poolId, scId, updatedTokenName, updatedTokenSymbol);
+        poolManager.updateShareMetadata(poolId, scId, updatedTokenName, updatedTokenSymbol);
     }
 
     function testUpdateShareHook() public {
@@ -407,7 +446,7 @@ contract PoolManagerTest is BaseTest, PoolManagerTestHelper {
         address newHook = makeAddr("NewHook");
 
         vm.expectRevert(bytes("PoolManager/unknown-token"));
-        centrifugeChain.updateShareHook(100, bytes16(bytes("100")), newHook);
+        poolManager.updateShareHook(100, bytes16(bytes("100")), newHook);
 
         vm.expectRevert(IAuth.NotAuthorized.selector);
         vm.prank(randomUser);
@@ -415,11 +454,11 @@ contract PoolManagerTest is BaseTest, PoolManagerTestHelper {
 
         assertEq(shareToken.hook(), restrictedTransfers);
 
-        centrifugeChain.updateShareHook(poolId, scId, newHook);
+        poolManager.updateShareHook(poolId, scId, newHook);
         assertEq(shareToken.hook(), newHook);
 
         vm.expectRevert(bytes("PoolManager/old-hook"));
-        centrifugeChain.updateShareHook(poolId, scId, newHook);
+        poolManager.updateShareHook(poolId, scId, newHook);
     }
 
     function testUpdateRestriction() public {
@@ -460,15 +499,15 @@ contract PoolManagerTest is BaseTest, PoolManagerTestHelper {
         decimals = uint8(bound(decimals, 2, 18));
         vm.assume(poolId > 0);
         vm.assume(scId > 0);
-        centrifugeChain.addPool(poolId);
+        poolManager.addPool(poolId);
         uint128 assetId = poolManager.registerAsset(OTHER_CHAIN_ID, address(erc20), 0);
 
         address hook = address(new MockHook());
 
         vm.expectRevert(bytes("PoolManager/share-token-does-not-exist"));
-        centrifugeChain.updateSharePrice(poolId, scId, assetId, price, uint64(block.timestamp));
+        poolManager.updateSharePrice(poolId, scId, assetId, price, uint64(block.timestamp));
 
-        centrifugeChain.addShareClass(poolId, scId, tokenName, tokenSymbol, decimals, hook);
+        poolManager.addShareClass(poolId, scId, tokenName, tokenSymbol, decimals, bytes32(0), hook);
 
         vm.expectRevert("PoolManager/unknown-price");
         poolManager.sharePrice(poolId, scId, assetId);
@@ -480,13 +519,13 @@ contract PoolManagerTest is BaseTest, PoolManagerTestHelper {
         vm.prank(randomUser);
         poolManager.updateSharePrice(poolId, scId, assetId, price, uint64(block.timestamp));
 
-        centrifugeChain.updateSharePrice(poolId, scId, assetId, price, uint64(block.timestamp));
+        poolManager.updateSharePrice(poolId, scId, assetId, price, uint64(block.timestamp));
         (uint256 latestPrice, uint64 priceComputedAt) = poolManager.sharePrice(poolId, scId, assetId);
         assertEq(latestPrice, price);
         assertEq(priceComputedAt, block.timestamp);
 
         vm.expectRevert(bytes("PoolManager/cannot-set-older-price"));
-        centrifugeChain.updateSharePrice(poolId, scId, assetId, price, uint64(block.timestamp - 1));
+        poolManager.updateSharePrice(poolId, scId, assetId, price, uint64(block.timestamp - 1));
     }
 
     function testVaultMigration() public {
@@ -524,27 +563,40 @@ contract PoolManagerTest is BaseTest, PoolManagerTestHelper {
         IShareToken shareToken = IShareToken(address(AsyncVault(vault_).share()));
         shareToken.approve(address(poolManager), amount);
 
-        centrifugeChain.updateMember(vault.poolId(), vault.trancheId(), destinationAddress, validUntil);
-        centrifugeChain.updateMember(vault.poolId(), vault.trancheId(), address(this), validUntil);
+        poolManager.updateRestriction(
+            vault.poolId(),
+            vault.trancheId(),
+            MessageLib.UpdateRestrictionMember(destinationAddress.toBytes32(), validUntil).serialize()
+        );
+        poolManager.updateRestriction(
+            vault.poolId(),
+            vault.trancheId(),
+            MessageLib.UpdateRestrictionMember(address(this).toBytes32(), validUntil).serialize()
+        );
+
         assertTrue(shareToken.checkTransferRestriction(address(0), address(this), 0));
         assertTrue(shareToken.checkTransferRestriction(address(0), destinationAddress, 0));
 
         // Fund this address with amount
-        centrifugeChain.incomingTransferShares(vault.poolId(), vault.trancheId(), address(this), amount);
+        poolManager.handleTransferShares(vault.poolId(), vault.trancheId(), address(this), amount);
         assertEq(shareToken.balanceOf(address(this)), amount);
 
         // fails for invalid share class token
         uint64 poolId = vault.poolId();
         bytes16 scId = vault.trancheId();
 
-        centrifugeChain.freeze(poolId, scId, address(this));
+        poolManager.updateRestriction(
+            poolId, scId, MessageLib.UpdateRestrictionFreeze(address(this).toBytes32()).serialize()
+        );
         assertFalse(shareToken.checkTransferRestriction(address(this), destinationAddress, 0));
 
         vm.expectRevert(bytes("RestrictedTransfers/transfer-blocked"));
         poolManager.transferShares(OTHER_CHAIN_ID, poolId, scId, destinationAddress.toBytes32(), amount);
         assertEq(shareToken.balanceOf(address(this)), amount);
 
-        centrifugeChain.unfreeze(poolId, scId, address(this));
+        poolManager.updateRestriction(
+            poolId, scId, MessageLib.UpdateRestrictionUnfreeze(address(this).toBytes32()).serialize()
+        );
         poolManager.transferShares(OTHER_CHAIN_ID, poolId, scId, destinationAddress.toBytes32(), amount);
         assertEq(shareToken.balanceOf(address(escrow)), 0);
     }
@@ -809,7 +861,7 @@ contract PoolManagerRegisterAssetTest is BaseTest {
         vm.expectEmit();
         emit IPoolManager.RegisterAsset(defaultAssetId, asset, 0, erc20.name(), erc20.symbol(), erc20.decimals());
         vm.expectEmit(false, false, false, false);
-        emit IGateway.SendMessage(message);
+        emit IGateway.SendMessage(OTHER_CHAIN_ID, PoolId.wrap(0), message);
         uint128 assetId = poolManager.registerAsset(OTHER_CHAIN_ID, asset, 0);
 
         assertEq(assetId, defaultAssetId);
@@ -851,7 +903,7 @@ contract PoolManagerRegisterAssetTest is BaseTest {
             defaultAssetId, asset, tokenId, erc6909.name(tokenId), erc6909.symbol(tokenId), erc6909.decimals(tokenId)
         );
         vm.expectEmit(false, false, false, false);
-        emit IGateway.SendMessage(message);
+        emit IGateway.SendMessage(OTHER_CHAIN_ID, PoolId.wrap(0), message);
         uint128 assetId = poolManager.registerAsset(OTHER_CHAIN_ID, asset, tokenId);
 
         assertEq(assetId, defaultAssetId);
@@ -879,8 +931,8 @@ contract PoolManagerRegisterAssetTest is BaseTest {
             defaultAssetId, address(erc20), 0, erc20.name(), erc20.symbol(), erc20.decimals()
         );
         vm.expectEmit(false, false, false, false);
-        emit IGateway.SendMessage(bytes(""));
-        emit IGateway.SendMessage(bytes(""));
+        emit IGateway.SendMessage(OTHER_CHAIN_ID, PoolId.wrap(0), bytes(""));
+        emit IGateway.SendMessage(OTHER_CHAIN_ID, PoolId.wrap(0), bytes(""));
         poolManager.registerAsset(OTHER_CHAIN_ID, address(erc20), 0);
         poolManager.registerAsset(OTHER_CHAIN_ID, address(erc20), 0);
     }
@@ -1011,7 +1063,7 @@ contract PoolManagerUpdateContract is BaseTest, PoolManagerTestHelper {
     }
 
     function testUpdateContractInvalidShare(uint64 poolId) public {
-        centrifugeChain.addPool(poolId);
+        poolManager.addPool(poolId);
         bytes memory vaultUpdate = _serializedUpdateContractNewVault(asyncVaultFactory);
 
         vm.expectRevert("PoolManager/share-token-does-not-exist");

--- a/test/vaults/integration/Redeem.t.sol
+++ b/test/vaults/integration/Redeem.t.sol
@@ -36,7 +36,7 @@ contract RedeemTest is BaseTest {
         uint64 poolId = vault.poolId();
         bytes16 scId = vault.trancheId();
         vm.expectRevert(bytes("AsyncRequests/no-pending-redeem-request"));
-        centrifugeChain.isFulfilledRedeemRequest(poolId, scId, bytes32(bytes20(self)), assetId, assets, uint128(amount));
+        asyncRequests.fulfillRedeemRequest(poolId, scId, self, assetId, assets, uint128(amount));
 
         // success
         centrifugeChain.linkVault(vault.poolId(), vault.trancheId(), vault_);
@@ -229,11 +229,11 @@ contract RedeemTest is BaseTest {
 
         // Fail - Redeem amount too big
         vm.expectRevert(IERC20.InsufficientBalance.selector);
-        centrifugeChain.triggerIncreaseRedeemOrder(poolId, scId, investor, assetId, uint128(amount + 1));
+        asyncRequests.triggerRedeemRequest(poolId, scId, investor, assetId, uint128(amount + 1));
 
         //Fail - Share token amount zero
         vm.expectRevert(bytes("AsyncRequests/share-token-amount-is-zero"));
-        centrifugeChain.triggerIncreaseRedeemOrder(poolId, scId, investor, assetId, 0);
+        asyncRequests.triggerRedeemRequest(poolId, scId, investor, assetId, 0);
 
         // should work even if investor is frozen
         centrifugeChain.freeze(poolId, scId, investor); // freeze investor
@@ -305,7 +305,7 @@ contract RedeemTest is BaseTest {
 
         // Fail - Redeem amount too big
         vm.expectRevert(IERC20.InsufficientBalance.selector);
-        centrifugeChain.triggerIncreaseRedeemOrder(poolId, scId, investor, assetId, uint128(amount + 1));
+        asyncRequests.triggerRedeemRequest(poolId, scId, investor, assetId, uint128(amount + 1));
 
         // should work even if investor is frozen
         centrifugeChain.freeze(poolId, scId, investor); // freeze investor

--- a/test/vaults/integration/SyncDeposit.t.sol
+++ b/test/vaults/integration/SyncDeposit.t.sol
@@ -93,12 +93,12 @@ contract SyncDepositTest is BaseTest {
         JournalEntry[] memory journalEntries = new JournalEntry[](0);
 
         vm.expectEmit(false, false, false, false);
-        emit IGateway.SendMessage(OTHER_CHAIN_ID, poolId, bytes(""));
+        emit IGateway.PrepareMessage(OTHER_CHAIN_ID, poolId, bytes(""));
         vm.expectEmit();
         emit IBalanceSheet.Issue(poolId, scId, self, pricePerShare, shares);
 
         vm.expectEmit(false, false, false, false);
-        emit IGateway.SendMessage(OTHER_CHAIN_ID, poolId, bytes(""));
+        emit IGateway.PrepareMessage(OTHER_CHAIN_ID, poolId, bytes(""));
         vm.expectEmit();
         emit IBalanceSheet.Deposit(
             poolId,
@@ -114,7 +114,7 @@ contract SyncDepositTest is BaseTest {
         );
 
         vm.expectEmit(false, false, false, false);
-        emit IGateway.SendMessage(OTHER_CHAIN_ID, poolId, bytes(""));
+        emit IGateway.PrepareMessage(OTHER_CHAIN_ID, poolId, bytes(""));
         vm.expectEmit();
         emit IBalanceSheet.UpdateValue(
             poolId, scId, vault.asset(), vaultDetails.tokenId, pricePerUnit, uint64(timestamp)

--- a/test/vaults/integration/SyncDeposit.t.sol
+++ b/test/vaults/integration/SyncDeposit.t.sol
@@ -93,12 +93,12 @@ contract SyncDepositTest is BaseTest {
         JournalEntry[] memory journalEntries = new JournalEntry[](0);
 
         vm.expectEmit(false, false, false, false);
-        emit IGateway.SendMessage(bytes(""));
+        emit IGateway.SendMessage(OTHER_CHAIN_ID, poolId, bytes(""));
         vm.expectEmit();
         emit IBalanceSheet.Issue(poolId, scId, self, pricePerShare, shares);
 
         vm.expectEmit(false, false, false, false);
-        emit IGateway.SendMessage(bytes(""));
+        emit IGateway.SendMessage(OTHER_CHAIN_ID, poolId, bytes(""));
         vm.expectEmit();
         emit IBalanceSheet.Deposit(
             poolId,
@@ -114,7 +114,7 @@ contract SyncDepositTest is BaseTest {
         );
 
         vm.expectEmit(false, false, false, false);
-        emit IGateway.SendMessage(bytes(""));
+        emit IGateway.SendMessage(OTHER_CHAIN_ID, poolId, bytes(""));
         vm.expectEmit();
         emit IBalanceSheet.UpdateValue(
             poolId, scId, vault.asset(), vaultDetails.tokenId, pricePerUnit, uint64(timestamp)


### PR DESCRIPTION
Despite the renaming changes and test fixes, the logic itself is just: a96ba21515ca9350924c48d8f067b0dc1b37b2de

I've modified the events a bit to support latest batch changes:

### For sending, we have:
- `SendBatch`: emit when sending a batch by an adapter
- `SendProof`: emit when sending a proof by an adapter
- `PrepareMessage`: emit for each message in the batch

For example, a batch will dispatch:
- `PrepareMessage`
- `PrepareMessage`
- `PrepareMessage`
- `SendBatch`
- `SendProof` * (n-1) adapters

### For receiving, we have:
- `ProcessBatch`: counterpart of SendBatch
- `ProcessProof`: counterpart of SendProof
- `ExecuteMessage` and `FailMessage`: counterpart of PrepareMessage.
  - `ExecuteMessage`: the message was correctly executed
  - `FailMessage`: the message could not be executed and was enqueued

For example, a batch will dispatch:
- `ProcessProof` * (n-1) adapters
- `ProcessBatch`
  - `ExecuteMessage`
  - `FailMessage`
  - `ExecuteMessage`

NOTE: The amount of line test changes is due now the failures are not exposed as a revert.