### PR TITLE
Ref: Factory addresss typed

### DIFF
--- a/src/hooks/Permissionless.sol
+++ b/src/hooks/Permissionless.sol
@@ -5,11 +5,11 @@ import {Auth} from "src/misc/Auth.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 import {BitmapLib} from "src/misc/libraries/BitmapLib.sol";
+import {IERC165} from "src/misc/interfaces/IERC7575.sol";
 
 import {IRoot} from "src/common/interfaces/IRoot.sol";
 import {UpdateRestrictionType, MessageLib} from "src/common/libraries/MessageLib.sol";
 
-import {IERC165} from "src/vaults/interfaces/IERC7575.sol";
 import {IHook, HookData, ESCROW_HOOK_ID} from "src/vaults/interfaces/token/IHook.sol";
 import {IShareToken} from "src/vaults/interfaces/token/IShareToken.sol";
 

--- a/src/vaults/AsyncVault.sol
+++ b/src/vaults/AsyncVault.sol
@@ -16,6 +16,7 @@ import {IAsyncVault} from "src/vaults/interfaces/IBaseVaults.sol";
 import {IAsyncRequests} from "src/vaults/interfaces/investments/IAsyncRequests.sol";
 import {IPoolEscrowProvider} from "src/vaults/interfaces/factories/IPoolEscrowFactory.sol";
 import {IShareToken} from "src/vaults/interfaces/token/IShareToken.sol";
+import {IAsyncRedeemManager} from "src/vaults/interfaces/investments/IAsyncRedeemManager.sol";
 
 /// @title  AsyncVault
 /// @notice Asynchronous Tokenized Vault standard implementation for Centrifuge pools
@@ -35,7 +36,7 @@ contract AsyncVault is AsyncRedeemVault, IAsyncVault {
         uint256 tokenId_,
         IShareToken token_,
         address root_,
-        address manager_,
+        IAsyncRedeemManager manager_,
         IPoolEscrowProvider poolEscrowProvider
     )
         BaseVault(poolId_, scId_, asset_, tokenId_, token_, root_, manager_, poolEscrowProvider)

--- a/src/vaults/BaseVaults.sol
+++ b/src/vaults/BaseVaults.sol
@@ -69,7 +69,7 @@ abstract contract BaseVault is Auth, Recoverable, IBaseVault {
         uint256 tokenId_,
         IShareToken token_,
         address root_,
-        address manager_,
+        IBaseInvestmentManager manager_,
         IPoolEscrowProvider poolEscrowProvider_
     ) Auth(msg.sender) {
         poolId = poolId_;
@@ -80,7 +80,7 @@ abstract contract BaseVault is Auth, Recoverable, IBaseVault {
         _shareDecimals = IERC20Metadata(share).decimals();
         root = IRoot(root_);
         // TODO: Redundant due to filing?
-        manager = IBaseInvestmentManager(manager_);
+        manager = manager_;
         _poolEscrowProvider = poolEscrowProvider_;
 
         nameHash = keccak256(bytes("Centrifuge"));
@@ -209,8 +209,8 @@ abstract contract BaseVault is Auth, Recoverable, IBaseVault {
 abstract contract AsyncRedeemVault is BaseVault, IAsyncRedeemVault {
     IAsyncRedeemManager public asyncRedeemManager;
 
-    constructor(address asyncRequests_) {
-        asyncRedeemManager = IAsyncRedeemManager(asyncRequests_);
+    constructor(IAsyncRedeemManager asyncRequests_) {
+        asyncRedeemManager = asyncRequests_;
     }
 
     // --- ERC-7540 methods ---
@@ -338,8 +338,8 @@ abstract contract AsyncRedeemVault is BaseVault, IAsyncRedeemVault {
 abstract contract BaseSyncDepositVault is BaseVault {
     ISyncDepositManager public syncDepositManager;
 
-    constructor(address syncRequests_) {
-        syncDepositManager = ISyncDepositManager(syncRequests_);
+    constructor(ISyncDepositManager syncRequests_) {
+        syncDepositManager = syncRequests_;
     }
 
     // --- ERC-4626 methods ---

--- a/src/vaults/SyncDepositVault.sol
+++ b/src/vaults/SyncDepositVault.sol
@@ -12,6 +12,8 @@ import {BaseVault, AsyncRedeemVault, BaseSyncDepositVault} from "src/vaults/Base
 import {ISyncRequests} from "src/vaults/interfaces/investments/ISyncRequests.sol";
 import {IPoolEscrowProvider} from "src/vaults/interfaces/factories/IPoolEscrowFactory.sol";
 import {IShareToken} from "src/vaults/interfaces/token/IShareToken.sol";
+import {IAsyncRedeemManager} from "src/vaults/interfaces/investments/IAsyncRedeemManager.sol";
+import {ISyncDepositManager} from "src/vaults/interfaces/investments/ISyncDepositManager.sol";
 
 /// @title  SyncDepositVault
 /// @notice Partially (a)synchronous Tokenized Vault implementation with synchronous deposits and asynchronous
@@ -27,8 +29,8 @@ contract SyncDepositVault is BaseSyncDepositVault, AsyncRedeemVault {
         uint256 tokenId_,
         IShareToken token_,
         address root_,
-        address syncDepositManager_,
-        address asyncRedeemManager_,
+        ISyncDepositManager syncDepositManager_,
+        IAsyncRedeemManager asyncRedeemManager_,
         IPoolEscrowProvider poolEscrowProvider_
     )
         BaseVault(poolId_, scId_, asset_, tokenId_, token_, root_, syncDepositManager_, poolEscrowProvider_)

--- a/src/vaults/VaultRouter.sol
+++ b/src/vaults/VaultRouter.sol
@@ -45,14 +45,14 @@ contract VaultRouter is Auth, Multicall, Recoverable, IVaultRouter {
 
     constructor(
         address escrow_,
-        address gateway_,
-        address poolManager_,
+        IGateway gateway_,
+        IPoolManager poolManager_,
         IMessageDispatcher messageDispatcher_,
         address deployer
     ) Auth(deployer) {
         escrow = IEscrow(escrow_);
-        gateway = IGateway(gateway_);
-        poolManager = IPoolManager(poolManager_);
+        gateway = gateway_;
+        poolManager = poolManager_;
         messageDispatcher = messageDispatcher_;
     }
 

--- a/src/vaults/factories/AsyncVaultFactory.sol
+++ b/src/vaults/factories/AsyncVaultFactory.sol
@@ -10,19 +10,23 @@ import {AsyncVault} from "src/vaults/AsyncVault.sol";
 import {IVaultFactory} from "src/vaults/interfaces/factories/IVaultFactory.sol";
 import {IPoolEscrowProvider} from "src/vaults/interfaces/factories/IPoolEscrowFactory.sol";
 import {IShareToken} from "src/vaults/interfaces/token/IShareToken.sol";
+import {IAsyncRedeemManager} from "src/vaults/interfaces/investments/IAsyncRedeemManager.sol";
 
 /// @title  ERC7540 Vault Factory
 /// @dev    Utility for deploying new vault contracts
 contract AsyncVaultFactory is Auth, IVaultFactory {
     address public immutable root;
-    address public immutable investmentManager;
+    IAsyncRedeemManager public immutable asyncRedeemManager;
     IPoolEscrowProvider public immutable poolEscrowProvider;
 
-    constructor(address root_, address investmentManager_, IPoolEscrowProvider poolEscrowProvider_, address deployer)
-        Auth(deployer)
-    {
+    constructor(
+        address root_,
+        IAsyncRedeemManager asyncRedeemManager_,
+        IPoolEscrowProvider poolEscrowProvider_,
+        address deployer
+    ) Auth(deployer) {
         root = root_;
-        investmentManager = investmentManager_;
+        asyncRedeemManager = asyncRedeemManager_;
         poolEscrowProvider = poolEscrowProvider_;
     }
 
@@ -33,14 +37,13 @@ contract AsyncVaultFactory is Auth, IVaultFactory {
         address asset,
         uint256 tokenId,
         IShareToken token,
-        address, /* escrow */
         address[] calldata wards_
     ) public auth returns (address) {
         AsyncVault vault =
-            new AsyncVault(poolId, scId, asset, tokenId, token, root, investmentManager, poolEscrowProvider);
+            new AsyncVault(poolId, scId, asset, tokenId, token, root, asyncRedeemManager, poolEscrowProvider);
 
         vault.rely(root);
-        vault.rely(investmentManager);
+        vault.rely(address(asyncRedeemManager));
         uint256 wardsCount = wards_.length;
         for (uint256 i; i < wardsCount; i++) {
             vault.rely(wards_[i]);

--- a/src/vaults/factories/PoolEscrowFactory.sol
+++ b/src/vaults/factories/PoolEscrowFactory.sol
@@ -17,7 +17,7 @@ contract PoolEscrowFactory is IPoolEscrowFactory, Auth {
     address public balanceSheet;
     address public asyncRequests;
 
-    mapping(PoolId poolId => address) public escrows;
+    mapping(PoolId poolId => IPoolEscrow) public escrows;
 
     constructor(address root_, address deployer) Auth(deployer) {
         root = root_;
@@ -35,7 +35,7 @@ contract PoolEscrowFactory is IPoolEscrowFactory, Auth {
 
     /// @inheritdoc IPoolEscrowFactory
     function newEscrow(PoolId poolId) public auth returns (IPoolEscrow) {
-        require(escrows[poolId] == address(0), EscrowAlreadyDeployed());
+        require(address(escrows[poolId]) == address(0), EscrowAlreadyDeployed());
         PoolEscrow escrow_ = new PoolEscrow{salt: bytes32(uint256(poolId.raw()))}(poolId, address(this));
 
         escrow_.rely(root);
@@ -46,7 +46,7 @@ contract PoolEscrowFactory is IPoolEscrowFactory, Auth {
 
         escrow_.deny(address(this));
 
-        escrows[poolId] = address(escrow_);
+        escrows[poolId] = escrow_;
 
         emit DeployPoolEscrow(poolId, address(escrow_));
         return IPoolEscrow(escrow_);
@@ -64,7 +64,7 @@ contract PoolEscrowFactory is IPoolEscrowFactory, Auth {
     }
 
     /// @inheritdoc IPoolEscrowProvider
-    function deployedEscrow(PoolId poolId) external view returns (address) {
+    function deployedEscrow(PoolId poolId) external view returns (IPoolEscrow) {
         return escrows[poolId];
     }
 }

--- a/src/vaults/interfaces/IPoolManager.sol
+++ b/src/vaults/interfaces/IPoolManager.sol
@@ -2,10 +2,12 @@
 pragma solidity >=0.5.0;
 
 import {D18, d18} from "src/misc/types/D18.sol";
-import {IShareToken} from "src/vaults/interfaces/token/IShareToken.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
+
+import {IShareToken} from "src/vaults/interfaces/token/IShareToken.sol";
+import {IVaultFactory} from "src/vaults/interfaces/factories/IVaultFactory.sol";
 
 /// @dev Centrifuge pools
 struct Pool {
@@ -88,7 +90,7 @@ interface IPoolManager {
         ShareClassId indexed scId,
         address indexed asset,
         uint256 tokenId,
-        address factory,
+        IVaultFactory factory,
         address vault
     );
     event PriceUpdate(
@@ -198,7 +200,7 @@ interface IPoolManager {
     /// @param assetId The asset id for which we want to deploy a vault
     /// @param factory The address of the corresponding vault factory
     /// @return address The address of the deployed vault
-    function deployVault(PoolId poolId, ShareClassId scId, AssetId assetId, address factory)
+    function deployVault(PoolId poolId, ShareClassId scId, AssetId assetId, IVaultFactory factory)
         external
         returns (address);
 

--- a/src/vaults/interfaces/factories/IPoolEscrowFactory.sol
+++ b/src/vaults/interfaces/factories/IPoolEscrowFactory.sol
@@ -13,7 +13,7 @@ interface IPoolEscrowProvider {
     function escrow(PoolId poolId) external view returns (IPoolEscrow);
 
     /// @notice Returns the address of the corresponding deployed escrow contract if it exists
-    function deployedEscrow(PoolId poolId) external view returns (address);
+    function deployedEscrow(PoolId poolId) external view returns (IPoolEscrow);
 }
 
 interface IPoolEscrowFactory is IPoolEscrowProvider {

--- a/src/vaults/interfaces/factories/IVaultFactory.sol
+++ b/src/vaults/interfaces/factories/IVaultFactory.sol
@@ -5,6 +5,7 @@ import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
 import {IShareToken} from "src/vaults/interfaces/token/IShareToken.sol";
+import {IPoolEscrow} from "src/vaults/interfaces/IEscrow.sol";
 
 interface IVaultFactory {
     /// @notice Deploys new vault for `poolId`, `scId` and `asset`.
@@ -15,7 +16,6 @@ interface IVaultFactory {
     /// @param asset Token id of the underlying asset that is getting deposited inside the pool. I.e. zero if asset
     /// corresponds to ERC20 or non-zero if asset corresponds to ERC6909.
     /// @param token Address of the share class token that is getting issues against the deposited asset.
-    /// @param escrow An intermediary contract that holds a temporary funds until request is fulfilled.
     /// @param wards_ Address which can call methods behind authorized only.
     function newVault(
         PoolId poolId,
@@ -23,7 +23,6 @@ interface IVaultFactory {
         address asset,
         uint256 tokenId,
         IShareToken token,
-        address escrow,
         address[] calldata wards_
     ) external returns (address);
 }

--- a/src/vaults/legacy/LegacyVaultAdapter.sol
+++ b/src/vaults/legacy/LegacyVaultAdapter.sol
@@ -10,6 +10,7 @@ import {ILegacyVaultAdapter} from "src/vaults/legacy/interfaces/ILegacyVaultAdap
 import {IPoolEscrowProvider} from "src/vaults/interfaces/factories/IPoolEscrowFactory.sol";
 import {IShareToken} from "src/vaults/interfaces/token/IShareToken.sol";
 import {AsyncVault} from "src/vaults/AsyncVault.sol";
+import {IAsyncRedeemManager} from "src/vaults/interfaces/investments/IAsyncRedeemManager.sol";
 
 /// @title  LegacyVaultAdapter
 /// @notice An adapter connecting legacy ERC-7540 vaults from Centrifuge V2 to Centrifuge V3.
@@ -36,7 +37,7 @@ contract LegacyVaultAdapter is AsyncVault, ILegacyVaultAdapter, IInvestmentManag
         address asset,
         IShareToken token,
         address root,
-        address manager,
+        IAsyncRedeemManager manager,
         IPoolEscrowProvider poolEscrowProvider
     ) AsyncVault(poolId, scId, asset, LEGACY_TOKEN_ID, token, root, manager, poolEscrowProvider) {
         require(legacyVault_.poolId() == legacyPoolId_, NotLegacyPoolId(legacyPoolId_, legacyVault_.poolId()));

--- a/test/vaults/BaseTest.sol
+++ b/test/vaults/BaseTest.sol
@@ -28,6 +28,7 @@ import {ShareToken} from "src/vaults/token/ShareToken.sol";
 import {IShareToken} from "src/vaults/interfaces/token/IShareToken.sol";
 import {RestrictedTransfers} from "src/hooks/RestrictedTransfers.sol";
 import {VaultKind} from "src/vaults/interfaces/IVaultManager.sol";
+import {IVaultFactory} from "src/vaults/interfaces/factories/IVaultFactory.sol";
 
 // scripts
 import {VaultsDeployer} from "script/VaultsDeployer.s.sol";
@@ -199,7 +200,7 @@ contract BaseTest is VaultsDeployer, Test {
             POOL_A,
             ShareClassId.wrap(scId),
             MessageLib.UpdateContractVaultUpdate({
-                vaultOrFactory: bytes32(bytes20(vaultFactory)),
+                vaultOrFactory: vaultFactory,
                 assetId: assetId,
                 kind: uint8(VaultUpdateKind.DeployAndLink)
             }).serialize()
@@ -269,7 +270,7 @@ contract BaseTest is VaultsDeployer, Test {
     }
 
     function _vaultKindToVaultFactory(VaultKind vaultKind) internal view returns (bytes32 vaultFactoryBytes) {
-        address vaultFactory;
+        IVaultFactory vaultFactory;
 
         if (vaultKind == VaultKind.Async) {
             vaultFactory = asyncVaultFactory;
@@ -279,7 +280,7 @@ contract BaseTest is VaultsDeployer, Test {
             revert("BaseTest/unsupported-vault-kind");
         }
 
-        return bytes32(bytes20(vaultFactory));
+        return bytes32(bytes20(address(vaultFactory)));
     }
 
     // assumptions

--- a/test/vaults/integration/SyncRequests.t.sol
+++ b/test/vaults/integration/SyncRequests.t.sol
@@ -139,7 +139,7 @@ contract SyncRequestsUnauthorizedTest is SyncRequestsBaseTest {
 
     function _expectUnauthorized(address caller) internal {
         vm.assume(
-            caller != address(root) && caller != address(poolManager) && caller != syncDepositVaultFactory
+            caller != address(root) && caller != address(poolManager) && caller != address(syncDepositVaultFactory)
                 && caller != address(this)
         );
 

--- a/test/vaults/unit/VaultRouter.t.sol
+++ b/test/vaults/unit/VaultRouter.t.sol
@@ -42,7 +42,7 @@ contract VaultRouterTest is BaseTest {
 
     function testInitialization() public {
         // redeploying within test to increase coverage
-        new VaultRouter(address(routerEscrow), address(gateway), address(poolManager), messageDispatcher, address(this));
+        new VaultRouter(address(routerEscrow), gateway, poolManager, messageDispatcher, address(this));
 
         assertEq(address(vaultRouter.escrow()), address(routerEscrow));
         assertEq(address(vaultRouter.gateway()), address(gateway));


### PR DESCRIPTION
Use the Interface where it's known the address is always the interface. 

Fixes https://github.com/centrifuge/protocol-v3/issues/284