### PR TITLE
Hub: Remove valuation

### DIFF
--- a/script/HubDeployer.s.sol
+++ b/script/HubDeployer.s.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.28;
 
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {TransientValuation} from "src/misc/TransientValuation.sol";
 import {IdentityValuation} from "src/misc/IdentityValuation.sol";
 
 import {ISafe} from "src/common/Guardian.sol";
@@ -31,7 +30,6 @@ contract HubDeployer is CommonDeployer {
     Hub public hub;
 
     // Utilities
-    TransientValuation public transientValuation;
     IdentityValuation public identityValuation;
 
     // Data
@@ -41,12 +39,11 @@ contract HubDeployer is CommonDeployer {
         deployCommon(centrifugeId, adminSafe_, deployer, isTests);
 
         hubRegistry = new HubRegistry(deployer);
-        transientValuation = new TransientValuation(hubRegistry, deployer);
         identityValuation = new IdentityValuation(hubRegistry, deployer);
         accounting = new Accounting(deployer);
         holdings = new Holdings(hubRegistry, deployer);
         shareClassManager = new ShareClassManager(hubRegistry, deployer);
-        hub = new Hub(shareClassManager, hubRegistry, accounting, holdings, gateway, transientValuation, deployer);
+        hub = new Hub(shareClassManager, hubRegistry, accounting, holdings, gateway, deployer);
 
         _poolsRegister();
         _poolsRely();
@@ -60,7 +57,6 @@ contract HubDeployer is CommonDeployer {
         register("holdings", address(holdings));
         register("shareClassManager", address(shareClassManager));
         register("hub", address(hub));
-        register("transientValuation", address(transientValuation));
         register("identityValuation", address(identityValuation));
     }
 
@@ -84,7 +80,6 @@ contract HubDeployer is CommonDeployer {
         holdings.rely(address(root));
         shareClassManager.rely(address(root));
         hub.rely(address(root));
-        transientValuation.rely(address(root));
         identityValuation.rely(address(root));
     }
 
@@ -110,7 +105,6 @@ contract HubDeployer is CommonDeployer {
         shareClassManager.deny(deployer);
         hub.deny(deployer);
 
-        transientValuation.deny(deployer);
         identityValuation.deny(deployer);
     }
 }

--- a/script/adapters/Localhost.s.sol
+++ b/script/adapters/Localhost.s.sol
@@ -58,7 +58,7 @@ contract LocalhostDeployer is FullDeployer {
         hub.updateManager(poolId, vm.envAddress("ADMIN"), true);
         ShareClassId scId = shareClassManager.previewNextShareClassId(poolId);
 
-        D18 navPerShare = d18(1, 1);
+        D18 identityPrice = d18(1, 1);
 
         hub.setPoolMetadata(poolId, bytes("Testing pool"));
         hub.addShareClass(poolId, "Tokenized MMF", "MMF", bytes32(bytes("1")), bytes(""));
@@ -73,7 +73,6 @@ contract LocalhostDeployer is FullDeployer {
             poolId,
             scId,
             assetId,
-            identityValuation,
             AccountId.wrap(0x01),
             AccountId.wrap(0x02),
             AccountId.wrap(0x03),
@@ -92,9 +91,9 @@ contract LocalhostDeployer is FullDeployer {
             }).serialize()
         );
 
-        hub.updatePricePoolPerShare(poolId, scId, navPerShare, "");
+        hub.updatePricePoolPerShare(poolId, scId, identityPrice, "");
         hub.notifySharePrice(poolId, centrifugeId, scId);
-        hub.notifyAssetPrice(poolId, scId, assetId);
+        hub.notifyAssetPrice(poolId, scId, assetId, identityPrice);
 
         // Submit deposit request
         IShareToken shareToken = IShareToken(poolManager.shareToken(poolId.raw(), scId.raw()));
@@ -105,10 +104,8 @@ contract LocalhostDeployer is FullDeployer {
         vault.requestDeposit(investAmount, msg.sender, msg.sender);
 
         // Fulfill deposit request
-        IERC7726 valuation = holdings.valuation(poolId, scId, assetId);
-
-        hub.approveDeposits(poolId, scId, assetId, investAmount, valuation);
-        hub.issueShares(poolId, scId, assetId, navPerShare);
+        hub.approveDeposits(poolId, scId, assetId, investAmount, identityValuation);
+        hub.issueShares(poolId, scId, assetId, identityPrice);
 
         hub.claimDeposit(poolId, scId, assetId, bytes32(bytes20(msg.sender)));
 
@@ -121,7 +118,7 @@ contract LocalhostDeployer is FullDeployer {
         hub.updateManager(poolId, vm.envAddress("ADMIN"), true);
         ShareClassId scId = shareClassManager.previewNextShareClassId(poolId);
 
-        D18 navPerShare = d18(1, 1);
+        D18 identityPrice = d18(1, 1);
 
         hub.setPoolMetadata(poolId, bytes("Testing pool"));
         hub.addShareClass(poolId, "RWA Portfolio", "RWA", bytes32(bytes("2")), bytes(""));
@@ -136,7 +133,6 @@ contract LocalhostDeployer is FullDeployer {
             poolId,
             scId,
             assetId,
-            identityValuation,
             AccountId.wrap(0x01),
             AccountId.wrap(0x02),
             AccountId.wrap(0x03),
@@ -155,9 +151,9 @@ contract LocalhostDeployer is FullDeployer {
             }).serialize()
         );
 
-        hub.updatePricePoolPerShare(poolId, scId, navPerShare, "");
+        hub.updatePricePoolPerShare(poolId, scId, identityPrice, "");
         hub.notifySharePrice(poolId, centrifugeId, scId);
-        hub.notifyAssetPrice(poolId, scId, assetId);
+        hub.notifyAssetPrice(poolId, scId, assetId, identityPrice);
 
         // Deposit
         IShareToken shareToken = IShareToken(poolManager.shareToken(poolId.raw(), scId.raw()));

--- a/src/hub/interfaces/IHoldings.sol
+++ b/src/hub/interfaces/IHoldings.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.5.0;
 
-import {IERC7726} from "src/misc/interfaces/IERC7726.sol";
+import {D18} from "src/misc/types/D18.sol";
 
 import {PoolId} from "src/common/types/PoolId.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
@@ -11,8 +11,8 @@ import {ShareClassId} from "src/common/types/ShareClassId.sol";
 struct Holding {
     uint128 assetAmount;
     uint128 assetAmountValue;
-    IERC7726 valuation; // Used for existence
     bool isLiability;
+    bool existence;
 }
 
 struct HoldingAccount {
@@ -26,32 +26,17 @@ interface IHoldings {
 
     /// @notice Emitted when a holding is created
     event Create(
-        PoolId indexed,
-        ShareClassId indexed scId,
-        AssetId indexed assetId,
-        IERC7726 valuation,
-        bool isLiability,
-        HoldingAccount[] accounts
+        PoolId indexed, ShareClassId indexed scId, AssetId indexed assetId, bool isLiability, HoldingAccount[] accounts
     );
 
     /// @notice Emitted when a holding is increased
     event Increase(
-        PoolId indexed,
-        ShareClassId indexed scId,
-        AssetId indexed assetId,
-        IERC7726 valuation,
-        uint128 amount,
-        uint128 increasedValue
+        PoolId indexed, ShareClassId indexed scId, AssetId indexed assetId, uint128 amount, uint128 increasedValue
     );
 
     /// @notice Emitted when a holding is decreased
     event Decrease(
-        PoolId indexed,
-        ShareClassId indexed scId,
-        AssetId indexed assetId,
-        IERC7726 valuation,
-        uint128 amount,
-        uint128 decreasedValue
+        PoolId indexed, ShareClassId indexed scId, AssetId indexed assetId, uint128 amount, uint128 decreasedValue
     );
 
     /// @notice Emitted when the holding is updated
@@ -59,8 +44,8 @@ interface IHoldings {
         PoolId indexed, ShareClassId indexed scId, AssetId indexed assetId, bool isPositive, uint128 diffValue
     );
 
-    /// @notice Emitted when a holding valuation is updated
-    event UpdateValuation(PoolId indexed, ShareClassId indexed scId, AssetId indexed assetId, IERC7726 valuation);
+    /// @notice Emitted when a holding is updated
+    event UpdateValuation(PoolId indexed, ShareClassId indexed scId, AssetId indexed assetId);
 
     /// @notice Emitted when an account is for a holding is set
     event SetAccountId(
@@ -88,37 +73,33 @@ interface IHoldings {
     /// @param data New value given to the `what` parameter
     function file(bytes32 what, address data) external;
 
-    /// @notice Creates a new holding in a pool using a valuation
+    /// @notice Creates a new holding in a pool
     function create(
         PoolId poolId,
         ShareClassId scId,
         AssetId assetId,
-        IERC7726 valuation,
         bool isLiability,
         HoldingAccount[] memory accounts
     ) external;
 
     /// @notice Increments the amount of a holding and updates the value for that increment.
     /// @return value The value the holding has increment.
-    function increase(PoolId poolId, ShareClassId scId, AssetId assetId, IERC7726 valuation, uint128 amount)
+    function increase(PoolId poolId, ShareClassId scId, AssetId assetId, D18 price, uint128 amount)
         external
         returns (uint128 value);
 
     /// @notice Decrements the amount of a holding and updates the value for that decrement.
     /// @return value The value the holding has decrement.
-    function decrease(PoolId poolId, ShareClassId scId, AssetId assetId, IERC7726 valuation, uint128 amount)
+    function decrease(PoolId poolId, ShareClassId scId, AssetId assetId, D18 price, uint128 amount)
         external
         returns (uint128 value);
 
-    /// @notice Reset the value of a holding using the current valuation.
+    /// @notice Reset the value of a holding using the current price.
     /// @return isPositive Indicates whether the diffValue is positive or negative
-    /// @return diffValue The difference in value after the new valuation.
-    function update(PoolId poolId, ShareClassId scId, AssetId assetId)
+    /// @return diffValue The difference in value after the new price.
+    function update(PoolId poolId, ShareClassId scId, AssetId assetId, D18 price)
         external
         returns (bool isPositive, uint128 diffValue);
-
-    /// @notice Updates the valuation method used for this holding.
-    function updateValuation(PoolId poolId, ShareClassId scId, AssetId assetId, IERC7726 valuation) external;
 
     /// @notice Sets an account id for an specific kind
     function setAccountId(PoolId poolId, ShareClassId scId, AssetId assetId, uint8 kind, AccountId accountId)
@@ -129,9 +110,6 @@ interface IHoldings {
 
     /// @notice Returns the amount of this holding.
     function amount(PoolId poolId, ShareClassId scId, AssetId assetId) external view returns (uint128 amount);
-
-    /// @notice Returns the valuation method used for this holding.
-    function valuation(PoolId poolId, ShareClassId scId, AssetId assetId) external view returns (IERC7726);
 
     /// @notice Returns if the holding is a liability
     function isLiability(PoolId poolId, ShareClassId scId, AssetId assetId) external view returns (bool);

--- a/src/hub/interfaces/IHub.sol
+++ b/src/hub/interfaces/IHub.sol
@@ -91,7 +91,7 @@ interface IHub {
     /// @dev The receiving chainId is derived from the provided assetId
     /// @param scId Identifier of the share class
     /// @param assetId Identifier of the asset
-    function notifyAssetPrice(PoolId poolId, ShareClassId scId, AssetId assetId) external payable;
+    function notifyAssetPrice(PoolId poolId, ShareClassId scId, AssetId assetId, D18 price) external payable;
 
     /// @notice Attach custom data to a pool
     function setPoolMetadata(PoolId poolId, bytes calldata metadata) external payable;
@@ -180,7 +180,6 @@ interface IHub {
     /// e.g.: The equity, loss, and gain account can be the same account.
     /// They can also be shared across assets.
     /// e.g.: All assets can use the same equity account.
-    /// @param valuation Used to transform between payment assets and pool currency
     /// @param assetAccount Used to track the asset value
     /// @param equityAccount Used to track the equity value
     /// @param lossAccount Used to track the loss value
@@ -189,7 +188,6 @@ interface IHub {
         PoolId poolId,
         ShareClassId scId,
         AssetId assetId,
-        IERC7726 valuation,
         AccountId assetAccount,
         AccountId equityAccount,
         AccountId lossAccount,
@@ -199,26 +197,18 @@ interface IHub {
     /// @notice Create a new liablity associated to the asset in a share class.
     /// It will register the different accounts used for holdings.
     /// The accounts have to be created beforehand.
-    /// @param valuation Used to transform between the holding asset and pool currency
     /// @param expenseAccount Used to track the expense value
     /// @param liabilityAccount Used to track the liability value
     function createLiability(
         PoolId poolId,
         ShareClassId scId,
         AssetId assetId,
-        IERC7726 valuation,
         AccountId expenseAccount,
         AccountId liabilityAccount
     ) external payable;
 
-    /// @notice Updates the pool currency value of this holding based of the associated valuation.
-    function updateHoldingValue(PoolId poolId, ShareClassId scId, AssetId assetId) external payable;
-
-    /// @notice Updates the valuation used by a holding
-    /// @param valuation Used to transform between the holding asset and pool currency
-    function updateHoldingValuation(PoolId poolId, ShareClassId scId, AssetId assetId, IERC7726 valuation)
-        external
-        payable;
+    /// @notice Updates the pool currency value of this holding based on the associated price.
+    function updateHoldingValue(PoolId poolId, ShareClassId scId, AssetId assetId, D18 price) external payable;
 
     /// @notice Set an account of a holding
     function setHoldingAccountId(PoolId poolId, ShareClassId scId, AssetId assetId, uint8 kind, AccountId accountId)

--- a/test/hub/integration/BaseTest.sol
+++ b/test/hub/integration/BaseTest.sol
@@ -8,6 +8,7 @@ import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {MathLib} from "src/misc/libraries/MathLib.sol";
 import {IMulticall} from "src/misc/interfaces/IMulticall.sol";
 import {IERC7726} from "src/misc/interfaces/IERC7726.sol";
+import {ConversionLib} from "src/misc/libraries/ConversionLib.sol";
 
 import {MessageLib, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
 import {IAdapter} from "src/common/interfaces/IAdapter.sol";
@@ -46,6 +47,7 @@ contract BaseTest is HubDeployer, Test {
     uint128 constant APPROVED_INVESTOR_AMOUNT = INVESTOR_AMOUNT / 5;
     uint128 constant APPROVED_SHARE_AMOUNT = SHARE_AMOUNT / 5;
     D18 immutable NAV_PER_SHARE = d18(2, 1);
+    D18 immutable IDENTITY_PRICE = d18(1, 1);
 
     uint64 constant GAS = 100 wei;
 
@@ -69,7 +71,6 @@ contract BaseTest is HubDeployer, Test {
         vm.deal(FM, 1 ether);
 
         // Label contracts & actors (for debugging)
-        vm.label(address(transientValuation), "TransientValuation");
         vm.label(address(identityValuation), "IdentityValuation");
         vm.label(address(hubRegistry), "HubRegistry");
         vm.label(address(accounting), "Accounting");


### PR DESCRIPTION
Fixes https://github.com/centrifuge/protocol-v3/issues/250

This is an daring solution, happy to discuss or even not merge it. But I think it deserves to evaluate it.

The point is that every time we use the `holding.valuation`, we use it from an admin role which has the same level of privileges for setting the valuation. It means: the own actor can retriver the price from the oracle and pass it to the method in the same moment.

We only need to automate this through an IERC7726 if the valuation should be set by an admin to be used later by a lower-privileged user. **This is not the case for any of our methods in the Hub.**

That means that we can simplify it by:
- Removing transient valuation at all.
- Removing the `holding.valuation`
- Using D18 prices as parameters

In the same line, we can also remove the `valuation` parameter in `approveDeposits` and `revokeShares` by a price


NOTE: The PR is ready except for adapting the UTs from `Holding.t.sol` 