### PR TITLE
Gateway: renamings to more accurate names

### DIFF
--- a/snapshots/VaultRouter.json
+++ b/snapshots/VaultRouter.json
@@ -2,6 +2,6 @@
   "claimDeposit": "1147703",
   "enable": "60953",
   "lockDepositRequest": "92339",
-  "requestDeposit": "594279",
-  "requestRedeem": "2105486"
+  "requestDeposit": "594301",
+  "requestRedeem": "2105596"
 }

--- a/src/common/Gateway.sol
+++ b/src/common/Gateway.sol
@@ -142,7 +142,7 @@ contract Gateway is Auth, Recoverable, IGateway {
 
         IMessageProcessor processor_ = processor;
         if (processor_.isMessageRecovery(payload)) {
-            require(!isRecovery, RecoveryMessageRecovered());
+            require(!isRecovery, RecoveryPayloadRecovered());
             return processor_.handle(centrifugeId, payload);
         }
 
@@ -155,13 +155,13 @@ contract Gateway is Auth, Recoverable, IGateway {
 
             batchHash = payload.deserializeMessageProof();
             bytes32 payloadId = keccak256(abi.encodePacked(centrifugeId, localCentrifugeId, batchHash));
-            emit ProcessProof(centrifugeId, payloadId, batchHash, adapter_);
+            emit HandleProof(centrifugeId, payloadId, batchHash, adapter_);
         } else {
             require(adapter.id == PRIMARY_ADAPTER_ID, NonBatchAdapter());
 
             batchHash = keccak256(payload);
             bytes32 payloadId = keccak256(abi.encodePacked(centrifugeId, localCentrifugeId, batchHash));
-            emit ProcessBatch(centrifugeId, payloadId, payload, adapter_);
+            emit HandleBatch(centrifugeId, payloadId, payload, adapter_);
         }
 
         // Special case for gas efficiency
@@ -230,29 +230,29 @@ contract Gateway is Auth, Recoverable, IGateway {
     }
 
     /// @inheritdoc IGatewayHandler
-    function initiateMessageRecovery(uint16 centrifugeId, IAdapter adapter, bytes32 payloadHash) external auth {
+    function initiateRecovery(uint16 centrifugeId, IAdapter adapter, bytes32 payloadHash) external auth {
         require(_activeAdapters[centrifugeId][adapter].id != 0, InvalidAdapter());
         recoveries[centrifugeId][adapter][payloadHash] = block.timestamp + RECOVERY_CHALLENGE_PERIOD;
-        emit InitiateMessageRecovery(centrifugeId, payloadHash, adapter);
+        emit InitiateRecovery(centrifugeId, payloadHash, adapter);
     }
 
     /// @inheritdoc IGatewayHandler
-    function disputeMessageRecovery(uint16 centrifugeId, IAdapter adapter, bytes32 payloadHash) external auth {
+    function disputeRecovery(uint16 centrifugeId, IAdapter adapter, bytes32 payloadHash) external auth {
         delete recoveries[centrifugeId][adapter][payloadHash];
-        emit DisputeMessageRecovery(centrifugeId, payloadHash, adapter);
+        emit DisputeRecovery(centrifugeId, payloadHash, adapter);
     }
 
     /// @inheritdoc IGateway
-    function executeMessageRecovery(uint16 centrifugeId, IAdapter adapter, bytes calldata payload) external {
+    function executeRecovery(uint16 centrifugeId, IAdapter adapter, bytes calldata payload) external {
         bytes32 payloadHash = keccak256(payload);
         uint256 recovery = recoveries[centrifugeId][adapter][payloadHash];
 
-        require(recovery != 0, MessageRecoveryNotInitiated());
-        require(recovery <= block.timestamp, MessageRecoveryChallengePeriodNotEnded());
+        require(recovery != 0, RecoveryNotInitiated());
+        require(recovery <= block.timestamp, RecoveryChallengePeriodNotEnded());
 
         delete recoveries[centrifugeId][adapter][payloadHash];
         _handle(centrifugeId, payload, adapter, true);
-        emit ExecuteMessageRecovery(centrifugeId, payload, adapter);
+        emit ExecuteRecovery(centrifugeId, payload, adapter);
     }
 
     //----------------------------------------------------------------------------------------------

--- a/src/common/Guardian.sol
+++ b/src/common/Guardian.sol
@@ -97,19 +97,19 @@ contract Guardian is IGuardian {
     }
 
     /// @inheritdoc IGuardian
-    function initiateMessageRecovery(uint16 centrifugeId, uint16 adapterCentrifugeId, IAdapter adapter, bytes32 hash)
+    function initiateRecovery(uint16 centrifugeId, uint16 adapterCentrifugeId, IAdapter adapter, bytes32 hash)
         external
         onlySafe
     {
-        sender.sendInitiateMessageRecovery(centrifugeId, adapterCentrifugeId, address(adapter).toBytes32(), hash);
+        sender.sendInitiateRecovery(centrifugeId, adapterCentrifugeId, address(adapter).toBytes32(), hash);
     }
 
     /// @inheritdoc IGuardian
-    function disputeMessageRecovery(uint16 centrifugeId, uint16 adapterCentrifugeId, IAdapter adapter, bytes32 hash)
+    function disputeRecovery(uint16 centrifugeId, uint16 adapterCentrifugeId, IAdapter adapter, bytes32 hash)
         external
         onlySafe
     {
-        sender.sendDisputeMessageRecovery(centrifugeId, adapterCentrifugeId, address(adapter).toBytes32(), hash);
+        sender.sendDisputeRecovery(centrifugeId, adapterCentrifugeId, address(adapter).toBytes32(), hash);
     }
 
     // --- Helpers ---

--- a/src/common/MessageDispatcher.sol
+++ b/src/common/MessageDispatcher.sol
@@ -370,33 +370,33 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
     }
 
     /// @inheritdoc IRootMessageSender
-    function sendInitiateMessageRecovery(uint16 centrifugeId, uint16 adapterCentrifugeId, bytes32 adapter, bytes32 hash)
+    function sendInitiateRecovery(uint16 centrifugeId, uint16 adapterCentrifugeId, bytes32 adapter, bytes32 hash)
         external
         auth
     {
         if (centrifugeId == localCentrifugeId) {
-            gateway.initiateMessageRecovery(adapterCentrifugeId, IAdapter(adapter.toAddress()), hash);
+            gateway.initiateRecovery(adapterCentrifugeId, IAdapter(adapter.toAddress()), hash);
         } else {
             gateway.send(
                 centrifugeId,
-                MessageLib.InitiateMessageRecovery({hash: hash, adapter: adapter, centrifugeId: adapterCentrifugeId})
-                    .serialize()
+                MessageLib.InitiateRecovery({hash: hash, adapter: adapter, centrifugeId: adapterCentrifugeId}).serialize(
+                )
             );
         }
     }
 
     /// @inheritdoc IRootMessageSender
-    function sendDisputeMessageRecovery(uint16 centrifugeId, uint16 adapterCentrifugeId, bytes32 adapter, bytes32 hash)
+    function sendDisputeRecovery(uint16 centrifugeId, uint16 adapterCentrifugeId, bytes32 adapter, bytes32 hash)
         external
         auth
     {
         if (centrifugeId == localCentrifugeId) {
-            gateway.disputeMessageRecovery(adapterCentrifugeId, IAdapter(adapter.toAddress()), hash);
+            gateway.disputeRecovery(adapterCentrifugeId, IAdapter(adapter.toAddress()), hash);
         } else {
             gateway.send(
                 centrifugeId,
-                MessageLib.DisputeMessageRecovery({hash: hash, adapter: adapter, centrifugeId: adapterCentrifugeId})
-                    .serialize()
+                MessageLib.DisputeRecovery({hash: hash, adapter: adapter, centrifugeId: adapterCentrifugeId}).serialize(
+                )
             );
         }
     }

--- a/src/common/MessageProcessor.sol
+++ b/src/common/MessageProcessor.sol
@@ -65,12 +65,12 @@ contract MessageProcessor is Auth, IMessageProcessor {
     function handle(uint16, bytes calldata message) external auth {
         MessageType kind = message.messageType();
 
-        if (kind == MessageType.InitiateMessageRecovery) {
-            MessageLib.InitiateMessageRecovery memory m = message.deserializeInitiateMessageRecovery();
-            gateway.initiateMessageRecovery(m.centrifugeId, IAdapter(m.adapter.toAddress()), m.hash);
-        } else if (kind == MessageType.DisputeMessageRecovery) {
-            MessageLib.DisputeMessageRecovery memory m = message.deserializeDisputeMessageRecovery();
-            gateway.disputeMessageRecovery(m.centrifugeId, IAdapter(m.adapter.toAddress()), m.hash);
+        if (kind == MessageType.InitiateRecovery) {
+            MessageLib.InitiateRecovery memory m = message.deserializeInitiateRecovery();
+            gateway.initiateRecovery(m.centrifugeId, IAdapter(m.adapter.toAddress()), m.hash);
+        } else if (kind == MessageType.DisputeRecovery) {
+            MessageLib.DisputeRecovery memory m = message.deserializeDisputeRecovery();
+            gateway.disputeRecovery(m.centrifugeId, IAdapter(m.adapter.toAddress()), m.hash);
         } else if (kind == MessageType.ScheduleUpgrade) {
             MessageLib.ScheduleUpgrade memory m = message.deserializeScheduleUpgrade();
             root.scheduleRely(m.target.toAddress());
@@ -275,7 +275,7 @@ contract MessageProcessor is Auth, IMessageProcessor {
     /// @inheritdoc IMessageProperties
     function isMessageRecovery(bytes calldata message) external pure returns (bool) {
         uint8 code = message.messageCode();
-        return code == uint8(MessageType.InitiateMessageRecovery) || code == uint8(MessageType.DisputeMessageRecovery);
+        return code == uint8(MessageType.InitiateRecovery) || code == uint8(MessageType.DisputeRecovery);
     }
 
     /// @inheritdoc IMessageProperties

--- a/src/common/interfaces/IGateway.sol
+++ b/src/common/interfaces/IGateway.sol
@@ -59,16 +59,16 @@ interface IGateway is IMessageHandler, IMessageSender, IGatewayHandler {
         bytes32 adapterData,
         bool underpaid
     );
-    event ProcessBatch(uint16 indexed centrifugeId, bytes32 payloadId, bytes batch, IAdapter adapter);
-    event ProcessProof(uint16 indexed centrifugeId, bytes32 payloadId, bytes32 batchHash, IAdapter adapter);
+    event HandleBatch(uint16 indexed centrifugeId, bytes32 payloadId, bytes batch, IAdapter adapter);
+    event HandleProof(uint16 indexed centrifugeId, bytes32 payloadId, bytes32 batchHash, IAdapter adapter);
     event ExecuteMessage(uint16 indexed centrifugeId, bytes message);
     event FailMessage(uint16 indexed centrifugeId, bytes message, bytes error);
 
     event RecoverMessage(IAdapter adapter, bytes message);
     event RecoverProof(IAdapter adapter, bytes32 batchHash);
-    event InitiateMessageRecovery(uint16 centrifugeId, bytes32 batchHash, IAdapter adapter);
-    event DisputeMessageRecovery(uint16 centrifugeId, bytes32 batchHash, IAdapter adapter);
-    event ExecuteMessageRecovery(uint16 centrifugeId, bytes message, IAdapter adapter);
+    event InitiateRecovery(uint16 centrifugeId, bytes32 batchHash, IAdapter adapter);
+    event DisputeRecovery(uint16 centrifugeId, bytes32 batchHash, IAdapter adapter);
+    event ExecuteRecovery(uint16 centrifugeId, bytes message, IAdapter adapter);
 
     event File(bytes32 indexed what, uint16 centrifugeId, IAdapter[] adapters);
     event File(bytes32 indexed what, address addr);
@@ -98,7 +98,7 @@ interface IGateway is IMessageHandler, IMessageSender, IGatewayHandler {
     error InvalidAdapter();
 
     /// @notice Dispatched when the gateway tries to recover a recovery message, which is not allowed.
-    error RecoveryMessageRecovered();
+    error RecoveryPayloadRecovered();
 
     /// @notice Dispatched when the gateway tries to handle a proof from a non proof adapter.
     error NonProofAdapter();
@@ -107,10 +107,10 @@ interface IGateway is IMessageHandler, IMessageSender, IGatewayHandler {
     error NonBatchAdapter();
 
     /// @notice Dispatched when a recovery message is executed without being initiated.
-    error MessageRecoveryNotInitiated();
+    error RecoveryNotInitiated();
 
     /// @notice Dispatched when a recovery message is executed without waiting the challenge period.
-    error MessageRecoveryChallengePeriodNotEnded();
+    error RecoveryChallengePeriodNotEnded();
 
     /// @notice Dispatched when a the gateway tries to send an empty message.
     error EmptyMessage();
@@ -169,7 +169,7 @@ interface IGateway is IMessageHandler, IMessageSender, IGatewayHandler {
     /// @param  centrifugeId Chain where the adapter is configured for
     /// @param  adapter Adapter's address that the recovery is targeting
     /// @param  message Hash of the message to be recovered
-    function executeMessageRecovery(uint16 centrifugeId, IAdapter adapter, bytes calldata message) external;
+    function executeRecovery(uint16 centrifugeId, IAdapter adapter, bytes calldata message) external;
 
     // --- Helpers ---
     /// @notice A view method of the current quorum.abi

--- a/src/common/interfaces/IGatewayHandlers.sol
+++ b/src/common/interfaces/IGatewayHandlers.sol
@@ -13,17 +13,17 @@ import {PoolId} from "src/common/types/PoolId.sol";
 /// -----------------------------------------------------
 /// @notice Interface for Gateway methods called by messages
 interface IGatewayHandler {
-    /// @notice Initialize the recovery of a message.
+    /// @notice Initialize the recovery of a payload.
     /// @param  centrifugeId Chain where the adapter is configured for
     /// @param  adapter Adapter that the recovery was targeting
-    /// @param  messageHash Hash of the message being disputed
-    function initiateMessageRecovery(uint16 centrifugeId, IAdapter adapter, bytes32 messageHash) external;
+    /// @param  payloadHash Hash of the payload being disputed
+    function initiateRecovery(uint16 centrifugeId, IAdapter adapter, bytes32 payloadHash) external;
 
-    /// @notice Cancel the recovery of a message.
+    /// @notice Cancel the recovery of a payload.
     /// @param  centrifugeId Chain where the adapter is configured for
     /// @param  adapter Adapter that the recovery was targeting
-    /// @param  messageHash Hash of the message being disputed
-    function disputeMessageRecovery(uint16 centrifugeId, IAdapter adapter, bytes32 messageHash) external;
+    /// @param  payloadHash Hash of the payload being disputed
+    function disputeRecovery(uint16 centrifugeId, IAdapter adapter, bytes32 payloadHash) external;
 }
 
 /// -----------------------------------------------------

--- a/src/common/interfaces/IGatewaySenders.sol
+++ b/src/common/interfaces/IGatewaySenders.sol
@@ -30,11 +30,11 @@ interface IRootMessageSender {
     ) external;
 
     /// @notice Creates and send the message
-    function sendInitiateMessageRecovery(uint16 centrifugeId, uint16 adapterCentrifugeId, bytes32 adapter, bytes32 hash)
+    function sendInitiateRecovery(uint16 centrifugeId, uint16 adapterCentrifugeId, bytes32 adapter, bytes32 hash)
         external;
 
     /// @notice Creates and send the message
-    function sendDisputeMessageRecovery(uint16 centrifugeId, uint16 adapterCentrifugeId, bytes32 adapter, bytes32 hash)
+    function sendDisputeRecovery(uint16 centrifugeId, uint16 adapterCentrifugeId, bytes32 adapter, bytes32 hash)
         external;
 }
 

--- a/src/common/interfaces/IGuardian.sol
+++ b/src/common/interfaces/IGuardian.sol
@@ -66,13 +66,13 @@ interface IGuardian {
         uint256 amount
     ) external;
 
-    /// @notice Initiate message recovery on a specific chain
+    /// @notice Initiate a gateway payload recovery on a specific chain
     /// @dev    Only supports EVM targets today
-    function initiateMessageRecovery(uint16 centrifugeId, uint16 adapterCentrifugeId, IAdapter adapter, bytes32 hash)
+    function initiateRecovery(uint16 centrifugeId, uint16 adapterCentrifugeId, IAdapter adapter, bytes32 hash)
         external;
 
-    /// @notice Dispute message recovery on a specific chain
+    /// @notice Dispute a gateway paylaod recovery on a specific chain
     /// @dev    Only supports EVM targets today
-    function disputeMessageRecovery(uint16 centrifugeId, uint16 adapterCentrifugeId, IAdapter adapter, bytes32 hash)
+    function disputeRecovery(uint16 centrifugeId, uint16 adapterCentrifugeId, IAdapter adapter, bytes32 hash)
         external;
 }

--- a/src/common/libraries/MessageLib.sol
+++ b/src/common/libraries/MessageLib.sol
@@ -12,8 +12,8 @@ enum MessageType {
     /// @dev Placeholder for proof message type
     _MessageProof,
     // -- Gateway messages
-    InitiateMessageRecovery,
-    DisputeMessageRecovery,
+    InitiateRecovery,
+    DisputeRecovery,
     // -- Root messages
     ScheduleUpgrade,
     CancelUpgrade,
@@ -86,8 +86,8 @@ library MessageLib {
     /// If the message has some dynamic part, will be added later in `messageLength()`.
     // forgefmt: disable-next-item
     uint256 constant MESSAGE_LENGTHS_1 =
-        (67  << uint8(MessageType.InitiateMessageRecovery) * 8) +
-        (67  << uint8(MessageType.DisputeMessageRecovery) * 8) +
+        (67  << uint8(MessageType.InitiateRecovery) * 8) +
+        (67  << uint8(MessageType.DisputeRecovery) * 8) +
         (33  << uint8(MessageType.ScheduleUpgrade) * 8) +
         (33  << uint8(MessageType.CancelUpgrade) * 8) +
         (161 << uint8(MessageType.RecoverTokens) * 8) +
@@ -159,57 +159,41 @@ library MessageLib {
     }
 
     //---------------------------------------
-    //    InitiateMessageRecovery
+    //    InitiateRecovery
     //---------------------------------------
 
-    struct InitiateMessageRecovery {
+    struct InitiateRecovery {
         bytes32 hash;
         bytes32 adapter;
         uint16 centrifugeId;
     }
 
-    function deserializeInitiateMessageRecovery(bytes memory data)
-        internal
-        pure
-        returns (InitiateMessageRecovery memory)
-    {
-        require(messageType(data) == MessageType.InitiateMessageRecovery, UnknownMessageType());
-        return InitiateMessageRecovery({
-            hash: data.toBytes32(1),
-            adapter: data.toBytes32(33),
-            centrifugeId: data.toUint16(65)
-        });
+    function deserializeInitiateRecovery(bytes memory data) internal pure returns (InitiateRecovery memory) {
+        require(messageType(data) == MessageType.InitiateRecovery, UnknownMessageType());
+        return InitiateRecovery({hash: data.toBytes32(1), adapter: data.toBytes32(33), centrifugeId: data.toUint16(65)});
     }
 
-    function serialize(InitiateMessageRecovery memory t) internal pure returns (bytes memory) {
-        return abi.encodePacked(MessageType.InitiateMessageRecovery, t.hash, t.adapter, t.centrifugeId);
+    function serialize(InitiateRecovery memory t) internal pure returns (bytes memory) {
+        return abi.encodePacked(MessageType.InitiateRecovery, t.hash, t.adapter, t.centrifugeId);
     }
 
     //---------------------------------------
-    //    DisputeMessageRecovery
+    //    DisputeRecovery
     //---------------------------------------
 
-    struct DisputeMessageRecovery {
+    struct DisputeRecovery {
         bytes32 hash;
         bytes32 adapter;
         uint16 centrifugeId;
     }
 
-    function deserializeDisputeMessageRecovery(bytes memory data)
-        internal
-        pure
-        returns (DisputeMessageRecovery memory)
-    {
-        require(messageType(data) == MessageType.DisputeMessageRecovery, UnknownMessageType());
-        return DisputeMessageRecovery({
-            hash: data.toBytes32(1),
-            adapter: data.toBytes32(33),
-            centrifugeId: data.toUint16(65)
-        });
+    function deserializeDisputeRecovery(bytes memory data) internal pure returns (DisputeRecovery memory) {
+        require(messageType(data) == MessageType.DisputeRecovery, UnknownMessageType());
+        return DisputeRecovery({hash: data.toBytes32(1), adapter: data.toBytes32(33), centrifugeId: data.toUint16(65)});
     }
 
-    function serialize(DisputeMessageRecovery memory t) internal pure returns (bytes memory) {
-        return abi.encodePacked(MessageType.DisputeMessageRecovery, t.hash, t.adapter, t.centrifugeId);
+    function serialize(DisputeRecovery memory t) internal pure returns (bytes memory) {
+        return abi.encodePacked(MessageType.DisputeRecovery, t.hash, t.adapter, t.centrifugeId);
     }
 
     //---------------------------------------

--- a/test/common/unit/libraries/MessageLib.t.sol
+++ b/test/common/unit/libraries/MessageLib.t.sol
@@ -19,10 +19,10 @@ contract TestMessageProofCompatibility is Test {
 contract TestMessageLibIdentities is Test {
     using MessageLib for *;
 
-    function testInitiateMessageRecovery(bytes32 hash_, bytes32 adapter, uint16 centrifugeId) public pure {
-        MessageLib.InitiateMessageRecovery memory a =
-            MessageLib.InitiateMessageRecovery({hash: hash_, adapter: adapter, centrifugeId: centrifugeId});
-        MessageLib.InitiateMessageRecovery memory b = MessageLib.deserializeInitiateMessageRecovery(a.serialize());
+    function testInitiateRecovery(bytes32 hash_, bytes32 adapter, uint16 centrifugeId) public pure {
+        MessageLib.InitiateRecovery memory a =
+            MessageLib.InitiateRecovery({hash: hash_, adapter: adapter, centrifugeId: centrifugeId});
+        MessageLib.InitiateRecovery memory b = MessageLib.deserializeInitiateRecovery(a.serialize());
 
         assertEq(a.hash, b.hash);
         assertEq(a.adapter, b.adapter);
@@ -31,10 +31,10 @@ contract TestMessageLibIdentities is Test {
         assertEq(a.serialize().messageLength(), a.serialize().length);
     }
 
-    function testDisputeMessageRecovery(bytes32 hash_, bytes32 adapter, uint16 centrifugeId) public pure {
-        MessageLib.DisputeMessageRecovery memory a =
-            MessageLib.DisputeMessageRecovery({hash: hash_, adapter: adapter, centrifugeId: centrifugeId});
-        MessageLib.DisputeMessageRecovery memory b = MessageLib.deserializeDisputeMessageRecovery(a.serialize());
+    function testDisputeRecovery(bytes32 hash_, bytes32 adapter, uint16 centrifugeId) public pure {
+        MessageLib.DisputeRecovery memory a =
+            MessageLib.DisputeRecovery({hash: hash_, adapter: adapter, centrifugeId: centrifugeId});
+        MessageLib.DisputeRecovery memory b = MessageLib.deserializeDisputeRecovery(a.serialize());
 
         assertEq(a.hash, b.hash);
         assertEq(a.adapter, b.adapter);

--- a/test/vaults/fuzzing/recon-aggregator/TargetFunctions.sol
+++ b/test/vaults/fuzzing/recon-aggregator/TargetFunctions.sol
@@ -15,12 +15,12 @@ abstract contract TargetFunctions is BaseTargetFunctions, Properties, BiasedTarg
     //     routerAggregator.deny(user);
     // }
 
-    function routerAggregator_disputeMessageRecovery(address router, bytes32 messageHash) public {
-        routerAggregator.disputeMessageRecovery(CENTRIFUGE_ID, IAdapter(router), messageHash);
+    function routerAggregator_disputeRecovery(address router, bytes32 messageHash) public {
+        routerAggregator.disputeRecovery(CENTRIFUGE_ID, IAdapter(router), messageHash);
     }
 
-    function routerAggregator_executeMessageRecovery(address router, bytes memory message) public {
-        routerAggregator.executeMessageRecovery(CENTRIFUGE_ID, IAdapter(router), message);
+    function routerAggregator_executeRecovery(address router, bytes memory message) public {
+        routerAggregator.executeRecovery(CENTRIFUGE_ID, IAdapter(router), message);
     }
 
     // @todo: re-enable

--- a/test/vaults/fuzzing/recon-aggregator/targets/BiasedTargetFunctions.sol
+++ b/test/vaults/fuzzing/recon-aggregator/targets/BiasedTargetFunctions.sol
@@ -77,7 +77,7 @@ abstract contract BiasedTargetFunctions is BaseTargetFunctions, Properties {
         // NOTE: Can we recover for self?
         // TODO: CHECK THIS!
         MockAdapter(address(adapters[calledRouterId])).execute(
-            MessageLib.InitiateMessageRecovery({
+            MessageLib.InitiateRecovery({
                 hash: keccak256(message),
                 adapter: bytes32(bytes20(address(adapters[recoverRouterId]))),
                 centrifugeId: 0
@@ -92,7 +92,7 @@ abstract contract BiasedTargetFunctions is BaseTargetFunctions, Properties {
 
         bytes memory message = messages[messageIndex];
         require(recoverMessageTime[keccak256(message)] != 0);
-        routerAggregator.executeMessageRecovery(CENTRIFUGE_ID, router, message);
+        routerAggregator.executeRecovery(CENTRIFUGE_ID, router, message);
 
         messageRecoveredCount[keccak256(message)] += 1;
 
@@ -108,7 +108,7 @@ abstract contract BiasedTargetFunctions is BaseTargetFunctions, Properties {
         IAdapter router = routerAggregator.adapters(CENTRIFUGE_ID, adapterId);
 
         bytes memory message = messages[messageIndex];
-        routerAggregator.disputeMessageRecovery(CENTRIFUGE_ID, router, keccak256(message));
+        routerAggregator.disputeRecovery(CENTRIFUGE_ID, router, keccak256(message));
 
         recoverMessageTime[keccak256(message)] = 0; // Unset time
     }

--- a/test/vaults/integration/Admin.t.sol
+++ b/test/vaults/integration/Admin.t.sol
@@ -262,24 +262,23 @@ contract AdminTest is BaseTest {
         // Initiate recovery
         _send(
             adapter1,
-            MessageLib.InitiateMessageRecovery(keccak256(proof), address(adapter3).toBytes32(), OTHER_CHAIN_ID)
-                .serialize()
+            MessageLib.InitiateRecovery(keccak256(proof), address(adapter3).toBytes32(), OTHER_CHAIN_ID).serialize()
         );
 
-        vm.expectRevert(IGateway.MessageRecoveryChallengePeriodNotEnded.selector);
-        gateway.executeMessageRecovery(OTHER_CHAIN_ID, adapter3, proof);
+        vm.expectRevert(IGateway.RecoveryChallengePeriodNotEnded.selector);
+        gateway.executeRecovery(OTHER_CHAIN_ID, adapter3, proof);
 
         vm.prank(makeAddr("unauthorized"));
         vm.expectRevert(IGuardian.NotTheAuthorizedSafe.selector);
-        guardian.disputeMessageRecovery(THIS_CHAIN_ID, OTHER_CHAIN_ID, adapter3, keccak256(proof));
+        guardian.disputeRecovery(THIS_CHAIN_ID, OTHER_CHAIN_ID, adapter3, keccak256(proof));
 
         // Dispute recovery
         vm.prank(address(adminSafe));
-        guardian.disputeMessageRecovery(THIS_CHAIN_ID, OTHER_CHAIN_ID, adapter3, keccak256(proof));
+        guardian.disputeRecovery(THIS_CHAIN_ID, OTHER_CHAIN_ID, adapter3, keccak256(proof));
 
         // Check that recovery is not possible anymore
-        vm.expectRevert(IGateway.MessageRecoveryNotInitiated.selector);
-        gateway.executeMessageRecovery(OTHER_CHAIN_ID, adapter3, proof);
+        vm.expectRevert(IGateway.RecoveryNotInitiated.selector);
+        gateway.executeRecovery(OTHER_CHAIN_ID, adapter3, proof);
     }
 
     function _send(MockAdapter adapter, bytes memory message) internal {


### PR DESCRIPTION
- Rename events `ProcessBatch/Proof` to `HandleBatch/Proof` to avoid confusing it with the fact that those messages are processed by the `MessageProcessor`. They are just handled by the Gateway
- Remove the name "message" from recovery actions to avoid thinking that it recovers messages. It recovers batches or proofs.