### PR TITLE
Feat: add transient bytes append

### DIFF
--- a/src/common/Gateway.sol
+++ b/src/common/Gateway.sol
@@ -280,7 +280,7 @@ contract Gateway is Auth, Recoverable, IGateway {
                 TransientArrayLib.push(BATCH_LOCATORS_SLOT, _encodeLocator(centrifugeId, poolId));
                 TransientBytesLib.set(batchSlot, message);
             } else {
-                TransientBytesLib.set(batchSlot, bytes.concat(previousMessage, message));
+                TransientBytesLib.append(batchSlot, message);
             }
         } else {
             _send(centrifugeId, poolId, message);

--- a/src/common/Gateway.sol
+++ b/src/common/Gateway.sol
@@ -278,10 +278,9 @@ contract Gateway is Auth, Recoverable, IGateway {
 
             if (previousMessage.length == 0) {
                 TransientArrayLib.push(BATCH_LOCATORS_SLOT, _encodeLocator(centrifugeId, poolId));
-                TransientBytesLib.set(batchSlot, message);
-            } else {
-                TransientBytesLib.append(batchSlot, message);
             }
+
+            TransientBytesLib.append(batchSlot, message);
         } else {
             _send(centrifugeId, poolId, message);
             _refundTransaction();

--- a/src/misc/libraries/TransientBytesLib.sol
+++ b/src/misc/libraries/TransientBytesLib.sol
@@ -9,18 +9,6 @@ library TransientBytesLib {
     using TransientStorageLib for bytes32;
     using BytesLib for bytes;
 
-    function set(bytes32 key, bytes memory value) internal {
-        uint256 chunks = value.length / 32 + 1;
-
-        bytes32 lengthSlot = keccak256(abi.encodePacked(key, type(uint256).max));
-        lengthSlot.tstore(value.length);
-
-        for (uint256 i = 0; i < chunks; i++) {
-            bytes32 slot = keccak256(abi.encodePacked(key, i));
-            slot.tstore(bytes32(value.sliceZeroPadded(i * 32, 32)));
-        }
-    }
-
     function append(bytes32 key, bytes memory value) internal {
         bytes32 lengthSlot = keccak256(abi.encodePacked(key, type(uint256).max));
         uint256 prevLength = lengthSlot.tloadUint256();

--- a/src/misc/libraries/TransientBytesLib.sol
+++ b/src/misc/libraries/TransientBytesLib.sol
@@ -29,16 +29,18 @@ library TransientBytesLib {
         uint256 offset = prevLength % 32;
 
         lengthSlot.tstore(prevLength + value.length);
-        uint256 chunks = (prevLength + value.length) / 32 + 1;
 
         bytes32 joinSlot = keccak256(abi.encodePacked(key, startChunk));
         bytes memory firstPart = abi.encodePacked(joinSlot.tloadBytes32()).sliceZeroPadded(0, offset);
         bytes memory secondPart = value.sliceZeroPadded(0, 32 - offset);
         joinSlot.tstore(bytes32(bytes.concat(firstPart, secondPart)));
 
-        for (uint256 i = startChunk + 1; i < chunks; i++) {
-            bytes32 slot = keccak256(abi.encodePacked(key, i));
-            slot.tstore(bytes32(value.sliceZeroPadded((32 - offset) + i * 32, 32)));
+        uint256 valueOffset = 32 - offset;
+        uint256 chunkIndex = startChunk + 1;
+        for (; valueOffset < value.length; chunkIndex++) {
+            bytes32 slot = keccak256(abi.encodePacked(key, chunkIndex));
+            slot.tstore(bytes32(value.sliceZeroPadded(valueOffset, 32)));
+            valueOffset += 32;
         }
     }
 

--- a/src/misc/libraries/TransientBytesLib.sol
+++ b/src/misc/libraries/TransientBytesLib.sol
@@ -21,6 +21,27 @@ library TransientBytesLib {
         }
     }
 
+    function append(bytes32 key, bytes memory value) internal {
+        bytes32 lengthSlot = keccak256(abi.encodePacked(key, type(uint256).max));
+        uint256 prevLength = lengthSlot.tloadUint256();
+
+        uint256 startChunk = prevLength / 32;
+        uint256 offset = prevLength % 32;
+
+        lengthSlot.tstore(prevLength + value.length);
+        uint256 chunks = (prevLength + value.length) / 32 + 1;
+
+        bytes32 joinSlot = keccak256(abi.encodePacked(key, startChunk));
+        bytes memory firstPart = abi.encodePacked(joinSlot.tloadBytes32()).sliceZeroPadded(0, offset);
+        bytes memory secondPart = value.sliceZeroPadded(0, 32 - offset);
+        joinSlot.tstore(bytes32(bytes.concat(firstPart, secondPart)));
+
+        for (uint256 i = startChunk + 1; i < chunks; i++) {
+            bytes32 slot = keccak256(abi.encodePacked(key, i));
+            slot.tstore(bytes32(value.sliceZeroPadded((32 - offset) + i * 32, 32)));
+        }
+    }
+
     function get(bytes32 key) internal view returns (bytes memory) {
         bytes memory data;
         uint256 length = keccak256(abi.encodePacked(key, type(uint256).max)).tloadUint256();

--- a/test/misc/unit/libraries/TransientBytesLib.t.sol
+++ b/test/misc/unit/libraries/TransientBytesLib.t.sol
@@ -9,22 +9,12 @@ contract TransientBytesLibTest is Test {
         bytes32 key = keccak256(abi.encode("key"));
         vm.assume(key != invalidKey);
 
-        TransientBytesLib.set(key, data1);
-        assertEq(TransientBytesLib.get(key), data1);
-
-        TransientBytesLib.set(key, data2);
-        assertEq(TransientBytesLib.get(key), data2);
-
-        assertEq(TransientBytesLib.get(invalidKey).length, 0);
-    }
-
-    function testAppend(bytes calldata data1, bytes calldata data2) public {
-        bytes32 key = keccak256(abi.encode("key"));
-
-        TransientBytesLib.set(key, data1);
+        TransientBytesLib.append(key, data1);
         assertEq(TransientBytesLib.get(key), data1);
 
         TransientBytesLib.append(key, data2);
         assertEq(TransientBytesLib.get(key), bytes.concat(data1, data2));
+
+        assertEq(TransientBytesLib.get(invalidKey).length, 0);
     }
 }

--- a/test/misc/unit/libraries/TransientBytesLib.t.sol
+++ b/test/misc/unit/libraries/TransientBytesLib.t.sol
@@ -17,4 +17,14 @@ contract TransientBytesLibTest is Test {
 
         assertEq(TransientBytesLib.get(invalidKey).length, 0);
     }
+
+    function testAppend(bytes calldata data1, bytes calldata data2) public {
+        bytes32 key = keccak256(abi.encode("key"));
+
+        TransientBytesLib.set(key, data1);
+        assertEq(TransientBytesLib.get(key), data1);
+
+        TransientBytesLib.append(key, data2);
+        assertEq(TransientBytesLib.get(key), bytes.concat(data1, data2));
+    }
 }


### PR DESCRIPTION
It avoids setting the whole batch each time a new message is added