### PR TITLE
Add PoolId, ShareClassId and AssetId types to common module

### DIFF
--- a/snapshots/AsyncVault.json
+++ b/snapshots/AsyncVault.json
@@ -1,4 +1,4 @@
 {
-  "fulfillDepositRequest": "921847",
-  "requestDeposit": "474062"
+  "fulfillDepositRequest": "920169",
+  "requestDeposit": "472013"
 }

--- a/snapshots/VaultRouter.json
+++ b/snapshots/VaultRouter.json
@@ -1,7 +1,7 @@
 {
-  "claimDeposit": "1154607",
+  "claimDeposit": "1152929",
   "enable": "60953",
   "lockDepositRequest": "92339",
-  "requestDeposit": "597367",
-  "requestRedeem": "2120682"
+  "requestDeposit": "593286",
+  "requestRedeem": "2110856"
 }

--- a/src/common/MessageDispatcher.sol
+++ b/src/common/MessageDispatcher.sol
@@ -78,7 +78,7 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
     /// @inheritdoc IPoolMessageSender
     function sendNotifyPool(uint16 centrifugeId, PoolId poolId) external auth {
         if (centrifugeId == localCentrifugeId) {
-            poolManager.addPool(poolId.raw());
+            poolManager.addPool(poolId);
         } else {
             gateway.send(centrifugeId, MessageLib.NotifyPool({poolId: poolId.raw()}).serialize());
         }
@@ -96,7 +96,7 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
         bytes32 hook
     ) external auth {
         if (centrifugeId == localCentrifugeId) {
-            poolManager.addShareClass(poolId.raw(), scId.raw(), name, symbol, decimals, salt, hook.toAddress());
+            poolManager.addShareClass(poolId, scId, name, symbol, decimals, salt, hook.toAddress());
         } else {
             gateway.send(
                 centrifugeId,
@@ -120,7 +120,7 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
     {
         uint64 timestamp = block.timestamp.toUint64();
         if (chainId == localCentrifugeId) {
-            poolManager.updatePricePoolPerShare(poolId.raw(), scId.raw(), sharePrice.raw(), timestamp);
+            poolManager.updatePricePoolPerShare(poolId, scId, sharePrice.raw(), timestamp);
         } else {
             gateway.send(
                 chainId,
@@ -137,7 +137,7 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
     function sendNotifyPricePoolPerAsset(PoolId poolId, ShareClassId scId, AssetId assetId, D18 price) external auth {
         uint64 timestamp = block.timestamp.toUint64();
         if (assetId.centrifugeId() == localCentrifugeId) {
-            poolManager.updatePricePoolPerAsset(poolId.raw(), scId.raw(), assetId.raw(), price.raw(), timestamp);
+            poolManager.updatePricePoolPerAsset(poolId, scId, assetId, price.raw(), timestamp);
         } else {
             gateway.send(
                 assetId.centrifugeId(),
@@ -163,7 +163,7 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
     ) external auth {
         if (assetId.centrifugeId() == localCentrifugeId) {
             investmentManager.fulfillDepositRequest(
-                poolId.raw(), scId.raw(), investor.toAddress(), assetId.raw(), assetAmount, shareAmount
+                poolId, scId, investor.toAddress(), assetId, assetAmount, shareAmount
             );
         } else {
             gateway.send(
@@ -191,7 +191,7 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
     ) external auth {
         if (assetId.centrifugeId() == localCentrifugeId) {
             investmentManager.fulfillRedeemRequest(
-                poolId.raw(), scId.raw(), investor.toAddress(), assetId.raw(), assetAmount, shareAmount
+                poolId, scId, investor.toAddress(), assetId, assetAmount, shareAmount
             );
         } else {
             gateway.send(
@@ -218,7 +218,7 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
     ) external auth {
         if (assetId.centrifugeId() == localCentrifugeId) {
             investmentManager.fulfillCancelDepositRequest(
-                poolId.raw(), scId.raw(), investor.toAddress(), assetId.raw(), cancelledAmount, cancelledAmount
+                poolId, scId, investor.toAddress(), assetId, cancelledAmount, cancelledAmount
             );
         } else {
             gateway.send(
@@ -243,9 +243,7 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
         uint128 cancelledShares
     ) external auth {
         if (assetId.centrifugeId() == localCentrifugeId) {
-            investmentManager.fulfillCancelRedeemRequest(
-                poolId.raw(), scId.raw(), investor.toAddress(), assetId.raw(), cancelledShares
-            );
+            investmentManager.fulfillCancelRedeemRequest(poolId, scId, investor.toAddress(), assetId, cancelledShares);
         } else {
             gateway.send(
                 assetId.centrifugeId(),
@@ -266,7 +264,7 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
         auth
     {
         if (centrifugeId == localCentrifugeId) {
-            poolManager.updateRestriction(poolId.raw(), scId.raw(), payload);
+            poolManager.updateRestriction(poolId, scId, payload);
         } else {
             gateway.send(
                 centrifugeId,
@@ -284,7 +282,7 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
         bytes calldata payload
     ) external auth {
         if (centrifugeId == localCentrifugeId) {
-            poolManager.updateContract(poolId.raw(), scId.raw(), target.toAddress(), payload);
+            poolManager.updateContract(poolId, scId, target.toAddress(), payload);
         } else {
             gateway.send(
                 centrifugeId,
@@ -404,7 +402,7 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
     }
 
     /// @inheritdoc IVaultMessageSender
-    function sendTransferShares(uint16 centrifugeId, uint64 poolId, bytes16 scId, bytes32 receiver, uint128 amount)
+    function sendTransferShares(uint16 centrifugeId, PoolId poolId, ShareClassId scId, bytes32 receiver, uint128 amount)
         external
         auth
     {
@@ -413,24 +411,25 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
         } else {
             gateway.send(
                 centrifugeId,
-                MessageLib.TransferShares({poolId: poolId, scId: scId, receiver: receiver, amount: amount}).serialize()
+                MessageLib.TransferShares({poolId: poolId.raw(), scId: scId.raw(), receiver: receiver, amount: amount})
+                    .serialize()
             );
         }
     }
 
     /// @inheritdoc IVaultMessageSender
-    function sendDepositRequest(uint64 poolId, bytes16 scId, bytes32 investor, uint128 assetId, uint128 amount)
+    function sendDepositRequest(PoolId poolId, ShareClassId scId, bytes32 investor, uint128 assetId, uint128 amount)
         external
         auth
     {
-        if (PoolId.wrap(poolId).centrifugeId() == localCentrifugeId) {
-            hub.depositRequest(PoolId.wrap(poolId), ShareClassId.wrap(scId), investor, AssetId.wrap(assetId), amount);
+        if (poolId.centrifugeId() == localCentrifugeId) {
+            hub.depositRequest(poolId, scId, investor, AssetId.wrap(assetId), amount);
         } else {
             gateway.send(
-                PoolId.wrap(poolId).centrifugeId(),
+                poolId.centrifugeId(),
                 MessageLib.DepositRequest({
-                    poolId: poolId,
-                    scId: scId,
+                    poolId: poolId.raw(),
+                    scId: scId.raw(),
                     investor: investor,
                     assetId: assetId,
                     amount: amount
@@ -440,18 +439,18 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
     }
 
     /// @inheritdoc IVaultMessageSender
-    function sendRedeemRequest(uint64 poolId, bytes16 scId, bytes32 investor, uint128 assetId, uint128 amount)
+    function sendRedeemRequest(PoolId poolId, ShareClassId scId, bytes32 investor, uint128 assetId, uint128 amount)
         external
         auth
     {
-        if (PoolId.wrap(poolId).centrifugeId() == localCentrifugeId) {
-            hub.redeemRequest(PoolId.wrap(poolId), ShareClassId.wrap(scId), investor, AssetId.wrap(assetId), amount);
+        if (poolId.centrifugeId() == localCentrifugeId) {
+            hub.redeemRequest(poolId, scId, investor, AssetId.wrap(assetId), amount);
         } else {
             gateway.send(
-                PoolId.wrap(poolId).centrifugeId(),
+                poolId.centrifugeId(),
                 MessageLib.RedeemRequest({
-                    poolId: poolId,
-                    scId: scId,
+                    poolId: poolId.raw(),
+                    scId: scId.raw(),
                     investor: investor,
                     assetId: assetId,
                     amount: amount
@@ -461,27 +460,41 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
     }
 
     /// @inheritdoc IVaultMessageSender
-    function sendCancelDepositRequest(uint64 poolId, bytes16 scId, bytes32 investor, uint128 assetId) external auth {
-        if (PoolId.wrap(poolId).centrifugeId() == localCentrifugeId) {
-            hub.cancelDepositRequest(PoolId.wrap(poolId), ShareClassId.wrap(scId), investor, AssetId.wrap(assetId));
+    function sendCancelDepositRequest(PoolId poolId, ShareClassId scId, bytes32 investor, uint128 assetId)
+        external
+        auth
+    {
+        if (poolId.centrifugeId() == localCentrifugeId) {
+            hub.cancelDepositRequest(poolId, scId, investor, AssetId.wrap(assetId));
         } else {
             gateway.send(
-                PoolId.wrap(poolId).centrifugeId(),
-                MessageLib.CancelDepositRequest({poolId: poolId, scId: scId, investor: investor, assetId: assetId})
-                    .serialize()
+                poolId.centrifugeId(),
+                MessageLib.CancelDepositRequest({
+                    poolId: poolId.raw(),
+                    scId: scId.raw(),
+                    investor: investor,
+                    assetId: assetId
+                }).serialize()
             );
         }
     }
 
     /// @inheritdoc IVaultMessageSender
-    function sendCancelRedeemRequest(uint64 poolId, bytes16 scId, bytes32 investor, uint128 assetId) external auth {
-        if (PoolId.wrap(poolId).centrifugeId() == localCentrifugeId) {
-            hub.cancelRedeemRequest(PoolId.wrap(poolId), ShareClassId.wrap(scId), investor, AssetId.wrap(assetId));
+    function sendCancelRedeemRequest(PoolId poolId, ShareClassId scId, bytes32 investor, uint128 assetId)
+        external
+        auth
+    {
+        if (poolId.centrifugeId() == localCentrifugeId) {
+            hub.cancelRedeemRequest(poolId, scId, investor, AssetId.wrap(assetId));
         } else {
             gateway.send(
-                PoolId.wrap(poolId).centrifugeId(),
-                MessageLib.CancelRedeemRequest({poolId: poolId, scId: scId, investor: investor, assetId: assetId})
-                    .serialize()
+                poolId.centrifugeId(),
+                MessageLib.CancelRedeemRequest({
+                    poolId: poolId.raw(),
+                    scId: scId.raw(),
+                    investor: investor,
+                    assetId: assetId
+                }).serialize()
             );
         }
     }

--- a/src/common/MessageProcessor.sol
+++ b/src/common/MessageProcessor.sol
@@ -86,33 +86,47 @@ contract MessageProcessor is Auth, IMessageProcessor {
             MessageLib.RegisterAsset memory m = message.deserializeRegisterAsset();
             hub.registerAsset(AssetId.wrap(m.assetId), m.decimals);
         } else if (kind == MessageType.NotifyPool) {
-            poolManager.addPool(MessageLib.deserializeNotifyPool(message).poolId);
+            poolManager.addPool(PoolId.wrap(MessageLib.deserializeNotifyPool(message).poolId));
         } else if (kind == MessageType.NotifyShareClass) {
             MessageLib.NotifyShareClass memory m = MessageLib.deserializeNotifyShareClass(message);
             poolManager.addShareClass(
-                m.poolId, m.scId, m.name, m.symbol.toString(), m.decimals, m.salt, m.hook.toAddress()
+                PoolId.wrap(m.poolId),
+                ShareClassId.wrap(m.scId),
+                m.name,
+                m.symbol.toString(),
+                m.decimals,
+                m.salt,
+                m.hook.toAddress()
             );
         } else if (kind == MessageType.NotifyPricePoolPerShare) {
             MessageLib.NotifyPricePoolPerShare memory m = MessageLib.deserializeNotifyPricePoolPerShare(message);
-            poolManager.updatePricePoolPerShare(m.poolId, m.scId, m.price, m.timestamp);
+            poolManager.updatePricePoolPerShare(PoolId.wrap(m.poolId), ShareClassId.wrap(m.scId), m.price, m.timestamp);
         } else if (kind == MessageType.NotifyPricePoolPerAsset) {
             MessageLib.NotifyPricePoolPerAsset memory m = MessageLib.deserializeNotifyPricePoolPerAsset(message);
-            poolManager.updatePricePoolPerAsset(m.poolId, m.scId, m.assetId, m.price, m.timestamp);
+            poolManager.updatePricePoolPerAsset(
+                PoolId.wrap(m.poolId), ShareClassId.wrap(m.scId), AssetId.wrap(m.assetId), m.price, m.timestamp
+            );
         } else if (kind == MessageType.UpdateShareClassMetadata) {
             MessageLib.UpdateShareClassMetadata memory m = MessageLib.deserializeUpdateShareClassMetadata(message);
-            poolManager.updateShareMetadata(m.poolId, m.scId, m.name, m.symbol.toString());
+            poolManager.updateShareMetadata(
+                PoolId.wrap(m.poolId), ShareClassId.wrap(m.scId), m.name, m.symbol.toString()
+            );
         } else if (kind == MessageType.UpdateShareClassHook) {
             MessageLib.UpdateShareClassHook memory m = MessageLib.deserializeUpdateShareClassHook(message);
-            poolManager.updateShareHook(m.poolId, m.scId, m.hook.toAddress());
+            poolManager.updateShareHook(PoolId.wrap(m.poolId), ShareClassId.wrap(m.scId), m.hook.toAddress());
         } else if (kind == MessageType.TransferShares) {
             MessageLib.TransferShares memory m = MessageLib.deserializeTransferShares(message);
-            poolManager.handleTransferShares(m.poolId, m.scId, m.receiver.toAddress(), m.amount);
+            poolManager.handleTransferShares(
+                PoolId.wrap(m.poolId), ShareClassId.wrap(m.scId), m.receiver.toAddress(), m.amount
+            );
         } else if (kind == MessageType.UpdateRestriction) {
             MessageLib.UpdateRestriction memory m = MessageLib.deserializeUpdateRestriction(message);
-            poolManager.updateRestriction(m.poolId, m.scId, m.payload);
+            poolManager.updateRestriction(PoolId.wrap(m.poolId), ShareClassId.wrap(m.scId), m.payload);
         } else if (kind == MessageType.UpdateContract) {
             MessageLib.UpdateContract memory m = MessageLib.deserializeUpdateContract(message);
-            poolManager.updateContract(m.poolId, m.scId, m.target.toAddress(), m.payload);
+            poolManager.updateContract(
+                PoolId.wrap(m.poolId), ShareClassId.wrap(m.scId), m.target.toAddress(), m.payload
+            );
         } else if (kind == MessageType.DepositRequest) {
             MessageLib.DepositRequest memory m = message.deserializeDepositRequest();
             hub.depositRequest(
@@ -136,26 +150,51 @@ contract MessageProcessor is Auth, IMessageProcessor {
         } else if (kind == MessageType.FulfilledDepositRequest) {
             MessageLib.FulfilledDepositRequest memory m = message.deserializeFulfilledDepositRequest();
             investmentManager.fulfillDepositRequest(
-                m.poolId, m.scId, m.investor.toAddress(), m.assetId, m.assetAmount, m.shareAmount
+                PoolId.wrap(m.poolId),
+                ShareClassId.wrap(m.scId),
+                m.investor.toAddress(),
+                AssetId.wrap(m.assetId),
+                m.assetAmount,
+                m.shareAmount
             );
         } else if (kind == MessageType.FulfilledRedeemRequest) {
             MessageLib.FulfilledRedeemRequest memory m = message.deserializeFulfilledRedeemRequest();
             investmentManager.fulfillRedeemRequest(
-                m.poolId, m.scId, m.investor.toAddress(), m.assetId, m.assetAmount, m.shareAmount
+                PoolId.wrap(m.poolId),
+                ShareClassId.wrap(m.scId),
+                m.investor.toAddress(),
+                AssetId.wrap(m.assetId),
+                m.assetAmount,
+                m.shareAmount
             );
         } else if (kind == MessageType.FulfilledCancelDepositRequest) {
             MessageLib.FulfilledCancelDepositRequest memory m = message.deserializeFulfilledCancelDepositRequest();
             investmentManager.fulfillCancelDepositRequest(
-                m.poolId, m.scId, m.investor.toAddress(), m.assetId, m.cancelledAmount, m.cancelledAmount
+                PoolId.wrap(m.poolId),
+                ShareClassId.wrap(m.scId),
+                m.investor.toAddress(),
+                AssetId.wrap(m.assetId),
+                m.cancelledAmount,
+                m.cancelledAmount
             );
         } else if (kind == MessageType.FulfilledCancelRedeemRequest) {
             MessageLib.FulfilledCancelRedeemRequest memory m = message.deserializeFulfilledCancelRedeemRequest();
             investmentManager.fulfillCancelRedeemRequest(
-                m.poolId, m.scId, m.investor.toAddress(), m.assetId, m.cancelledShares
+                PoolId.wrap(m.poolId),
+                ShareClassId.wrap(m.scId),
+                m.investor.toAddress(),
+                AssetId.wrap(m.assetId),
+                m.cancelledShares
             );
         } else if (kind == MessageType.TriggerRedeemRequest) {
             MessageLib.TriggerRedeemRequest memory m = message.deserializeTriggerRedeemRequest();
-            investmentManager.triggerRedeemRequest(m.poolId, m.scId, m.investor.toAddress(), m.assetId, m.shares);
+            investmentManager.triggerRedeemRequest(
+                PoolId.wrap(m.poolId),
+                ShareClassId.wrap(m.scId),
+                m.investor.toAddress(),
+                AssetId.wrap(m.assetId),
+                m.shares
+            );
         } else if (kind == MessageType.TriggerUpdateHoldingAmount) {
             MessageLib.TriggerUpdateHoldingAmount memory m = message.deserializeTriggerUpdateHoldingAmount();
 

--- a/src/common/interfaces/IGatewayHandlers.sol
+++ b/src/common/interfaces/IGatewayHandlers.sol
@@ -75,13 +75,13 @@ interface IHubGatewayHandler {
 interface IPoolManagerGatewayHandler {
     /// @notice    New pool details from an existing Centrifuge pool are added.
     /// @dev       The function can only be executed by the gateway contract.
-    function addPool(uint64 poolId) external;
+    function addPool(PoolId poolId) external;
 
     /// @notice     New share class details from an existing Centrifuge pool are added.
     /// @dev        The function can only be executed by the gateway contract.
     function addShareClass(
-        uint64 poolId,
-        bytes16 scId,
+        PoolId poolId,
+        ShareClassId scId,
         string memory tokenName,
         string memory tokenSymbol,
         uint8 decimals,
@@ -91,7 +91,7 @@ interface IPoolManagerGatewayHandler {
 
     /// @notice   Updates the tokenName and tokenSymbol of a share class token
     /// @dev      The function can only be executed by the gateway contract.
-    function updateShareMetadata(uint64 poolId, bytes16 scId, string memory tokenName, string memory tokenSymbol)
+    function updateShareMetadata(PoolId poolId, ShareClassId scId, string memory tokenName, string memory tokenSymbol)
         external;
 
     /// @notice  Updates the price of a share class token, i.e. the factor of pool currency amount per share class token
@@ -100,7 +100,7 @@ interface IPoolManagerGatewayHandler {
     /// @param  scId The share class id
     /// @param  price The price of pool currency per share class token as factor.
     /// @param  computedAt The timestamp when the price was computed
-    function updatePricePoolPerShare(uint64 poolId, bytes16 scId, uint128 price, uint64 computedAt) external;
+    function updatePricePoolPerShare(PoolId poolId, ShareClassId scId, uint128 price, uint64 computedAt) external;
 
     /// @notice  Updates the price of an asset, i.e. the factor of pool currency amount per asset unit
     /// @dev     The function can only be executed by the gateway contract.
@@ -110,9 +110,9 @@ interface IPoolManagerGatewayHandler {
     /// @param  poolPerAsset The price of pool currency per asset unit as factor.
     /// @param  computedAt The timestamp when the price was computed
     function updatePricePoolPerAsset(
-        uint64 poolId,
-        bytes16 scId,
-        uint128 assetId,
+        PoolId poolId,
+        ShareClassId scId,
+        AssetId assetId,
         uint128 poolPerAsset,
         uint64 computedAt
     ) external;
@@ -121,25 +121,26 @@ interface IPoolManagerGatewayHandler {
     /// @param  poolId The centrifuge pool id
     /// @param  scId The share class id
     /// @param  hook The new hook addres
-    function updateShareHook(uint64 poolId, bytes16 scId, address hook) external;
+    function updateShareHook(PoolId poolId, ShareClassId scId, address hook) external;
 
     /// @notice Updates the restrictions on a share class token for a specific user
     /// @param  poolId The centrifuge pool id
     /// @param  scId The share class id
     /// @param  update The restriction update in the form of a bytes array indicating
     ///                the restriction to be updated, the user to be updated, and a validUntil timestamp.
-    function updateRestriction(uint64 poolId, bytes16 scId, bytes memory update) external;
+    function updateRestriction(PoolId poolId, ShareClassId scId, bytes memory update) external;
 
     /// @notice Mints share class tokens to a recipient
     /// @dev    The function can only be executed internally or by the gateway contract.
-    function handleTransferShares(uint64 poolId, bytes16 scId, address destinationAddress, uint128 amount) external;
+    function handleTransferShares(PoolId poolId, ShareClassId scId, address destinationAddress, uint128 amount)
+        external;
 
     /// @notice Updates the target address. Generic update function from CP to CV
     /// @param  poolId The centrifuge pool id
     /// @param  scId The share class id
     /// @param  target The target address to be called
     /// @param  update The payload to be processed by the target address
-    function updateContract(uint64 poolId, bytes16 scId, address target, bytes memory update) external;
+    function updateContract(PoolId poolId, ShareClassId scId, address target, bytes memory update) external;
 }
 
 /// @notice Interface for CV methods related to async investments called by messages
@@ -152,10 +153,10 @@ interface IInvestmentManagerGatewayHandler {
     /// @dev    The shares in the escrow are reserved for the user and are transferred to the user on deposit
     ///         and mint calls.
     function fulfillDepositRequest(
-        uint64 poolId,
-        bytes16 scId,
+        PoolId poolId,
+        ShareClassId scId,
         address user,
-        uint128 assetId,
+        AssetId assetId,
         uint128 assets,
         uint128 shares
     ) external;
@@ -211,10 +212,10 @@ interface IInvestmentManagerGatewayHandler {
     ///         so there are no more `pendingDepositRequest` and right there the `pendingCancelDepositRequest will be
     ///         deleted.
     function fulfillCancelDepositRequest(
-        uint64 poolId,
-        bytes16 scId,
+        PoolId poolId,
+        ShareClassId scId,
         address user,
-        uint128 assetId,
+        AssetId assetId,
         uint128 assets,
         uint128 fulfillment
     ) external;
@@ -227,10 +228,10 @@ interface IInvestmentManagerGatewayHandler {
     /// @dev    The assets in the escrow are reserved for the user and are transferred to the user on redeem
     ///         and withdraw calls.
     function fulfillRedeemRequest(
-        uint64 poolId,
-        bytes16 scId,
+        PoolId poolId,
+        ShareClassId scId,
         address user,
-        uint128 assetId,
+        AssetId assetId,
         uint128 assets,
         uint128 shares
     ) external;
@@ -241,7 +242,7 @@ interface IInvestmentManagerGatewayHandler {
     ///         partial.
     /// @dev    The shares in the escrow are reserved for the user and are transferred to the user during
     ///         claimCancelRedeemRequest calls.
-    function fulfillCancelRedeemRequest(uint64 poolId, bytes16 scId, address user, uint128 assetId, uint128 shares)
+    function fulfillCancelRedeemRequest(PoolId poolId, ShareClassId scId, address user, AssetId assetId, uint128 shares)
         external;
 
     /// @notice Triggers a redeem request on behalf of the user through Centrifuge governance.
@@ -252,7 +253,7 @@ interface IInvestmentManagerGatewayHandler {
     ///         got fulfilled.
     /// @dev    The user share amount required to fulfill the redeem request has to be locked in escrow,
     ///         even though the asset payout can only happen after epoch execution.
-    function triggerRedeemRequest(uint64 poolId, bytes16 scId, address user, uint128 assetId, uint128 shares)
+    function triggerRedeemRequest(PoolId poolId, ShareClassId scId, address user, AssetId assetId, uint128 shares)
         external;
 }
 

--- a/src/common/interfaces/IGatewaySenders.sol
+++ b/src/common/interfaces/IGatewaySenders.sol
@@ -124,22 +124,22 @@ interface IPoolMessageSender is ILocalCentrifugeId {
 /// @notice Interface for dispatch-only gateway
 interface IVaultMessageSender is ILocalCentrifugeId {
     /// @notice Creates and send the message
-    function sendTransferShares(uint16 centrifugeId, uint64 poolId, bytes16 scId, bytes32 receiver, uint128 amount)
+    function sendTransferShares(uint16 centrifugeId, PoolId poolId, ShareClassId scId, bytes32 receiver, uint128 amount)
         external;
 
     /// @notice Creates and send the message
-    function sendDepositRequest(uint64 poolId, bytes16 scId, bytes32 investor, uint128 assetId, uint128 amount)
+    function sendDepositRequest(PoolId poolId, ShareClassId scId, bytes32 investor, uint128 assetId, uint128 amount)
         external;
 
     /// @notice Creates and send the message
-    function sendRedeemRequest(uint64 poolId, bytes16 scId, bytes32 investor, uint128 assetId, uint128 amount)
+    function sendRedeemRequest(PoolId poolId, ShareClassId scId, bytes32 investor, uint128 assetId, uint128 amount)
         external;
 
     /// @notice Creates and send the message
-    function sendCancelDepositRequest(uint64 poolId, bytes16 scId, bytes32 investor, uint128 assetId) external;
+    function sendCancelDepositRequest(PoolId poolId, ShareClassId scId, bytes32 investor, uint128 assetId) external;
 
     /// @notice Creates and send the message
-    function sendCancelRedeemRequest(uint64 poolId, bytes16 scId, bytes32 investor, uint128 assetId) external;
+    function sendCancelRedeemRequest(PoolId poolId, ShareClassId scId, bytes32 investor, uint128 assetId) external;
 
     /// @notice Creates and send the message
     function sendRegisterAsset(uint16 centrifugeId, uint128 assetId, uint8 decimals) external;

--- a/test/vaults/fuzzing/recon-core/targets/GatewayMockFunctions.sol
+++ b/test/vaults/fuzzing/recon-core/targets/GatewayMockFunctions.sol
@@ -7,6 +7,9 @@ import {Properties} from "../Properties.sol";
 import {vm} from "@chimera/Hevm.sol";
 
 import {MessageLib} from "src/common/libraries/MessageLib.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
+import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
 
 // Src Deps | For cycling of values
 import {AsyncVault} from "src/vaults/AsyncVault.sol";
@@ -122,7 +125,7 @@ abstract contract GatewayMockFunctions is BaseTargetFunctions, Properties {
 
     // Step 3
     function poolManager_addPool(uint64 poolId) public {
-        poolManager.addPool(poolId);
+        poolManager.addPool(PoolId.wrap(poolId));
     }
 
     // Step 4
@@ -135,7 +138,13 @@ abstract contract GatewayMockFunctions is BaseTargetFunctions, Properties {
         address hook
     ) public returns (address) {
         address newToken = poolManager.addShareClass(
-            poolId, scId, tokenName, tokenSymbol, decimals, keccak256(abi.encodePacked(poolId, scId)), hook
+            PoolId.wrap(poolId),
+            ShareClassId.wrap(scId),
+            tokenName,
+            tokenSymbol,
+            decimals,
+            keccak256(abi.encodePacked(poolId, scId)),
+            hook
         );
 
         shareClassTokens.push(newToken);
@@ -153,26 +162,38 @@ abstract contract GatewayMockFunctions is BaseTargetFunctions, Properties {
      */
     function poolManager_updateMember(uint64 validUntil) public {
         poolManager.updateRestriction(
-            poolId, scId, MessageLib.UpdateRestrictionMember(actor.toBytes32(), validUntil).serialize()
+            PoolId.wrap(poolId),
+            ShareClassId.wrap(scId),
+            MessageLib.UpdateRestrictionMember(actor.toBytes32(), validUntil).serialize()
         );
     }
 
     // TODO: Price is capped at u64 to test overflows
     function poolManager_updatePricePoolPerShare(uint64 price, uint64 computedAt) public {
-        poolManager.updatePricePoolPerShare(poolId, scId, price, computedAt);
-        poolManager.updatePricePoolPerAsset(poolId, scId, assetId, price, computedAt);
+        poolManager.updatePricePoolPerShare(PoolId.wrap(poolId), ShareClassId.wrap(scId), price, computedAt);
+        poolManager.updatePricePoolPerAsset(
+            PoolId.wrap(poolId), ShareClassId.wrap(scId), AssetId.wrap(assetId), price, computedAt
+        );
     }
 
     function poolManager_updateShareMetadata(string memory tokenName, string memory tokenSymbol) public {
-        poolManager.updateShareMetadata(poolId, scId, tokenName, tokenSymbol);
+        poolManager.updateShareMetadata(PoolId.wrap(poolId), ShareClassId.wrap(scId), tokenName, tokenSymbol);
     }
 
     function poolManager_freeze() public {
-        poolManager.updateRestriction(poolId, scId, MessageLib.UpdateRestrictionFreeze(actor.toBytes32()).serialize());
+        poolManager.updateRestriction(
+            PoolId.wrap(poolId),
+            ShareClassId.wrap(scId),
+            MessageLib.UpdateRestrictionFreeze(actor.toBytes32()).serialize()
+        );
     }
 
     function poolManager_unfreeze() public {
-        poolManager.updateRestriction(poolId, scId, MessageLib.UpdateRestrictionUnfreeze(actor.toBytes32()).serialize());
+        poolManager.updateRestriction(
+            PoolId.wrap(poolId),
+            ShareClassId.wrap(scId),
+            MessageLib.UpdateRestrictionUnfreeze(actor.toBytes32()).serialize()
+        );
     }
 
     // TODO: Rely / Permissions

--- a/test/vaults/fuzzing/recon-core/targets/PoolManagerFunctions.sol
+++ b/test/vaults/fuzzing/recon-core/targets/PoolManagerFunctions.sol
@@ -6,6 +6,9 @@ import {BaseTargetFunctions} from "@chimera/BaseTargetFunctions.sol";
 import {Properties} from "../Properties.sol";
 import {vm} from "@chimera/Hevm.sol";
 
+import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
+
 // Dependencies
 import {ERC20} from "src/misc/ERC20.sol";
 import {AsyncVault} from "src/vaults/AsyncVault.sol";
@@ -19,7 +22,7 @@ abstract contract PoolManagerFunctions is BaseTargetFunctions, Properties {
     // TODO: Actors / Randomness
     // TODO: Overflow stuff
     function poolManager_handleTransferShares(uint128 amount) public {
-        poolManager.handleTransferShares(poolId, scId, actor, amount);
+        poolManager.handleTransferShares(PoolId.wrap(poolId), ShareClassId.wrap(scId), actor, amount);
         // TF-12 mint share class tokens from user, not tracked in escrow
 
         // Track minting for Global-3

--- a/test/vaults/fuzzing/recon-core/targets/VaultCallbacks.sol
+++ b/test/vaults/fuzzing/recon-core/targets/VaultCallbacks.sol
@@ -8,6 +8,10 @@ import {BaseTargetFunctions} from "@chimera/BaseTargetFunctions.sol";
 import {Properties} from "../Properties.sol";
 import {vm} from "@chimera/Hevm.sol";
 
+import {PoolId} from "src/common/types/PoolId.sol";
+import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
+
 // Src Deps | For cycling of values
 import {AsyncVault} from "src/vaults/AsyncVault.sol";
 import {ERC20} from "src/misc/ERC20.sol";
@@ -61,7 +65,9 @@ abstract contract VaultCallbacks is BaseTargetFunctions, Properties {
             }
         }
 
-        asyncRequests.fulfillDepositRequest(poolId, scId, actor, assetId, currencyPayout, tokenPayout);
+        asyncRequests.fulfillDepositRequest(
+            PoolId.wrap(poolId), ShareClassId.wrap(scId), actor, AssetId.wrap(assetId), currencyPayout, tokenPayout
+        );
 
         // E-2 | Global-1
         sumOfFullfilledDeposits[address(token)] += tokenPayout;
@@ -120,7 +126,9 @@ abstract contract VaultCallbacks is BaseTargetFunctions, Properties {
         // /// @audit We mint payout here which has to be paid by the borrowers
         // // END TODO test_invariant_asyncVault_10_w_recon
 
-        asyncRequests.fulfillRedeemRequest(poolId, scId, actor, assetId, currencyPayout, tokenPayout);
+        asyncRequests.fulfillRedeemRequest(
+            PoolId.wrap(poolId), ShareClassId.wrap(scId), actor, AssetId.wrap(assetId), currencyPayout, tokenPayout
+        );
 
         sumOfClaimedRequests[address(token)] += tokenPayout;
 
@@ -179,7 +187,9 @@ abstract contract VaultCallbacks is BaseTargetFunctions, Properties {
         // Need to cap remainingInvestOrder by the shares?
 
         // TODO: Would they set the order to a higher value?
-        asyncRequests.fulfillCancelDepositRequest(poolId, scId, actor, assetId, currencyPayout, currencyPayout);
+        asyncRequests.fulfillCancelDepositRequest(
+            PoolId.wrap(poolId), ShareClassId.wrap(scId), actor, AssetId.wrap(assetId), currencyPayout, currencyPayout
+        );
         /// @audit Reduced by: currencyPayout
 
         cancelDepositCurrencyPayout[address(assetErc20)] += currencyPayout;
@@ -230,7 +240,9 @@ abstract contract VaultCallbacks is BaseTargetFunctions, Properties {
             }
         }
 
-        asyncRequests.fulfillCancelRedeemRequest(poolId, scId, actor, assetId, tokenPayout);
+        asyncRequests.fulfillCancelRedeemRequest(
+            PoolId.wrap(poolId), ShareClassId.wrap(scId), actor, AssetId.wrap(assetId), tokenPayout
+        );
         /// @audit tokenPayout
 
         cancelRedeemShareTokenPayout[address(token)] += tokenPayout;

--- a/test/vaults/integration/BalanceSheet.t.sol
+++ b/test/vaults/integration/BalanceSheet.t.sol
@@ -33,25 +33,19 @@ contract BalanceSheetTest is BaseTest {
 
         assetId =
             AssetId.wrap(poolManager.registerAsset{value: 0.1 ether}(OTHER_CHAIN_ID, address(erc20), erc20TokenId));
-        poolManager.addPool(POOL_A.raw());
+        poolManager.addPool(POOL_A);
         poolManager.addShareClass(
-            POOL_A.raw(),
-            defaultShareClassId,
-            "testShareClass",
-            "tsc",
-            defaultDecimals,
-            bytes32(""),
-            restrictedTransfers
+            POOL_A, defaultTypedShareClassId, "testShareClass", "tsc", defaultDecimals, bytes32(""), restrictedTransfers
         );
         poolManager.updateRestriction(
-            POOL_A.raw(),
-            defaultShareClassId,
+            POOL_A,
+            defaultTypedShareClassId,
             MessageLib.UpdateRestrictionMember({user: address(this).toBytes32(), validUntil: MAX_UINT64}).serialize()
         );
         // In order for allowances to work during issuance, the balanceSheet must be canManage to transfer
         poolManager.updateRestriction(
-            POOL_A.raw(),
-            defaultShareClassId,
+            POOL_A,
+            defaultTypedShareClassId,
             MessageLib.UpdateRestrictionMember({user: address(balanceSheet).toBytes32(), validUntil: MAX_UINT64})
                 .serialize()
         );

--- a/test/vaults/integration/Deposit.t.sol
+++ b/test/vaults/integration/Deposit.t.sol
@@ -7,6 +7,7 @@ import {d18} from "src/misc/types/D18.sol";
 
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
 
 import "test/vaults/BaseTest.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
@@ -73,7 +74,9 @@ contract DepositTest is BaseTest {
         uint64 poolId = vault.poolId();
         bytes16 scId = vault.trancheId();
         vm.expectRevert(IAsyncRequests.NoPendingRequest.selector);
-        asyncRequests.fulfillDepositRequest(poolId, scId, self, assetId, uint128(amount), shares);
+        asyncRequests.fulfillDepositRequest(
+            PoolId.wrap(poolId), ShareClassId.wrap(scId), self, AssetId.wrap(assetId), uint128(amount), shares
+        );
 
         // success
         erc20.approve(vault_, amount);
@@ -657,7 +660,9 @@ contract DepositTest is BaseTest {
         assertEq(erc20.balanceOf(address(self)), 0);
 
         vm.expectRevert(IAsyncRequests.NoPendingRequest.selector);
-        asyncRequests.fulfillCancelDepositRequest(poolId, scId, self, assetId, uint128(amount), uint128(amount));
+        asyncRequests.fulfillCancelDepositRequest(
+            PoolId.wrap(poolId), ShareClassId.wrap(scId), self, AssetId.wrap(assetId), uint128(amount), uint128(amount)
+        );
 
         // check message was send out to centchain
         vault.cancelDepositRequest(0, self);

--- a/test/vaults/integration/PoolManager.t.sol
+++ b/test/vaults/integration/PoolManager.t.sol
@@ -14,6 +14,9 @@ import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 import {D18} from "src/misc/types/D18.sol";
 
 import {MessageLib} from "src/common/libraries/MessageLib.sol";
+import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
 
 import {IPoolManager, VaultDetails} from "src/vaults/interfaces/IPoolManager.sol";
 import {IBaseVault} from "src/vaults/interfaces/IERC7540.sol";
@@ -62,8 +65,16 @@ contract PoolManagerTestHelper is BaseTest {
         tokenSymbol = tokenSymbol_;
         scId = scId_;
 
-        poolManager.addPool(poolId);
-        poolManager.addShareClass(poolId, scId, tokenName, tokenSymbol, decimals, bytes32(0), address(new MockHook()));
+        poolManager.addPool(PoolId.wrap(poolId));
+        poolManager.addShareClass(
+            PoolId.wrap(poolId),
+            ShareClassId.wrap(scId),
+            tokenName,
+            tokenSymbol,
+            decimals,
+            bytes32(0),
+            address(new MockHook())
+        );
     }
 
     function registerAssetErc20() public {
@@ -151,14 +162,14 @@ contract PoolManagerTest is BaseTest, PoolManagerTestHelper {
     }
 
     function testAddPool(uint64 poolId) public {
-        poolManager.addPool(poolId);
+        poolManager.addPool(PoolId.wrap(poolId));
 
         vm.expectRevert(IPoolManager.PoolAlreadyAdded.selector);
-        poolManager.addPool(poolId);
+        poolManager.addPool(PoolId.wrap(poolId));
 
         vm.expectRevert(IAuth.NotAuthorized.selector);
         vm.prank(randomUser);
-        poolManager.addPool(poolId);
+        poolManager.addPool(PoolId.wrap(poolId));
     }
 
     function testAddShareClass(
@@ -176,23 +187,35 @@ contract PoolManagerTest is BaseTest, PoolManagerTestHelper {
         address hook = address(new MockHook());
 
         vm.expectRevert(IPoolManager.InvalidPool.selector);
-        poolManager.addShareClass(poolId, scId, tokenName, tokenSymbol, decimals, salt, hook);
-        poolManager.addPool(poolId);
+        poolManager.addShareClass(
+            PoolId.wrap(poolId), ShareClassId.wrap(scId), tokenName, tokenSymbol, decimals, salt, hook
+        );
+        poolManager.addPool(PoolId.wrap(poolId));
 
         vm.expectRevert(IAuth.NotAuthorized.selector);
         vm.prank(randomUser);
-        poolManager.addShareClass(poolId, scId, tokenName, tokenSymbol, decimals, salt, hook);
+        poolManager.addShareClass(
+            PoolId.wrap(poolId), ShareClassId.wrap(scId), tokenName, tokenSymbol, decimals, salt, hook
+        );
 
         vm.expectRevert(IPoolManager.TooFewDecimals.selector);
-        poolManager.addShareClass(poolId, scId, tokenName, tokenSymbol, 0, bytes32(0), hook);
+        poolManager.addShareClass(
+            PoolId.wrap(poolId), ShareClassId.wrap(scId), tokenName, tokenSymbol, 0, bytes32(0), hook
+        );
 
         vm.expectRevert(IPoolManager.TooManyDecimals.selector);
-        poolManager.addShareClass(poolId, scId, tokenName, tokenSymbol, 19, bytes32(0), hook);
+        poolManager.addShareClass(
+            PoolId.wrap(poolId), ShareClassId.wrap(scId), tokenName, tokenSymbol, 19, bytes32(0), hook
+        );
 
         vm.expectRevert(IPoolManager.InvalidHook.selector);
-        poolManager.addShareClass(poolId, scId, tokenName, tokenSymbol, decimals, salt, address(1));
+        poolManager.addShareClass(
+            PoolId.wrap(poolId), ShareClassId.wrap(scId), tokenName, tokenSymbol, decimals, salt, address(1)
+        );
 
-        poolManager.addShareClass(poolId, scId, tokenName, tokenSymbol, decimals, salt, hook);
+        poolManager.addShareClass(
+            PoolId.wrap(poolId), ShareClassId.wrap(scId), tokenName, tokenSymbol, decimals, salt, hook
+        );
         CentrifugeToken shareToken = CentrifugeToken(poolManager.shareToken(poolId, scId));
         assertEq(tokenName, shareToken.name());
         assertEq(tokenSymbol, shareToken.symbol());
@@ -200,7 +223,9 @@ contract PoolManagerTest is BaseTest, PoolManagerTestHelper {
         assertEq(hook, shareToken.hook());
 
         vm.expectRevert(IPoolManager.ShareClassAlreadyRegistered.selector);
-        poolManager.addShareClass(poolId, scId, tokenName, tokenSymbol, decimals, salt, hook);
+        poolManager.addShareClass(
+            PoolId.wrap(poolId), ShareClassId.wrap(scId), tokenName, tokenSymbol, decimals, salt, hook
+        );
     }
 
     function testAddMultipleSharesWorks(
@@ -215,12 +240,14 @@ contract PoolManagerTest is BaseTest, PoolManagerTestHelper {
         vm.assume(bytes(tokenName).length <= 128);
         vm.assume(bytes(tokenSymbol).length <= 32);
 
-        poolManager.addPool(poolId);
+        poolManager.addPool(PoolId.wrap(poolId));
 
         address hook = address(new MockHook());
 
         for (uint256 i = 0; i < scIds.length; i++) {
-            poolManager.addShareClass(poolId, scIds[i], tokenName, tokenSymbol, decimals, bytes32(i), hook);
+            poolManager.addShareClass(
+                PoolId.wrap(poolId), ShareClassId.wrap(scIds[i]), tokenName, tokenSymbol, decimals, bytes32(i), hook
+            );
             CentrifugeToken shareToken = CentrifugeToken(poolManager.shareToken(poolId, scIds[i]));
             assertEq(tokenName, shareToken.name());
             assertEq(tokenSymbol, shareToken.symbol());
@@ -238,17 +265,19 @@ contract PoolManagerTest is BaseTest, PoolManagerTestHelper {
 
         // fund this account with amount
         poolManager.updateRestriction(
-            vault.poolId(),
-            vault.trancheId(),
+            PoolId.wrap(vault.poolId()),
+            ShareClassId.wrap(vault.trancheId()),
             MessageLib.UpdateRestrictionMember(address(this).toBytes32(), validUntil).serialize()
         );
 
-        poolManager.handleTransferShares(vault.poolId(), vault.trancheId(), address(this), amount);
+        poolManager.handleTransferShares(
+            PoolId.wrap(vault.poolId()), ShareClassId.wrap(vault.trancheId()), address(this), amount
+        );
         assertEq(shareToken.balanceOf(address(this)), amount); // Verify the address(this) has the expected amount
 
         poolManager.updateRestriction(
-            vault.poolId(),
-            vault.trancheId(),
+            PoolId.wrap(vault.poolId()),
+            ShareClassId.wrap(vault.trancheId()),
             MessageLib.UpdateRestrictionMember(address(uint160(OTHER_CHAIN_ID)).toBytes32(), type(uint64).max).serialize(
             )
         );
@@ -280,16 +309,18 @@ contract PoolManagerTest is BaseTest, PoolManagerTestHelper {
         IShareToken shareToken = IShareToken(address(vault.share()));
 
         vm.expectRevert(IHook.TransferBlocked.selector);
-        poolManager.handleTransferShares(poolId, scId, destinationAddress, amount);
+        poolManager.handleTransferShares(PoolId.wrap(poolId), ShareClassId.wrap(scId), destinationAddress, amount);
         poolManager.updateRestriction(
-            poolId, scId, MessageLib.UpdateRestrictionMember(destinationAddress.toBytes32(), validUntil).serialize()
+            PoolId.wrap(poolId),
+            ShareClassId.wrap(scId),
+            MessageLib.UpdateRestrictionMember(destinationAddress.toBytes32(), validUntil).serialize()
         );
 
         vm.expectRevert(IPoolManager.UnknownToken.selector);
-        poolManager.handleTransferShares(poolId + 1, scId, destinationAddress, amount);
+        poolManager.handleTransferShares(PoolId.wrap(poolId + 1), ShareClassId.wrap(scId), destinationAddress, amount);
 
         assertTrue(shareToken.checkTransferRestriction(address(0), destinationAddress, 0));
-        poolManager.handleTransferShares(poolId, scId, destinationAddress, amount);
+        poolManager.handleTransferShares(PoolId.wrap(poolId), ShareClassId.wrap(scId), destinationAddress, amount);
         assertEq(shareToken.balanceOf(destinationAddress), amount);
     }
 
@@ -303,25 +334,27 @@ contract PoolManagerTest is BaseTest, PoolManagerTestHelper {
         IShareToken shareToken = IShareToken(address(AsyncVault(vault_).share()));
 
         poolManager.updateRestriction(
-            vault.poolId(),
-            vault.trancheId(),
+            PoolId.wrap(vault.poolId()),
+            ShareClassId.wrap(vault.trancheId()),
             MessageLib.UpdateRestrictionMember(destinationAddress.toBytes32(), validUntil).serialize()
         );
         poolManager.updateRestriction(
-            vault.poolId(),
-            vault.trancheId(),
+            PoolId.wrap(vault.poolId()),
+            ShareClassId.wrap(vault.trancheId()),
             MessageLib.UpdateRestrictionMember(address(this).toBytes32(), validUntil).serialize()
         );
         assertTrue(shareToken.checkTransferRestriction(address(0), address(this), 0));
         assertTrue(shareToken.checkTransferRestriction(address(0), destinationAddress, 0));
 
         // Fund this address with samount
-        poolManager.handleTransferShares(vault.poolId(), vault.trancheId(), address(this), amount);
+        poolManager.handleTransferShares(
+            PoolId.wrap(vault.poolId()), ShareClassId.wrap(vault.trancheId()), address(this), amount
+        );
         assertEq(shareToken.balanceOf(address(this)), amount);
 
         poolManager.updateRestriction(
-            vault.poolId(),
-            vault.trancheId(),
+            PoolId.wrap(vault.poolId()),
+            ShareClassId.wrap(vault.trancheId()),
             MessageLib.UpdateRestrictionMember(address(uint160(OTHER_CHAIN_ID)).toBytes32(), type(uint64).max).serialize(
             )
         );
@@ -356,19 +389,23 @@ contract PoolManagerTest is BaseTest, PoolManagerTestHelper {
 
         vm.expectRevert(IPoolManager.UnknownToken.selector);
         poolManager.updateRestriction(
-            100,
-            bytes16(bytes("100")),
+            PoolId.wrap(100),
+            ShareClassId.wrap(bytes16(bytes("100"))),
             MessageLib.UpdateRestrictionMember(randomUser.toBytes32(), validUntil).serialize()
         ); // use random poolId & shareId
 
         poolManager.updateRestriction(
-            poolId, scId, MessageLib.UpdateRestrictionMember(randomUser.toBytes32(), validUntil).serialize()
+            PoolId.wrap(poolId),
+            ShareClassId.wrap(scId),
+            MessageLib.UpdateRestrictionMember(randomUser.toBytes32(), validUntil).serialize()
         );
         assertTrue(shareToken.checkTransferRestriction(address(0), randomUser, 0));
 
         vm.expectRevert(IRestrictedTransfers.EndorsedUserCannotBeUpdated.selector);
         poolManager.updateRestriction(
-            poolId, scId, MessageLib.UpdateRestrictionMember(address(escrow).toBytes32(), validUntil).serialize()
+            PoolId.wrap(poolId),
+            ShareClassId.wrap(scId),
+            MessageLib.UpdateRestrictionMember(address(escrow).toBytes32(), validUntil).serialize()
         );
     }
 
@@ -383,44 +420,62 @@ contract PoolManagerTest is BaseTest, PoolManagerTestHelper {
 
         vm.expectRevert(IRestrictedTransfers.EndorsedUserCannotBeFrozen.selector);
         poolManager.updateRestriction(
-            poolId, scId, MessageLib.UpdateRestrictionFreeze(address(escrow).toBytes32()).serialize()
+            PoolId.wrap(poolId),
+            ShareClassId.wrap(scId),
+            MessageLib.UpdateRestrictionFreeze(address(escrow).toBytes32()).serialize()
         );
 
         vm.expectRevert(IPoolManager.UnknownToken.selector);
         poolManager.updateRestriction(
-            poolId + 1, scId, MessageLib.UpdateRestrictionFreeze(randomUser.toBytes32()).serialize()
+            PoolId.wrap(poolId + 1),
+            ShareClassId.wrap(scId),
+            MessageLib.UpdateRestrictionFreeze(randomUser.toBytes32()).serialize()
         );
 
         vm.expectRevert(IPoolManager.UnknownToken.selector);
         poolManager.updateRestriction(
-            poolId + 1, scId, MessageLib.UpdateRestrictionUnfreeze(randomUser.toBytes32()).serialize()
+            PoolId.wrap(poolId + 1),
+            ShareClassId.wrap(scId),
+            MessageLib.UpdateRestrictionUnfreeze(randomUser.toBytes32()).serialize()
         );
 
         poolManager.updateRestriction(
-            poolId, scId, MessageLib.UpdateRestrictionMember(randomUser.toBytes32(), validUntil).serialize()
+            PoolId.wrap(poolId),
+            ShareClassId.wrap(scId),
+            MessageLib.UpdateRestrictionMember(randomUser.toBytes32(), validUntil).serialize()
         );
         poolManager.updateRestriction(
-            poolId, scId, MessageLib.UpdateRestrictionMember(secondUser.toBytes32(), validUntil).serialize()
+            PoolId.wrap(poolId),
+            ShareClassId.wrap(scId),
+            MessageLib.UpdateRestrictionMember(secondUser.toBytes32(), validUntil).serialize()
         );
         assertTrue(shareToken.checkTransferRestriction(randomUser, secondUser, 0));
 
         poolManager.updateRestriction(
-            poolId, scId, MessageLib.UpdateRestrictionFreeze(randomUser.toBytes32()).serialize()
+            PoolId.wrap(poolId),
+            ShareClassId.wrap(scId),
+            MessageLib.UpdateRestrictionFreeze(randomUser.toBytes32()).serialize()
         );
         assertFalse(shareToken.checkTransferRestriction(randomUser, secondUser, 0));
 
         poolManager.updateRestriction(
-            poolId, scId, MessageLib.UpdateRestrictionUnfreeze(randomUser.toBytes32()).serialize()
+            PoolId.wrap(poolId),
+            ShareClassId.wrap(scId),
+            MessageLib.UpdateRestrictionUnfreeze(randomUser.toBytes32()).serialize()
         );
         assertTrue(shareToken.checkTransferRestriction(randomUser, secondUser, 0));
 
         poolManager.updateRestriction(
-            poolId, scId, MessageLib.UpdateRestrictionFreeze(secondUser.toBytes32()).serialize()
+            PoolId.wrap(poolId),
+            ShareClassId.wrap(scId),
+            MessageLib.UpdateRestrictionFreeze(secondUser.toBytes32()).serialize()
         );
         assertFalse(shareToken.checkTransferRestriction(randomUser, secondUser, 0));
 
         poolManager.updateRestriction(
-            poolId, scId, MessageLib.UpdateRestrictionUnfreeze(secondUser.toBytes32()).serialize()
+            PoolId.wrap(poolId),
+            ShareClassId.wrap(scId),
+            MessageLib.UpdateRestrictionUnfreeze(secondUser.toBytes32()).serialize()
         );
         assertTrue(shareToken.checkTransferRestriction(randomUser, secondUser, 0));
     }
@@ -436,21 +491,29 @@ contract PoolManagerTest is BaseTest, PoolManagerTestHelper {
         string memory updatedTokenSymbol = "newSymbol";
 
         vm.expectRevert(IPoolManager.UnknownToken.selector);
-        poolManager.updateShareMetadata(100, bytes16(bytes("100")), updatedTokenName, updatedTokenSymbol);
+        poolManager.updateShareMetadata(
+            PoolId.wrap(100), ShareClassId.wrap(bytes16(bytes("100"))), updatedTokenName, updatedTokenSymbol
+        );
 
         vm.expectRevert(IAuth.NotAuthorized.selector);
         vm.prank(randomUser);
-        poolManager.updateShareMetadata(poolId, scId, updatedTokenName, updatedTokenSymbol);
+        poolManager.updateShareMetadata(
+            PoolId.wrap(poolId), ShareClassId.wrap(scId), updatedTokenName, updatedTokenSymbol
+        );
 
         assertEq(shareToken.name(), "name");
         assertEq(shareToken.symbol(), "symbol");
 
-        poolManager.updateShareMetadata(poolId, scId, updatedTokenName, updatedTokenSymbol);
+        poolManager.updateShareMetadata(
+            PoolId.wrap(poolId), ShareClassId.wrap(scId), updatedTokenName, updatedTokenSymbol
+        );
         assertEq(shareToken.name(), updatedTokenName);
         assertEq(shareToken.symbol(), updatedTokenSymbol);
 
         vm.expectRevert(IPoolManager.OldMetadata.selector);
-        poolManager.updateShareMetadata(poolId, scId, updatedTokenName, updatedTokenSymbol);
+        poolManager.updateShareMetadata(
+            PoolId.wrap(poolId), ShareClassId.wrap(scId), updatedTokenName, updatedTokenSymbol
+        );
     }
 
     function testUpdateShareHook() public {
@@ -463,19 +526,19 @@ contract PoolManagerTest is BaseTest, PoolManagerTestHelper {
         address newHook = makeAddr("NewHook");
 
         vm.expectRevert(IPoolManager.UnknownToken.selector);
-        poolManager.updateShareHook(100, bytes16(bytes("100")), newHook);
+        poolManager.updateShareHook(PoolId.wrap(100), ShareClassId.wrap(bytes16(bytes("100"))), newHook);
 
         vm.expectRevert(IAuth.NotAuthorized.selector);
         vm.prank(randomUser);
-        poolManager.updateShareHook(poolId, scId, newHook);
+        poolManager.updateShareHook(PoolId.wrap(poolId), ShareClassId.wrap(scId), newHook);
 
         assertEq(shareToken.hook(), restrictedTransfers);
 
-        poolManager.updateShareHook(poolId, scId, newHook);
+        poolManager.updateShareHook(PoolId.wrap(poolId), ShareClassId.wrap(scId), newHook);
         assertEq(shareToken.hook(), newHook);
 
         vm.expectRevert(IPoolManager.OldHook.selector);
-        poolManager.updateShareHook(poolId, scId, newHook);
+        poolManager.updateShareHook(PoolId.wrap(poolId), ShareClassId.wrap(scId), newHook);
     }
 
     function testUpdateRestriction() public {
@@ -488,21 +551,21 @@ contract PoolManagerTest is BaseTest, PoolManagerTestHelper {
         bytes memory update = MessageLib.UpdateRestrictionFreeze(makeAddr("User").toBytes32()).serialize();
 
         vm.expectRevert(IPoolManager.UnknownToken.selector);
-        poolManager.updateRestriction(100, bytes16(bytes("100")), update);
+        poolManager.updateRestriction(PoolId.wrap(100), ShareClassId.wrap(bytes16(bytes("100"))), update);
 
         vm.expectRevert(IAuth.NotAuthorized.selector);
         vm.prank(randomUser);
-        poolManager.updateRestriction(poolId, scId, update);
+        poolManager.updateRestriction(PoolId.wrap(poolId), ShareClassId.wrap(scId), update);
 
         address hook = shareToken.hook();
-        poolManager.updateShareHook(poolId, scId, address(0));
+        poolManager.updateShareHook(PoolId.wrap(poolId), ShareClassId.wrap(scId), address(0));
 
         vm.expectRevert(IPoolManager.InvalidHook.selector);
-        poolManager.updateRestriction(poolId, scId, update);
+        poolManager.updateRestriction(PoolId.wrap(poolId), ShareClassId.wrap(scId), update);
 
-        poolManager.updateShareHook(poolId, scId, hook);
+        poolManager.updateShareHook(PoolId.wrap(poolId), ShareClassId.wrap(scId), hook);
 
-        poolManager.updateRestriction(poolId, scId, update);
+        poolManager.updateRestriction(PoolId.wrap(poolId), ShareClassId.wrap(scId), update);
     }
 
     function testUpdatePricePoolPerShareWorks(
@@ -517,17 +580,23 @@ contract PoolManagerTest is BaseTest, PoolManagerTestHelper {
         decimals = uint8(bound(decimals, 2, 18));
         vm.assume(poolId > 0);
         vm.assume(scId > 0);
-        poolManager.addPool(poolId);
+        poolManager.addPool(PoolId.wrap(poolId));
         uint128 assetId = poolManager.registerAsset{value: defaultGas}(OTHER_CHAIN_ID, address(erc20), 0);
 
         address hook = address(new MockHook());
 
         vm.expectRevert(IPoolManager.ShareTokenDoesNotExist.selector);
-        poolManager.updatePricePoolPerShare(poolId, scId, price, uint64(block.timestamp));
+        poolManager.updatePricePoolPerShare(
+            PoolId.wrap(poolId), ShareClassId.wrap(scId), price, uint64(block.timestamp)
+        );
 
-        poolManager.addShareClass(poolId, scId, tokenName, tokenSymbol, decimals, salt, hook);
+        poolManager.addShareClass(
+            PoolId.wrap(poolId), ShareClassId.wrap(scId), tokenName, tokenSymbol, decimals, salt, hook
+        );
 
-        poolManager.updatePricePoolPerAsset(poolId, scId, assetId, 1e18, uint64(block.timestamp));
+        poolManager.updatePricePoolPerAsset(
+            PoolId.wrap(poolId), ShareClassId.wrap(scId), AssetId.wrap(assetId), 1e18, uint64(block.timestamp)
+        );
 
         vm.expectRevert(IPoolManager.InvalidPrice.selector);
         poolManager.priceAssetPerShare(poolId, scId, assetId, true);
@@ -537,18 +606,26 @@ contract PoolManagerTest is BaseTest, PoolManagerTestHelper {
 
         vm.expectRevert(IAuth.NotAuthorized.selector);
         vm.prank(randomUser);
-        poolManager.updatePricePoolPerShare(poolId, scId, price, uint64(block.timestamp));
+        poolManager.updatePricePoolPerShare(
+            PoolId.wrap(poolId), ShareClassId.wrap(scId), price, uint64(block.timestamp)
+        );
         vm.expectRevert(IAuth.NotAuthorized.selector);
         vm.prank(randomUser);
-        poolManager.updatePricePoolPerAsset(poolId, scId, assetId, price, uint64(block.timestamp));
+        poolManager.updatePricePoolPerAsset(
+            PoolId.wrap(poolId), ShareClassId.wrap(scId), AssetId.wrap(assetId), price, uint64(block.timestamp)
+        );
 
-        poolManager.updatePricePoolPerShare(poolId, scId, price, uint64(block.timestamp));
+        poolManager.updatePricePoolPerShare(
+            PoolId.wrap(poolId), ShareClassId.wrap(scId), price, uint64(block.timestamp)
+        );
         (D18 latestPrice, uint64 lastUpdated) = poolManager.priceAssetPerShare(poolId, scId, assetId, false);
         assertEq(latestPrice.raw(), price);
         assertEq(lastUpdated, block.timestamp);
 
         vm.expectRevert(IPoolManager.CannotSetOlderPrice.selector);
-        poolManager.updatePricePoolPerShare(poolId, scId, price, uint64(block.timestamp - 1));
+        poolManager.updatePricePoolPerShare(
+            PoolId.wrap(poolId), ShareClassId.wrap(scId), price, uint64(block.timestamp - 1)
+        );
 
         // NOTE: We have no maxAge set, so price is invalid after timestamp of block increases
         vm.warp(block.timestamp + 1);
@@ -597,13 +674,13 @@ contract PoolManagerTest is BaseTest, PoolManagerTestHelper {
         shareToken.approve(address(poolManager), amount);
 
         poolManager.updateRestriction(
-            vault.poolId(),
-            vault.trancheId(),
+            PoolId.wrap(vault.poolId()),
+            ShareClassId.wrap(vault.trancheId()),
             MessageLib.UpdateRestrictionMember(destinationAddress.toBytes32(), validUntil).serialize()
         );
         poolManager.updateRestriction(
-            vault.poolId(),
-            vault.trancheId(),
+            PoolId.wrap(vault.poolId()),
+            ShareClassId.wrap(vault.trancheId()),
             MessageLib.UpdateRestrictionMember(address(this).toBytes32(), validUntil).serialize()
         );
 
@@ -611,7 +688,9 @@ contract PoolManagerTest is BaseTest, PoolManagerTestHelper {
         assertTrue(shareToken.checkTransferRestriction(address(0), destinationAddress, 0));
 
         // Fund this address with amount
-        poolManager.handleTransferShares(vault.poolId(), vault.trancheId(), address(this), amount);
+        poolManager.handleTransferShares(
+            PoolId.wrap(vault.poolId()), ShareClassId.wrap(vault.trancheId()), address(this), amount
+        );
         assertEq(shareToken.balanceOf(address(this)), amount);
 
         // fails for invalid share class token
@@ -619,7 +698,9 @@ contract PoolManagerTest is BaseTest, PoolManagerTestHelper {
         bytes16 scId = vault.trancheId();
 
         poolManager.updateRestriction(
-            poolId, scId, MessageLib.UpdateRestrictionFreeze(address(this).toBytes32()).serialize()
+            PoolId.wrap(poolId),
+            ShareClassId.wrap(scId),
+            MessageLib.UpdateRestrictionFreeze(address(this).toBytes32()).serialize()
         );
         assertFalse(shareToken.checkTransferRestriction(address(this), destinationAddress, 0));
 
@@ -629,8 +710,8 @@ contract PoolManagerTest is BaseTest, PoolManagerTestHelper {
         );
 
         poolManager.updateRestriction(
-            vault.poolId(),
-            vault.trancheId(),
+            PoolId.wrap(vault.poolId()),
+            ShareClassId.wrap(vault.trancheId()),
             MessageLib.UpdateRestrictionMember(address(uint160(OTHER_CHAIN_ID)).toBytes32(), type(uint64).max).serialize(
             )
         );
@@ -642,7 +723,9 @@ contract PoolManagerTest is BaseTest, PoolManagerTestHelper {
         assertEq(shareToken.balanceOf(address(this)), amount);
 
         poolManager.updateRestriction(
-            poolId, scId, MessageLib.UpdateRestrictionUnfreeze(address(this).toBytes32()).serialize()
+            PoolId.wrap(poolId),
+            ShareClassId.wrap(scId),
+            MessageLib.UpdateRestrictionUnfreeze(address(this).toBytes32()).serialize()
         );
         poolManager.transferShares{value: defaultGas}(
             OTHER_CHAIN_ID, poolId, scId, destinationAddress.toBytes32(), amount
@@ -1050,7 +1133,7 @@ contract PoolManagerUpdateContract is BaseTest, PoolManagerTestHelper {
 
         vm.expectEmit();
         emit IPoolManager.UpdateContract(poolId, scId, address(poolManager), vaultUpdate);
-        poolManager.updateContract(poolId, scId, address(poolManager), vaultUpdate);
+        poolManager.updateContract(PoolId.wrap(poolId), ShareClassId.wrap(scId), address(poolManager), vaultUpdate);
     }
 
     function testUpdateContractTargetUpdateContractMock(
@@ -1068,7 +1151,7 @@ contract PoolManagerUpdateContract is BaseTest, PoolManagerTestHelper {
 
         vm.expectEmit();
         emit IPoolManager.UpdateContract(poolId, scId, address(mock), vaultUpdate);
-        poolManager.updateContract(poolId, scId, address(mock), vaultUpdate);
+        poolManager.updateContract(PoolId.wrap(poolId), ShareClassId.wrap(scId), address(mock), vaultUpdate);
     }
 
     function testUpdateContractInvalidVaultFactory(
@@ -1083,7 +1166,7 @@ contract PoolManagerUpdateContract is BaseTest, PoolManagerTestHelper {
         bytes memory vaultUpdate = _serializedUpdateContractNewVault(address(1));
 
         vm.expectRevert(IPoolManager.InvalidFactory.selector);
-        poolManager.updateContract(poolId, scId, address(poolManager), vaultUpdate);
+        poolManager.updateContract(PoolId.wrap(poolId), ShareClassId.wrap(scId), address(poolManager), vaultUpdate);
     }
 
     function testUpdateContractUnknownVault(
@@ -1102,21 +1185,21 @@ contract PoolManagerUpdateContract is BaseTest, PoolManagerTestHelper {
         }).serialize();
 
         vm.expectRevert(IPoolManager.UnknownVault.selector);
-        poolManager.updateContract(poolId, scId, address(poolManager), vaultUpdate);
+        poolManager.updateContract(PoolId.wrap(poolId), ShareClassId.wrap(scId), address(poolManager), vaultUpdate);
     }
 
     function testUpdateContractInvalidShare(uint64 poolId) public {
-        poolManager.addPool(poolId);
+        poolManager.addPool(PoolId.wrap(poolId));
         bytes memory vaultUpdate = _serializedUpdateContractNewVault(asyncVaultFactory);
 
         vm.expectRevert(IPoolManager.ShareTokenDoesNotExist.selector);
-        poolManager.updateContract(poolId, scId, address(poolManager), vaultUpdate);
+        poolManager.updateContract(PoolId.wrap(poolId), ShareClassId.wrap(scId), address(poolManager), vaultUpdate);
     }
 
     function testUpdateContractUnauthorized() public {
         vm.prank(makeAddr("unauthorized"));
         vm.expectRevert(IAuth.NotAuthorized.selector);
-        poolManager.updateContract(0, bytes16(0), address(0), bytes(""));
+        poolManager.updateContract(PoolId.wrap(0), ShareClassId.wrap(bytes16(0)), address(0), bytes(""));
     }
 
     function testUpdateUnauthorized() public {

--- a/test/vaults/integration/Redeem.t.sol
+++ b/test/vaults/integration/Redeem.t.sol
@@ -5,6 +5,11 @@ import "test/vaults/BaseTest.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {IERC20} from "src/misc/interfaces/IERC20.sol";
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
+
+import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
+
 import {IAsyncRequests} from "src/vaults/interfaces/investments/IAsyncRequests.sol";
 import {IBaseVault} from "src/vaults/interfaces/IERC7540.sol";
 
@@ -38,7 +43,9 @@ contract RedeemTest is BaseTest {
         uint64 poolId = vault.poolId();
         bytes16 scId = vault.trancheId();
         vm.expectRevert(IAsyncRequests.NoPendingRequest.selector);
-        asyncRequests.fulfillRedeemRequest(poolId, scId, self, assetId, assets, uint128(amount));
+        asyncRequests.fulfillRedeemRequest(
+            PoolId.wrap(poolId), ShareClassId.wrap(scId), self, AssetId.wrap(assetId), assets, uint128(amount)
+        );
 
         // success
         centrifugeChain.linkVault(vault.poolId(), vault.trancheId(), vault_);
@@ -231,11 +238,15 @@ contract RedeemTest is BaseTest {
 
         // Fail - Redeem amount too big
         vm.expectRevert(IERC20.InsufficientBalance.selector);
-        asyncRequests.triggerRedeemRequest(poolId, scId, investor, assetId, uint128(amount + 1));
+        asyncRequests.triggerRedeemRequest(
+            PoolId.wrap(poolId), ShareClassId.wrap(scId), investor, AssetId.wrap(assetId), uint128(amount + 1)
+        );
 
         //Fail - Share token amount zero
         vm.expectRevert(IAsyncRequests.ShareTokenAmountIsZero.selector);
-        asyncRequests.triggerRedeemRequest(poolId, scId, investor, assetId, 0);
+        asyncRequests.triggerRedeemRequest(
+            PoolId.wrap(poolId), ShareClassId.wrap(scId), investor, AssetId.wrap(assetId), 0
+        );
 
         // should work even if investor is frozen
         centrifugeChain.freeze(poolId, scId, investor); // freeze investor
@@ -307,7 +318,9 @@ contract RedeemTest is BaseTest {
 
         // Fail - Redeem amount too big
         vm.expectRevert(IERC20.InsufficientBalance.selector);
-        asyncRequests.triggerRedeemRequest(poolId, scId, investor, assetId, uint128(amount + 1));
+        asyncRequests.triggerRedeemRequest(
+            PoolId.wrap(poolId), ShareClassId.wrap(scId), investor, AssetId.wrap(assetId), uint128(amount + 1)
+        );
 
         // should work even if investor is frozen
         centrifugeChain.freeze(poolId, scId, investor); // freeze investor


### PR DESCRIPTION
This PR is the first chunk of this refactoring.

It only does the required changes in `vaults` to get rid of non-typed values in the `common` module.

It increases a bit the test lines, but those lines should be removed again once everything uses custom types.