### PR TITLE
Ref: typed vaults

### DIFF
--- a/snapshots/AsyncVault.json
+++ b/snapshots/AsyncVault.json
@@ -1,4 +1,4 @@
 {
   "fulfillDepositRequest": "943198",
-  "requestDeposit": "472208"
+  "requestDeposit": "472204"
 }

--- a/snapshots/VaultRouter.json
+++ b/snapshots/VaultRouter.json
@@ -1,7 +1,7 @@
 {
-  "claimDeposit": "1192186",
+  "claimDeposit": "1192179",
   "enable": "60975",
   "lockDepositRequest": "92339",
-  "requestDeposit": "563450",
-  "requestRedeem": "2101868"
+  "requestDeposit": "563446",
+  "requestRedeem": "2101844"
 }

--- a/src/vaults/AsyncRequests.sol
+++ b/src/vaults/AsyncRequests.sol
@@ -51,8 +51,8 @@ contract AsyncRequests is BaseInvestmentManager, IAsyncRequests {
     IVaultMessageSender public sender;
     IBalanceSheet public balanceSheet;
 
-    mapping(address vault => mapping(address investor => AsyncInvestmentState)) public investments;
-    mapping(PoolId poolId => mapping(ShareClassId scId => mapping(AssetId assetId => address vault))) public vault;
+    mapping(IBaseVault vault => mapping(address investor => AsyncInvestmentState)) public investments;
+    mapping(PoolId poolId => mapping(ShareClassId scId => mapping(AssetId assetId => IAsyncVault vault))) public vault;
 
     constructor(address root_, address deployer) BaseInvestmentManager(root_, deployer) {}
 
@@ -68,43 +68,42 @@ contract AsyncRequests is BaseInvestmentManager, IAsyncRequests {
 
     // --- IVaultManager ---
     /// @inheritdoc IVaultManager
-    function addVault(PoolId poolId, ShareClassId scId, address vaultAddr, address asset_, AssetId assetId)
+    /// @dev vault_ Must be an IAsyncVault
+    function addVault(PoolId poolId, ShareClassId scId, IBaseVault vault_, address asset_, AssetId assetId)
         public
         auth
     {
-        IAsyncVault vault_ = IAsyncVault(vaultAddr);
         address token = vault_.share();
 
         require(vault_.asset() == asset_, AssetMismatch());
-        require(vault[poolId][scId][assetId] == address(0), VaultAlreadyExists());
+        require(address(vault[poolId][scId][assetId]) == address(0), VaultAlreadyExists());
 
-        vault[poolId][scId][assetId] = vaultAddr;
-        IAuth(token).rely(vaultAddr);
-        IShareToken(token).updateVault(vault_.asset(), vaultAddr);
-        rely(vaultAddr);
+        vault[poolId][scId][assetId] = IAsyncVault(address(vault_));
+        IAuth(token).rely(address(vault_));
+        IShareToken(token).updateVault(vault_.asset(), address(vault_));
+        rely(address(vault_));
     }
 
     /// @inheritdoc IVaultManager
-    function removeVault(PoolId poolId, ShareClassId scId, address vaultAddr, address asset_, AssetId assetId)
+    function removeVault(PoolId poolId, ShareClassId scId, IBaseVault vault_, address asset_, AssetId assetId)
         public
         auth
     {
-        IAsyncVault vault_ = IAsyncVault(vaultAddr);
         address token = vault_.share();
 
         require(vault_.asset() == asset_, AssetMismatch());
-        require(vault[poolId][scId][assetId] != address(0), VaultDoesNotExist());
+        require(address(vault[poolId][scId][assetId]) != address(0), VaultDoesNotExist());
 
         delete vault[poolId][scId][assetId];
 
-        IAuth(token).deny(vaultAddr);
+        IAuth(token).deny(address(vault_));
         IShareToken(token).updateVault(vault_.asset(), address(0));
-        deny(vaultAddr);
+        deny(address(vault_));
     }
 
     // --- Async investment handlers ---
     /// @inheritdoc IAsyncDepositManager
-    function requestDeposit(address vaultAddr, uint256 assets, address controller, address, address)
+    function requestDeposit(IBaseVault vault_, uint256 assets, address controller, address, address)
         public
         auth
         returns (bool)
@@ -112,23 +111,20 @@ contract AsyncRequests is BaseInvestmentManager, IAsyncRequests {
         uint128 _assets = assets.toUint128();
         require(_assets != 0, ZeroAmountNotAllowed());
 
-        return _processDepositRequest(vaultAddr, _assets, controller);
+        return _processDepositRequest(vault_, _assets, controller);
     }
 
     /// @dev Necessary because of stack-too-deep
-    function _processDepositRequest(address vaultAddr, uint128 assets, address controller) internal returns (bool) {
-        IAsyncVault vault_ = IAsyncVault(vaultAddr);
-        VaultDetails memory vaultDetails = poolManager.vaultDetails(vaultAddr);
+    function _processDepositRequest(IBaseVault vault_, uint128 assets, address controller) internal returns (bool) {
+        VaultDetails memory vaultDetails = poolManager.vaultDetails(vault_);
         PoolId poolId = vault_.poolId();
         ShareClassId scId = vault_.scId();
 
-        require(poolManager.isLinked(poolId, scId, vaultDetails.asset, vaultAddr), AssetNotAllowed());
+        require(poolManager.isLinked(poolId, scId, vaultDetails.asset, vault_), AssetNotAllowed());
 
-        require(
-            _canTransfer(vaultAddr, address(0), controller, convertToShares(vaultAddr, assets)), TransferNotAllowed()
-        );
+        require(_canTransfer(vault_, address(0), controller, convertToShares(vault_, assets)), TransferNotAllowed());
 
-        AsyncInvestmentState storage state = investments[vaultAddr][controller];
+        AsyncInvestmentState storage state = investments[vault_][controller];
         require(state.pendingCancelDepositRequest != true, CancellationIsPending());
 
         state.pendingDepositRequest += assets;
@@ -138,38 +134,36 @@ contract AsyncRequests is BaseInvestmentManager, IAsyncRequests {
     }
 
     /// @inheritdoc IAsyncRedeemManager
-    function requestRedeem(address vaultAddr, uint256 shares, address controller, address owner, address source)
+    function requestRedeem(IBaseVault vault_, uint256 shares, address controller, address owner, address source)
         public
         auth
         returns (bool)
     {
         uint128 _shares = shares.toUint128();
         require(_shares != 0, ZeroAmountNotAllowed());
-        IAsyncVault vault_ = IAsyncVault(vaultAddr);
 
         // You cannot redeem using a disallowed asset, instead another vault will have to be used
-        require(poolManager.isLinked(vault_.poolId(), vault_.scId(), vault_.asset(), vaultAddr), AssetNotAllowed());
+        require(poolManager.isLinked(vault_.poolId(), vault_.scId(), vault_.asset(), vault_), AssetNotAllowed());
 
         require(
-            _canTransfer(vaultAddr, owner, ESCROW_HOOK_ID, shares)
-                && _canTransfer(vaultAddr, controller, ESCROW_HOOK_ID, shares),
+            _canTransfer(vault_, owner, ESCROW_HOOK_ID, shares)
+                && _canTransfer(vault_, controller, ESCROW_HOOK_ID, shares),
             TransferNotAllowed()
         );
 
-        return _processRedeemRequest(vaultAddr, _shares, controller, source, false);
+        return _processRedeemRequest(vault_, _shares, controller, source, false);
     }
 
     /// @dev    triggered indicates if the the _processRedeemRequest call was triggered from centrifugeChain
-    function _processRedeemRequest(address vaultAddr, uint128 shares, address controller, address, bool triggered)
+    function _processRedeemRequest(IBaseVault vault_, uint128 shares, address controller, address, bool triggered)
         internal
         returns (bool)
     {
-        IAsyncVault vault_ = IAsyncVault(vaultAddr);
-        AsyncInvestmentState storage state = investments[vaultAddr][controller];
+        AsyncInvestmentState storage state = investments[vault_][controller];
         require(state.pendingCancelRedeemRequest != true || triggered, CancellationIsPending());
 
         state.pendingRedeemRequest = state.pendingRedeemRequest + shares;
-        VaultDetails memory vaultDetails = poolManager.vaultDetails(address(vault_));
+        VaultDetails memory vaultDetails = poolManager.vaultDetails(vault_);
 
         sender.sendRedeemRequest(vault_.poolId(), vault_.scId(), controller.toBytes32(), vaultDetails.assetId, shares);
 
@@ -177,31 +171,28 @@ contract AsyncRequests is BaseInvestmentManager, IAsyncRequests {
     }
 
     /// @inheritdoc IAsyncDepositManager
-    function cancelDepositRequest(address vaultAddr, address controller, address) public auth {
-        IAsyncVault vault_ = IAsyncVault(vaultAddr);
-
-        AsyncInvestmentState storage state = investments[vaultAddr][controller];
+    function cancelDepositRequest(IBaseVault vault_, address controller, address) public auth {
+        AsyncInvestmentState storage state = investments[vault_][controller];
         require(state.pendingDepositRequest > 0, NoPendingRequest());
         require(state.pendingCancelDepositRequest != true, CancellationIsPending());
         state.pendingCancelDepositRequest = true;
 
-        VaultDetails memory vaultDetails = poolManager.vaultDetails(address(vault_));
+        VaultDetails memory vaultDetails = poolManager.vaultDetails(vault_);
 
         sender.sendCancelDepositRequest(vault_.poolId(), vault_.scId(), controller.toBytes32(), vaultDetails.assetId);
     }
 
     /// @inheritdoc IAsyncRedeemManager
-    function cancelRedeemRequest(address vaultAddr, address controller, address) public auth {
-        IAsyncVault vault_ = IAsyncVault(vaultAddr);
-        uint256 approximateSharesPayout = pendingRedeemRequest(vaultAddr, controller);
+    function cancelRedeemRequest(IBaseVault vault_, address controller, address) public auth {
+        uint256 approximateSharesPayout = pendingRedeemRequest(vault_, controller);
         require(approximateSharesPayout > 0, NoPendingRequest());
-        require(_canTransfer(vaultAddr, address(0), controller, approximateSharesPayout), TransferNotAllowed());
+        require(_canTransfer(vault_, address(0), controller, approximateSharesPayout), TransferNotAllowed());
 
-        AsyncInvestmentState storage state = investments[vaultAddr][controller];
+        AsyncInvestmentState storage state = investments[vault_][controller];
         require(state.pendingCancelRedeemRequest != true, CancellationIsPending());
         state.pendingCancelRedeemRequest = true;
 
-        VaultDetails memory vaultDetails = poolManager.vaultDetails(address(vault_));
+        VaultDetails memory vaultDetails = poolManager.vaultDetails(vault_);
 
         sender.sendCancelRedeemRequest(vault_.poolId(), vault_.scId(), controller.toBytes32(), vaultDetails.assetId);
     }
@@ -216,7 +207,7 @@ contract AsyncRequests is BaseInvestmentManager, IAsyncRequests {
         uint128 assets,
         uint128 shares
     ) public auth {
-        address vault_ = vault[poolId][scId][assetId];
+        IAsyncVault vault_ = vault[poolId][scId][assetId];
 
         AsyncInvestmentState storage state = investments[vault_][user];
         require(state.pendingDepositRequest != 0, NoPendingRequest());
@@ -227,10 +218,10 @@ contract AsyncRequests is BaseInvestmentManager, IAsyncRequests {
         if (state.pendingDepositRequest == 0) delete state.pendingCancelDepositRequest;
 
         // Mint to escrow. Recipient can claim by calling deposit / mint
-        IShareToken shareToken = IShareToken(IAsyncVault(vault_).share());
+        IShareToken shareToken = IShareToken(vault_.share());
         shareToken.mint(address(poolEscrowProvider.escrow(poolId)), shares);
 
-        IAsyncVault(vault_).onDepositClaimable(user, assets, shares);
+        vault_.onDepositClaimable(user, assets, shares);
     }
 
     /// @inheritdoc IInvestmentManagerGatewayHandler
@@ -242,7 +233,7 @@ contract AsyncRequests is BaseInvestmentManager, IAsyncRequests {
         uint128 assets,
         uint128 shares
     ) public auth {
-        address vault_ = vault[poolId][scId][assetId];
+        IAsyncVault vault_ = vault[poolId][scId][assetId];
 
         AsyncInvestmentState storage state = investments[vault_][user];
         require(state.pendingRedeemRequest != 0, NoPendingRequest());
@@ -256,10 +247,10 @@ contract AsyncRequests is BaseInvestmentManager, IAsyncRequests {
         if (state.pendingRedeemRequest == 0) delete state.pendingCancelRedeemRequest;
 
         // Burn redeemed share class tokens from escrow
-        IShareToken shareToken = IShareToken(IAsyncVault(vault_).share());
+        IShareToken shareToken = IShareToken(vault_.share());
         shareToken.burn(address(poolEscrowProvider.escrow(poolId)), shares);
 
-        IAsyncVault(vault_).onRedeemClaimable(user, assets, shares);
+        vault_.onRedeemClaimable(user, assets, shares);
     }
 
     /// @inheritdoc IInvestmentManagerGatewayHandler
@@ -271,7 +262,7 @@ contract AsyncRequests is BaseInvestmentManager, IAsyncRequests {
         uint128 assets,
         uint128 fulfillment
     ) public auth {
-        address vault_ = vault[poolId][scId][assetId];
+        IAsyncVault vault_ = vault[poolId][scId][assetId];
 
         AsyncInvestmentState storage state = investments[vault_][user];
         require(state.pendingCancelDepositRequest == true, NoPendingRequest());
@@ -282,7 +273,7 @@ contract AsyncRequests is BaseInvestmentManager, IAsyncRequests {
 
         if (state.pendingDepositRequest == 0) delete state.pendingCancelDepositRequest;
 
-        IAsyncVault(vault_).onCancelDepositClaimable(user, assets);
+        vault_.onCancelDepositClaimable(user, assets);
     }
 
     /// @inheritdoc IInvestmentManagerGatewayHandler
@@ -290,7 +281,7 @@ contract AsyncRequests is BaseInvestmentManager, IAsyncRequests {
         public
         auth
     {
-        address vault_ = vault[poolId][scId][assetId];
+        IAsyncVault vault_ = vault[poolId][scId][assetId];
         AsyncInvestmentState storage state = investments[vault_][user];
         require(state.pendingCancelRedeemRequest == true, NoPendingRequest());
 
@@ -299,7 +290,7 @@ contract AsyncRequests is BaseInvestmentManager, IAsyncRequests {
 
         if (state.pendingRedeemRequest == 0) delete state.pendingCancelRedeemRequest;
 
-        IAsyncVault(vault_).onCancelRedeemClaimable(user, shares);
+        vault_.onCancelRedeemClaimable(user, shares);
     }
 
     /// @inheritdoc IInvestmentManagerGatewayHandler
@@ -308,7 +299,7 @@ contract AsyncRequests is BaseInvestmentManager, IAsyncRequests {
         auth
     {
         require(shares != 0, ShareTokenAmountIsZero());
-        address vault_ = vault[poolId][scId][assetId];
+        IAsyncVault vault_ = vault[poolId][scId][assetId];
 
         // If there's any unclaimed deposits, claim those first
         AsyncInvestmentState storage state = investments[vault_][user];
@@ -329,7 +320,7 @@ contract AsyncRequests is BaseInvestmentManager, IAsyncRequests {
         // from user to escrow (lock share class tokens in escrow)
         if (tokensToTransfer != 0) {
             require(
-                IShareToken(address(IAsyncVault(vault_).share())).authTransferFrom(
+                IShareToken(vault_.share()).authTransferFrom(
                     user, user, address(poolEscrowProvider.escrow(poolId)), tokensToTransfer
                 ),
                 ShareTokenTransferFailed()
@@ -338,50 +329,49 @@ contract AsyncRequests is BaseInvestmentManager, IAsyncRequests {
 
         (address asset, uint256 tokenId) = poolManager.idToAsset(assetId);
         emit TriggerRedeemRequest(poolId.raw(), scId.raw(), user, asset, tokenId, shares);
-        IAsyncVault(vault_).onRedeemRequest(user, user, shares);
+        vault_.onRedeemRequest(user, user, shares);
     }
 
     // --- Sync investment handlers ---
     /// @inheritdoc IDepositManager
-    function deposit(address vaultAddr, uint256 assets, address receiver, address controller)
+    function deposit(IBaseVault vault_, uint256 assets, address receiver, address controller)
         public
         auth
         returns (uint256 shares)
     {
-        require(assets <= _maxDeposit(vaultAddr, controller), ExceedsMaxDeposit());
+        require(assets <= _maxDeposit(vault_, controller), ExceedsMaxDeposit());
 
-        AsyncInvestmentState storage state = investments[vaultAddr][controller];
+        AsyncInvestmentState storage state = investments[vault_][controller];
 
-        uint128 sharesUp = _calculateShares(vaultAddr, assets.toUint128(), state.depositPrice, MathLib.Rounding.Up);
-        uint128 sharesDown = _calculateShares(vaultAddr, assets.toUint128(), state.depositPrice, MathLib.Rounding.Down);
-        _processDeposit(state, sharesUp, sharesDown, vaultAddr, receiver);
+        uint128 sharesUp = _calculateShares(vault_, assets.toUint128(), state.depositPrice, MathLib.Rounding.Up);
+        uint128 sharesDown = _calculateShares(vault_, assets.toUint128(), state.depositPrice, MathLib.Rounding.Down);
+        _processDeposit(state, sharesUp, sharesDown, vault_, receiver);
         shares = uint256(sharesDown);
     }
 
     /// @inheritdoc IDepositManager
-    function mint(address vaultAddr, uint256 shares, address receiver, address controller)
+    function mint(IBaseVault vault_, uint256 shares, address receiver, address controller)
         public
         auth
         returns (uint256 assets)
     {
-        AsyncInvestmentState storage state = investments[vaultAddr][controller];
+        AsyncInvestmentState storage state = investments[vault_][controller];
         uint128 shares_ = shares.toUint128();
-        _processDeposit(state, shares_, shares_, vaultAddr, receiver);
+        _processDeposit(state, shares_, shares_, vault_, receiver);
 
-        assets = uint256(_calculateAssets(vaultAddr, shares_, state.depositPrice, MathLib.Rounding.Down));
+        assets = uint256(_calculateAssets(vault_, shares_, state.depositPrice, MathLib.Rounding.Down));
     }
 
     function _processDeposit(
         AsyncInvestmentState storage state,
         uint128 sharesUp,
         uint128 sharesDown,
-        address vaultAddr,
+        IBaseVault vault_,
         address receiver
     ) internal {
         require(sharesUp <= state.maxMint, ExceedsDepositLimits());
         state.maxMint = state.maxMint > sharesUp ? state.maxMint - sharesUp : 0;
 
-        IAsyncVault vault_ = IAsyncVault(vaultAddr);
         if (sharesDown > 0) {
             require(
                 IERC20(vault_.share()).transferFrom(
@@ -394,66 +384,62 @@ contract AsyncRequests is BaseInvestmentManager, IAsyncRequests {
 
     // --- Redeem Manager ---
     /// @inheritdoc IRedeemManager
-    function redeem(address vaultAddr, uint256 shares, address receiver, address controller)
+    function redeem(IBaseVault vault_, uint256 shares, address receiver, address controller)
         public
         auth
         returns (uint256 assets)
     {
-        require(shares <= maxRedeem(vaultAddr, controller), ExceedsMaxRedeem());
+        require(shares <= maxRedeem(vault_, controller), ExceedsMaxRedeem());
 
-        AsyncInvestmentState storage state = investments[vaultAddr][controller];
+        AsyncInvestmentState storage state = investments[vault_][controller];
 
-        uint128 assetsUp = _calculateAssets(vaultAddr, shares.toUint128(), state.redeemPrice, MathLib.Rounding.Up);
-        uint128 assetsDown = _calculateAssets(vaultAddr, shares.toUint128(), state.redeemPrice, MathLib.Rounding.Down);
-        _processRedeem(state, assetsUp, assetsDown, vaultAddr, receiver, controller);
+        uint128 assetsUp = _calculateAssets(vault_, shares.toUint128(), state.redeemPrice, MathLib.Rounding.Up);
+        uint128 assetsDown = _calculateAssets(vault_, shares.toUint128(), state.redeemPrice, MathLib.Rounding.Down);
+        _processRedeem(state, assetsUp, assetsDown, vault_, receiver, controller);
         assets = uint256(assetsDown);
     }
 
     /// @inheritdoc IRedeemManager
-    function withdraw(address vaultAddr, uint256 assets, address receiver, address controller)
+    function withdraw(IBaseVault vault_, uint256 assets, address receiver, address controller)
         public
         auth
         returns (uint256 shares)
     {
-        AsyncInvestmentState storage state = investments[vaultAddr][controller];
+        AsyncInvestmentState storage state = investments[vault_][controller];
         uint128 assets_ = assets.toUint128();
-        _processRedeem(state, assets_, assets_, vaultAddr, receiver, controller);
+        _processRedeem(state, assets_, assets_, vault_, receiver, controller);
 
-        shares = uint256(_calculateShares(vaultAddr, assets_, state.redeemPrice, MathLib.Rounding.Down));
+        shares = uint256(_calculateShares(vault_, assets_, state.redeemPrice, MathLib.Rounding.Down));
     }
 
     function _processRedeem(
         AsyncInvestmentState storage state,
         uint128 assetsUp,
         uint128 assetsDown,
-        address vaultAddr,
+        IBaseVault vault_,
         address receiver,
         address controller
     ) internal {
         if (controller != receiver) {
             require(
-                _canTransfer(vaultAddr, controller, receiver, convertToShares(vaultAddr, assetsDown)),
-                TransferNotAllowed()
+                _canTransfer(vault_, controller, receiver, convertToShares(vault_, assetsDown)), TransferNotAllowed()
             );
         }
 
-        require(
-            _canTransfer(vaultAddr, receiver, address(0), convertToShares(vaultAddr, assetsDown)), TransferNotAllowed()
-        );
+        require(_canTransfer(vault_, receiver, address(0), convertToShares(vault_, assetsDown)), TransferNotAllowed());
 
         require(assetsUp <= state.maxWithdraw, ExceedsRedeemLimits());
         state.maxWithdraw = state.maxWithdraw > assetsUp ? state.maxWithdraw - assetsUp : 0;
 
         if (assetsDown > 0) {
-            _withdraw(vaultAddr, receiver, assetsDown);
+            _withdraw(vault_, receiver, assetsDown);
         }
     }
 
     /// @dev Transfer funds from escrow to receiver and update holdings
-    function _withdraw(address vaultAddr, address receiver, uint128 assets) internal {
-        VaultDetails memory vaultDetails = poolManager.vaultDetails(vaultAddr);
+    function _withdraw(IBaseVault vault_, address receiver, uint128 assets) internal {
+        VaultDetails memory vaultDetails = poolManager.vaultDetails(vault_);
 
-        IAsyncVault vault_ = IAsyncVault(vaultAddr);
         PoolId poolId = vault_.poolId();
         ShareClassId scId = vault_.scId();
 
@@ -468,25 +454,25 @@ contract AsyncRequests is BaseInvestmentManager, IAsyncRequests {
     }
 
     /// @inheritdoc IAsyncDepositManager
-    function claimCancelDepositRequest(address vaultAddr, address receiver, address controller)
+    function claimCancelDepositRequest(IBaseVault vault_, address receiver, address controller)
         public
         auth
         returns (uint256 assets)
     {
-        AsyncInvestmentState storage state = investments[vaultAddr][controller];
+        AsyncInvestmentState storage state = investments[vault_][controller];
         assets = state.claimableCancelDepositRequest;
         state.claimableCancelDepositRequest = 0;
-        uint256 shares = convertToShares(vaultAddr, assets);
+        uint256 shares = convertToShares(vault_, assets);
 
         if (controller != receiver) {
-            require(_canTransfer(vaultAddr, controller, receiver, shares), TransferNotAllowed());
+            require(_canTransfer(vault_, controller, receiver, shares), TransferNotAllowed());
         }
-        require(_canTransfer(vaultAddr, receiver, address(0), shares), TransferNotAllowed());
+        require(_canTransfer(vault_, receiver, address(0), shares), TransferNotAllowed());
 
         if (assets > 0) {
-            VaultDetails memory vaultDetails = poolManager.vaultDetails(vaultAddr);
+            VaultDetails memory vaultDetails = poolManager.vaultDetails(vault_);
 
-            address escrow = address(poolEscrowProvider.escrow(IAsyncVault(vaultAddr).poolId()));
+            address escrow = address(poolEscrowProvider.escrow(vault_.poolId()));
             if (vaultDetails.tokenId == 0) {
                 SafeTransferLib.safeTransferFrom(vaultDetails.asset, escrow, receiver, assets);
             } else {
@@ -496,15 +482,14 @@ contract AsyncRequests is BaseInvestmentManager, IAsyncRequests {
     }
 
     /// @inheritdoc IAsyncRedeemManager
-    function claimCancelRedeemRequest(address vaultAddr, address receiver, address controller)
+    function claimCancelRedeemRequest(IBaseVault vault_, address receiver, address controller)
         public
         auth
         returns (uint256 shares)
     {
-        AsyncInvestmentState storage state = investments[vaultAddr][controller];
+        AsyncInvestmentState storage state = investments[vault_][controller];
         shares = state.claimableCancelRedeemRequest;
         state.claimableCancelRedeemRequest = 0;
-        IAsyncVault vault_ = IAsyncVault(vaultAddr);
 
         if (shares > 0) {
             require(
@@ -518,118 +503,118 @@ contract AsyncRequests is BaseInvestmentManager, IAsyncRequests {
 
     // --- View functions ---
     /// @inheritdoc IDepositManager
-    function maxDeposit(address vaultAddr, address user) public view returns (uint256 assets) {
-        if (!_canTransfer(vaultAddr, ESCROW_HOOK_ID, user, 0)) {
+    function maxDeposit(IBaseVault vault_, address user) public view returns (uint256 assets) {
+        if (!_canTransfer(vault_, ESCROW_HOOK_ID, user, 0)) {
             return 0;
         }
-        assets = uint256(_maxDeposit(vaultAddr, user));
+        assets = uint256(_maxDeposit(vault_, user));
     }
 
-    function _maxDeposit(address vaultAddr, address user) internal view returns (uint128 assets) {
-        AsyncInvestmentState memory state = investments[vaultAddr][user];
+    function _maxDeposit(IBaseVault vault_, address user) internal view returns (uint128 assets) {
+        AsyncInvestmentState memory state = investments[vault_][user];
 
-        assets = _calculateAssets(vaultAddr, state.maxMint, state.depositPrice, MathLib.Rounding.Down);
+        assets = _calculateAssets(vault_, state.maxMint, state.depositPrice, MathLib.Rounding.Down);
     }
 
     /// @inheritdoc IDepositManager
-    function maxMint(address vaultAddr, address user) public view returns (uint256 shares) {
-        if (!_canTransfer(vaultAddr, ESCROW_HOOK_ID, user, 0)) {
+    function maxMint(IBaseVault vault_, address user) public view returns (uint256 shares) {
+        if (!_canTransfer(vault_, ESCROW_HOOK_ID, user, 0)) {
             return 0;
         }
-        shares = uint256(investments[vaultAddr][user].maxMint);
+        shares = uint256(investments[vault_][user].maxMint);
     }
 
     /// @inheritdoc IRedeemManager
-    function maxWithdraw(address vaultAddr, address user) public view returns (uint256 assets) {
-        if (!_canTransfer(vaultAddr, user, address(0), 0)) return 0;
-        assets = uint256(investments[vaultAddr][user].maxWithdraw);
+    function maxWithdraw(IBaseVault vault_, address user) public view returns (uint256 assets) {
+        if (!_canTransfer(vault_, user, address(0), 0)) return 0;
+        assets = uint256(investments[vault_][user].maxWithdraw);
     }
 
     /// @inheritdoc IRedeemManager
-    function maxRedeem(address vaultAddr, address user) public view returns (uint256 shares) {
-        if (!_canTransfer(vaultAddr, user, address(0), 0)) return 0;
-        AsyncInvestmentState memory state = investments[vaultAddr][user];
+    function maxRedeem(IBaseVault vault_, address user) public view returns (uint256 shares) {
+        if (!_canTransfer(vault_, user, address(0), 0)) return 0;
+        AsyncInvestmentState memory state = investments[vault_][user];
 
-        shares = uint256(_calculateShares(vaultAddr, state.maxWithdraw, state.redeemPrice, MathLib.Rounding.Down));
+        shares = uint256(_calculateShares(vault_, state.maxWithdraw, state.redeemPrice, MathLib.Rounding.Down));
     }
 
     /// @inheritdoc IAsyncDepositManager
-    function pendingDepositRequest(address vaultAddr, address user) public view returns (uint256 assets) {
-        assets = uint256(investments[vaultAddr][user].pendingDepositRequest);
+    function pendingDepositRequest(IBaseVault vault_, address user) public view returns (uint256 assets) {
+        assets = uint256(investments[vault_][user].pendingDepositRequest);
     }
 
     /// @inheritdoc IAsyncRedeemManager
-    function pendingRedeemRequest(address vaultAddr, address user) public view returns (uint256 shares) {
-        shares = uint256(investments[vaultAddr][user].pendingRedeemRequest);
+    function pendingRedeemRequest(IBaseVault vault_, address user) public view returns (uint256 shares) {
+        shares = uint256(investments[vault_][user].pendingRedeemRequest);
     }
 
     /// @inheritdoc IAsyncDepositManager
-    function pendingCancelDepositRequest(address vaultAddr, address user) public view returns (bool isPending) {
-        isPending = investments[vaultAddr][user].pendingCancelDepositRequest;
+    function pendingCancelDepositRequest(IBaseVault vault_, address user) public view returns (bool isPending) {
+        isPending = investments[vault_][user].pendingCancelDepositRequest;
     }
 
     /// @inheritdoc IAsyncRedeemManager
-    function pendingCancelRedeemRequest(address vaultAddr, address user) public view returns (bool isPending) {
-        isPending = investments[vaultAddr][user].pendingCancelRedeemRequest;
+    function pendingCancelRedeemRequest(IBaseVault vault_, address user) public view returns (bool isPending) {
+        isPending = investments[vault_][user].pendingCancelRedeemRequest;
     }
 
     /// @inheritdoc IAsyncDepositManager
-    function claimableCancelDepositRequest(address vaultAddr, address user) public view returns (uint256 assets) {
-        assets = investments[vaultAddr][user].claimableCancelDepositRequest;
+    function claimableCancelDepositRequest(IBaseVault vault_, address user) public view returns (uint256 assets) {
+        assets = investments[vault_][user].claimableCancelDepositRequest;
     }
 
     /// @inheritdoc IAsyncRedeemManager
-    function claimableCancelRedeemRequest(address vaultAddr, address user) public view returns (uint256 shares) {
-        shares = investments[vaultAddr][user].claimableCancelRedeemRequest;
+    function claimableCancelRedeemRequest(IBaseVault vault_, address user) public view returns (uint256 shares) {
+        shares = investments[vault_][user].claimableCancelRedeemRequest;
     }
 
     /// @inheritdoc IVaultManager
-    function vaultByAssetId(PoolId poolId, ShareClassId scId, AssetId assetId) public view returns (address) {
+    function vaultByAssetId(PoolId poolId, ShareClassId scId, AssetId assetId) public view returns (IBaseVault) {
         return vault[poolId][scId][assetId];
     }
 
     /// @inheritdoc IVaultManager
-    function vaultKind(address) public pure returns (VaultKind, address) {
+    function vaultKind(IBaseVault) public pure returns (VaultKind, address) {
         return (VaultKind.Async, address(0));
     }
 
     // --- Helpers ---
     /// @dev    Checks transfer restrictions for the vault shares. Sender (from) and receiver (to) have to both pass
     ///         the restrictions for a successful share transfer.
-    function _canTransfer(address vaultAddr, address from, address to, uint256 value) internal view returns (bool) {
-        IShareToken share = IShareToken(IAsyncVault(vaultAddr).share());
+    function _canTransfer(IBaseVault vault_, address from, address to, uint256 value) internal view returns (bool) {
+        IShareToken share = IShareToken(vault_.share());
         return share.checkTransferRestriction(from, to, value);
     }
 
-    function _calculateShares(address vaultAddr, uint128 assets, uint256 price, MathLib.Rounding rounding)
+    function _calculateShares(IBaseVault vault_, uint128 assets, uint256 price, MathLib.Rounding rounding)
         internal
         view
         returns (uint128 shares)
     {
-        VaultDetails memory vaultDetails = poolManager.vaultDetails(vaultAddr);
-        address shareToken = IAsyncVault(vaultAddr).share();
+        VaultDetails memory vaultDetails = poolManager.vaultDetails(vault_);
+        address shareToken = vault_.share();
 
         return VaultPricingLib.calculateShares(
             shareToken, vaultDetails.asset, vaultDetails.tokenId, assets, price, rounding
         );
     }
 
-    function _calculateAssets(address vaultAddr, uint128 shares, uint256 price, MathLib.Rounding rounding)
+    function _calculateAssets(IBaseVault vault_, uint128 shares, uint256 price, MathLib.Rounding rounding)
         internal
         view
         returns (uint128 assets)
     {
-        VaultDetails memory vaultDetails = poolManager.vaultDetails(vaultAddr);
-        address shareToken = IAsyncVault(vaultAddr).share();
+        VaultDetails memory vaultDetails = poolManager.vaultDetails(vault_);
+        address shareToken = vault_.share();
 
         return VaultPricingLib.calculateAssets(
             shareToken, shares, vaultDetails.asset, vaultDetails.tokenId, price, rounding
         );
     }
 
-    function _calculatePrice(address vaultAddr, uint128 shares, uint128 assets) internal view returns (uint256 price) {
-        VaultDetails memory vaultDetails = poolManager.vaultDetails(vaultAddr);
-        address shareToken = IAsyncVault(vaultAddr).share();
+    function _calculatePrice(IBaseVault vault_, uint128 shares, uint128 assets) internal view returns (uint256 price) {
+        VaultDetails memory vaultDetails = poolManager.vaultDetails(vault_);
+        address shareToken = vault_.share();
 
         return VaultPricingLib.calculatePrice(shareToken, shares, vaultDetails.asset, vaultDetails.tokenId, assets);
     }

--- a/src/vaults/AsyncVault.sol
+++ b/src/vaults/AsyncVault.sol
@@ -53,9 +53,7 @@ contract AsyncVault is AsyncRedeemVault, IAsyncVault {
             InsufficientBalance()
         );
 
-        require(
-            asyncManager().requestDeposit(address(this), assets, controller, owner, msg.sender), RequestDepositFailed()
-        );
+        require(asyncManager().requestDeposit(this, assets, controller, owner, msg.sender), RequestDepositFailed());
 
         if (tokenId == 0) {
             SafeTransferLib.safeTransferFrom(asset, owner, address(_poolEscrowProvider.escrow(poolId)), assets);
@@ -69,7 +67,7 @@ contract AsyncVault is AsyncRedeemVault, IAsyncVault {
 
     /// @inheritdoc IERC7540Deposit
     function pendingDepositRequest(uint256, address controller) public view returns (uint256 pendingAssets) {
-        pendingAssets = asyncManager().pendingDepositRequest(address(this), controller);
+        pendingAssets = asyncManager().pendingDepositRequest(this, controller);
     }
 
     /// @inheritdoc IERC7540Deposit
@@ -81,18 +79,18 @@ contract AsyncVault is AsyncRedeemVault, IAsyncVault {
     /// @inheritdoc IERC7540CancelDeposit
     function cancelDepositRequest(uint256, address controller) external {
         _validateController(controller);
-        asyncManager().cancelDepositRequest(address(this), controller, msg.sender);
+        asyncManager().cancelDepositRequest(this, controller, msg.sender);
         emit CancelDepositRequest(controller, REQUEST_ID, msg.sender);
     }
 
     /// @inheritdoc IERC7540CancelDeposit
     function pendingCancelDepositRequest(uint256, address controller) public view returns (bool isPending) {
-        isPending = asyncManager().pendingCancelDepositRequest(address(this), controller);
+        isPending = asyncManager().pendingCancelDepositRequest(this, controller);
     }
 
     /// @inheritdoc IERC7540CancelDeposit
     function claimableCancelDepositRequest(uint256, address controller) public view returns (uint256 claimableAssets) {
-        claimableAssets = asyncManager().claimableCancelDepositRequest(address(this), controller);
+        claimableAssets = asyncManager().claimableCancelDepositRequest(this, controller);
     }
 
     /// @inheritdoc IERC7540CancelDeposit
@@ -101,7 +99,7 @@ contract AsyncVault is AsyncRedeemVault, IAsyncVault {
         returns (uint256 assets)
     {
         _validateController(controller);
-        assets = asyncManager().claimCancelDepositRequest(address(this), receiver, controller);
+        assets = asyncManager().claimCancelDepositRequest(this, receiver, controller);
         emit CancelDepositClaim(controller, receiver, REQUEST_ID, msg.sender, assets);
     }
 
@@ -115,13 +113,13 @@ contract AsyncVault is AsyncRedeemVault, IAsyncVault {
     // --- ERC-4626 methods ---
     /// @inheritdoc IERC7575
     function maxDeposit(address controller) public view returns (uint256 maxAssets) {
-        maxAssets = asyncManager().maxDeposit(address(this), controller);
+        maxAssets = asyncManager().maxDeposit(this, controller);
     }
 
     /// @inheritdoc IERC7540Deposit
     function deposit(uint256 assets, address receiver, address controller) public returns (uint256 shares) {
         _validateController(controller);
-        shares = asyncManager().deposit(address(this), assets, receiver, controller);
+        shares = asyncManager().deposit(this, assets, receiver, controller);
         emit Deposit(controller, receiver, assets, shares);
     }
 
@@ -134,13 +132,13 @@ contract AsyncVault is AsyncRedeemVault, IAsyncVault {
 
     /// @inheritdoc IERC7575
     function maxMint(address controller) public view returns (uint256 maxShares) {
-        maxShares = asyncManager().maxMint(address(this), controller);
+        maxShares = asyncManager().maxMint(this, controller);
     }
 
     /// @inheritdoc IERC7540Deposit
     function mint(uint256 shares, address receiver, address controller) public returns (uint256 assets) {
         _validateController(controller);
-        assets = asyncManager().mint(address(this), shares, receiver, controller);
+        assets = asyncManager().mint(this, shares, receiver, controller);
         emit Deposit(controller, receiver, assets, shares);
     }
 
@@ -151,7 +149,7 @@ contract AsyncVault is AsyncRedeemVault, IAsyncVault {
 
     /// @dev Strongly-typed accessor to the generic async redeem manager
     function asyncManager() public view returns (IAsyncRequests) {
-        return IAsyncRequests(address(IAsyncRedeemVault(address(this)).asyncRedeemManager()));
+        return IAsyncRequests(address(IAsyncRedeemVault(this).asyncRedeemManager()));
     }
 
     /// @dev Preview functions for ERC-7540 vaults revert

--- a/src/vaults/BaseInvestmentManager.sol
+++ b/src/vaults/BaseInvestmentManager.sol
@@ -41,9 +41,8 @@ abstract contract BaseInvestmentManager is Auth, Recoverable, IBaseInvestmentMan
 
     // --- View functions ---
     /// @inheritdoc IBaseInvestmentManager
-    function convertToShares(address vaultAddr, uint256 assets) public view virtual returns (uint256 shares) {
-        IBaseVault vault_ = IBaseVault(vaultAddr);
-        VaultDetails memory vaultDetails = poolManager.vaultDetails(address(vault_));
+    function convertToShares(IBaseVault vault_, uint256 assets) public view virtual returns (uint256 shares) {
+        VaultDetails memory vaultDetails = poolManager.vaultDetails(vault_);
         (D18 priceAssetPerShare,) =
             poolManager.priceAssetPerShare(vault_.poolId(), vault_.scId(), vaultDetails.assetId, false);
 
@@ -51,9 +50,8 @@ abstract contract BaseInvestmentManager is Auth, Recoverable, IBaseInvestmentMan
     }
 
     /// @inheritdoc IBaseInvestmentManager
-    function convertToAssets(address vaultAddr, uint256 shares) public view virtual returns (uint256 assets) {
-        IBaseVault vault_ = IBaseVault(vaultAddr);
-        VaultDetails memory vaultDetails = poolManager.vaultDetails(address(vault_));
+    function convertToAssets(IBaseVault vault_, uint256 shares) public view virtual returns (uint256 assets) {
+        VaultDetails memory vaultDetails = poolManager.vaultDetails(vault_);
         (D18 priceAssetPerShare,) =
             poolManager.priceAssetPerShare(vault_.poolId(), vault_.scId(), vaultDetails.assetId, false);
 
@@ -61,9 +59,8 @@ abstract contract BaseInvestmentManager is Auth, Recoverable, IBaseInvestmentMan
     }
 
     /// @inheritdoc IBaseInvestmentManager
-    function priceLastUpdated(address vaultAddr) public view virtual returns (uint64 lastUpdated) {
-        IBaseVault vault_ = IBaseVault(vaultAddr);
-        VaultDetails memory vaultDetails = poolManager.vaultDetails(address(vault_));
+    function priceLastUpdated(IBaseVault vault_) public view virtual returns (uint64 lastUpdated) {
+        VaultDetails memory vaultDetails = poolManager.vaultDetails(vault_);
 
         (, lastUpdated) = poolManager.priceAssetPerShare(vault_.poolId(), vault_.scId(), vaultDetails.assetId, false);
     }

--- a/src/vaults/VaultRouter.sol
+++ b/src/vaults/VaultRouter.sol
@@ -20,6 +20,7 @@ import {IVaultRouter} from "src/vaults/interfaces/IVaultRouter.sol";
 import {IPoolManager, VaultDetails} from "src/vaults/interfaces/IPoolManager.sol";
 import {IEscrow} from "src/vaults/interfaces/IEscrow.sol";
 import {IShareToken} from "src/vaults/interfaces/token/IShareToken.sol";
+import {IBaseVault} from "src/vaults/interfaces/IBaseVaults.sol";
 
 /// @title  VaultRouter
 /// @notice This is a helper contract, designed to be the entrypoint for EOAs.
@@ -41,7 +42,7 @@ contract VaultRouter is Auth, Multicall, Recoverable, IVaultRouter {
     IMessageDispatcher public immutable messageDispatcher;
 
     /// @inheritdoc IVaultRouter
-    mapping(address controller => mapping(address vault => uint256 amount)) public lockedRequests;
+    mapping(address controller => mapping(IBaseVault vault => uint256 amount)) public lockedRequests;
 
     constructor(
         address escrow_,
@@ -74,17 +75,17 @@ contract VaultRouter is Auth, Multicall, Recoverable, IVaultRouter {
     }
 
     // --- Enable interactions with the vault ---
-    function enable(address vault) public payable protected {
-        IAsyncVault(vault).setEndorsedOperator(msg.sender, true);
+    function enable(IBaseVault vault) public payable protected {
+        vault.setEndorsedOperator(msg.sender, true);
     }
 
-    function disable(address vault) external payable protected {
-        IAsyncVault(vault).setEndorsedOperator(msg.sender, false);
+    function disable(IBaseVault vault) external payable protected {
+        vault.setEndorsedOperator(msg.sender, false);
     }
 
     // --- Deposit ---
     /// @inheritdoc IVaultRouter
-    function requestDeposit(address vault, uint256 amount, address controller, address owner)
+    function requestDeposit(IAsyncVault vault, uint256 amount, address controller, address owner)
         external
         payable
         protected
@@ -93,15 +94,15 @@ contract VaultRouter is Auth, Multicall, Recoverable, IVaultRouter {
 
         VaultDetails memory vaultDetails = poolManager.vaultDetails(vault);
         if (owner == address(this)) {
-            _approveMax(vaultDetails.asset, vaultDetails.tokenId, vault);
+            _approveMax(vaultDetails.asset, vaultDetails.tokenId, address(vault));
         }
 
         _pay();
-        IAsyncVault(vault).requestDeposit(amount, controller, owner);
+        vault.requestDeposit(amount, controller, owner);
     }
 
     /// @inheritdoc IVaultRouter
-    function lockDepositRequest(address vault, uint256 amount, address controller, address owner)
+    function lockDepositRequest(IBaseVault vault, uint256 amount, address controller, address owner)
         public
         payable
         protected
@@ -122,7 +123,7 @@ contract VaultRouter is Auth, Multicall, Recoverable, IVaultRouter {
     }
 
     /// @inheritdoc IVaultRouter
-    function enableLockDepositRequest(address vault, uint256 amount) external payable protected {
+    function enableLockDepositRequest(IBaseVault vault, uint256 amount) external payable protected {
         enable(vault);
 
         VaultDetails memory vaultDetails = poolManager.vaultDetails(vault);
@@ -140,7 +141,7 @@ contract VaultRouter is Auth, Multicall, Recoverable, IVaultRouter {
     }
 
     /// @inheritdoc IVaultRouter
-    function unlockDepositRequest(address vault, address receiver) external payable protected {
+    function unlockDepositRequest(IBaseVault vault, address receiver) external payable protected {
         uint256 lockedRequest = lockedRequests[msg.sender][vault];
         require(lockedRequest != 0, NoLockedBalance());
         lockedRequests[msg.sender][vault] = 0;
@@ -158,7 +159,7 @@ contract VaultRouter is Auth, Multicall, Recoverable, IVaultRouter {
     }
 
     /// @inheritdoc IVaultRouter
-    function executeLockedDepositRequest(address vault, address controller) external payable protected {
+    function executeLockedDepositRequest(IAsyncVault vault, address controller) external payable protected {
         uint256 lockedRequest = lockedRequests[controller][vault];
         require(lockedRequest != 0, NoLockedRequest());
         lockedRequests[controller][vault] = 0;
@@ -175,71 +176,75 @@ contract VaultRouter is Auth, Multicall, Recoverable, IVaultRouter {
         }
 
         _pay();
-        _approveMax(vaultDetails.asset, vaultDetails.tokenId, vault);
-        IAsyncVault(vault).requestDeposit(lockedRequest, controller, address(this));
+        _approveMax(vaultDetails.asset, vaultDetails.tokenId, address(vault));
+        vault.requestDeposit(lockedRequest, controller, address(this));
         emit ExecuteLockedDepositRequest(vault, controller, msg.sender);
     }
 
     /// @inheritdoc IVaultRouter
-    function claimDeposit(address vault, address receiver, address controller) external payable protected {
+    function claimDeposit(IAsyncVault vault, address receiver, address controller) external payable protected {
         _canClaim(vault, receiver, controller);
-        uint256 maxMint = IAsyncVault(vault).maxMint(controller);
-        IAsyncVault(vault).mint(maxMint, receiver, controller);
+        uint256 maxMint = vault.maxMint(controller);
+        vault.mint(maxMint, receiver, controller);
     }
 
     /// @inheritdoc IVaultRouter
-    function cancelDepositRequest(address vault) external payable protected {
+    function cancelDepositRequest(IAsyncVault vault) external payable protected {
         _pay();
-        IAsyncVault(vault).cancelDepositRequest(REQUEST_ID, msg.sender);
+        vault.cancelDepositRequest(REQUEST_ID, msg.sender);
     }
 
     /// @inheritdoc IVaultRouter
-    function claimCancelDepositRequest(address vault, address receiver, address controller)
+    function claimCancelDepositRequest(IAsyncVault vault, address receiver, address controller)
         external
         payable
         protected
     {
         _canClaim(vault, receiver, controller);
-        IAsyncVault(vault).claimCancelDepositRequest(REQUEST_ID, receiver, controller);
+        vault.claimCancelDepositRequest(REQUEST_ID, receiver, controller);
     }
 
     // --- Redeem ---
     /// @inheritdoc IVaultRouter
-    function requestRedeem(address vault, uint256 amount, address controller, address owner)
+    function requestRedeem(IAsyncVault vault, uint256 amount, address controller, address owner)
         external
         payable
         protected
     {
         require(owner == msg.sender || owner == address(this), InvalidOwner());
         _pay();
-        IAsyncVault(vault).requestRedeem(amount, controller, owner);
+        vault.requestRedeem(amount, controller, owner);
     }
 
     /// @inheritdoc IVaultRouter
-    function claimRedeem(address vault, address receiver, address controller) external payable protected {
+    function claimRedeem(IBaseVault vault, address receiver, address controller) external payable protected {
         _canClaim(vault, receiver, controller);
-        uint256 maxWithdraw = IAsyncVault(vault).maxWithdraw(controller);
+        uint256 maxWithdraw = vault.maxWithdraw(controller);
 
         VaultDetails memory vaultDetails = poolManager.vaultDetails(vault);
         if (vaultDetails.isWrapper && controller != msg.sender) {
             // Auto-unwrap if permissionlessly claiming for another controller
-            IAsyncVault(vault).withdraw(maxWithdraw, address(this), controller);
+            vault.withdraw(maxWithdraw, address(this), controller);
             unwrap(vaultDetails.asset, maxWithdraw, receiver);
         } else {
-            IAsyncVault(vault).withdraw(maxWithdraw, receiver, controller);
+            vault.withdraw(maxWithdraw, receiver, controller);
         }
     }
 
     /// @inheritdoc IVaultRouter
-    function cancelRedeemRequest(address vault) external payable protected {
+    function cancelRedeemRequest(IAsyncVault vault) external payable protected {
         _pay();
-        IAsyncVault(vault).cancelRedeemRequest(REQUEST_ID, msg.sender);
+        vault.cancelRedeemRequest(REQUEST_ID, msg.sender);
     }
 
     /// @inheritdoc IVaultRouter
-    function claimCancelRedeemRequest(address vault, address receiver, address controller) external payable protected {
+    function claimCancelRedeemRequest(IAsyncVault vault, address receiver, address controller)
+        external
+        payable
+        protected
+    {
         _canClaim(vault, receiver, controller);
-        IAsyncVault(vault).claimCancelRedeemRequest(REQUEST_ID, receiver, controller);
+        vault.claimCancelRedeemRequest(REQUEST_ID, receiver, controller);
     }
 
     // --- ERC20 permits ---
@@ -284,13 +289,13 @@ contract VaultRouter is Auth, Multicall, Recoverable, IVaultRouter {
     }
 
     /// @inheritdoc IVaultRouter
-    function hasPermissions(address vault, address controller) external view returns (bool) {
-        return IAsyncVault(vault).isPermissioned(controller);
+    function hasPermissions(IBaseVault vault, address controller) external view returns (bool) {
+        return vault.isPermissioned(controller);
     }
 
     /// @inheritdoc IVaultRouter
-    function isEnabled(address vault, address controller) public view returns (bool) {
-        return IAsyncVault(vault).isOperator(controller, address(this));
+    function isEnabled(IBaseVault vault, address controller) public view returns (bool) {
+        return vault.isOperator(controller, address(this));
     }
 
     /// @notice Gives the max approval to `to` for spending the given `asset` if not already approved.
@@ -312,7 +317,7 @@ contract VaultRouter is Auth, Multicall, Recoverable, IVaultRouter {
 
     /// @notice Ensures msg.sender is either the controller, or can permissionlessly claim
     ///         on behalf of the controller.
-    function _canClaim(address vault, address receiver, address controller) internal view {
+    function _canClaim(IBaseVault vault, address receiver, address controller) internal view {
         require(controller == msg.sender || (controller == receiver && isEnabled(vault, controller)), InvalidSender());
     }
 }

--- a/src/vaults/factories/AsyncVaultFactory.sol
+++ b/src/vaults/factories/AsyncVaultFactory.sol
@@ -11,6 +11,7 @@ import {IVaultFactory} from "src/vaults/interfaces/factories/IVaultFactory.sol";
 import {IPoolEscrowProvider} from "src/vaults/interfaces/factories/IPoolEscrowFactory.sol";
 import {IShareToken} from "src/vaults/interfaces/token/IShareToken.sol";
 import {IAsyncRedeemManager} from "src/vaults/interfaces/investments/IAsyncRedeemManager.sol";
+import {IBaseVault} from "src/vaults/interfaces/IBaseVaults.sol";
 
 /// @title  ERC7540 Vault Factory
 /// @dev    Utility for deploying new vault contracts
@@ -38,7 +39,7 @@ contract AsyncVaultFactory is Auth, IVaultFactory {
         uint256 tokenId,
         IShareToken token,
         address[] calldata wards_
-    ) public auth returns (address) {
+    ) public auth returns (IBaseVault) {
         AsyncVault vault =
             new AsyncVault(poolId, scId, asset, tokenId, token, root, asyncRedeemManager, poolEscrowProvider);
 
@@ -50,6 +51,6 @@ contract AsyncVaultFactory is Auth, IVaultFactory {
         }
 
         vault.deny(address(this));
-        return address(vault);
+        return vault;
     }
 }

--- a/src/vaults/factories/SyncDepositVaultFactory.sol
+++ b/src/vaults/factories/SyncDepositVaultFactory.sol
@@ -12,6 +12,7 @@ import {IAsyncRedeemManager} from "src/vaults/interfaces/investments/IAsyncRedee
 import {ISyncDepositManager} from "src/vaults/interfaces/investments/ISyncDepositManager.sol";
 import {IPoolEscrowProvider} from "src/vaults/interfaces/factories/IPoolEscrowFactory.sol";
 import {IShareToken} from "src/vaults/interfaces/token/IShareToken.sol";
+import {IBaseVault} from "src/vaults/interfaces/IBaseVaults.sol";
 
 /// @title  Sync Vault Factory
 /// @dev    Utility for deploying new vault contracts
@@ -42,7 +43,7 @@ contract SyncDepositVaultFactory is Auth, IVaultFactory {
         uint256 tokenId,
         IShareToken token,
         address[] calldata wards_
-    ) public auth returns (address) {
+    ) public auth returns (IBaseVault) {
         SyncDepositVault vault = new SyncDepositVault(
             poolId, scId, asset, tokenId, token, root, syncDepositManager, asyncRedeemManager, poolEscrowProvider
         );
@@ -57,6 +58,6 @@ contract SyncDepositVaultFactory is Auth, IVaultFactory {
         }
 
         vault.deny(address(this));
-        return address(vault);
+        return vault;
     }
 }

--- a/src/vaults/interfaces/IPoolManager.sol
+++ b/src/vaults/interfaces/IPoolManager.sol
@@ -8,6 +8,7 @@ import {AssetId} from "src/common/types/AssetId.sol";
 
 import {IShareToken} from "src/vaults/interfaces/token/IShareToken.sol";
 import {IVaultFactory} from "src/vaults/interfaces/factories/IVaultFactory.sol";
+import {IBaseVault} from "src/vaults/interfaces/IBaseVaults.sol";
 
 /// @dev Centrifuge pools
 struct Pool {
@@ -23,7 +24,7 @@ struct ShareClassDetails {
     /// @dev Each share class can have multiple vaults deployed,
     ///      multiple vaults can be linked to the same asset.
     ///      A vault in this storage DOES NOT mean the vault can be used
-    mapping(address asset => mapping(uint256 tokenId => address[])) vaults;
+    mapping(address asset => mapping(uint256 tokenId => IBaseVault[])) vaults;
     /// @dev For each share class, we store the price per pool unit in asset denomination (POOL_UNIT/ASSET_UNIT)
     mapping(address asset => mapping(uint256 tokenId => Price)) pricePoolPerAsset;
 }
@@ -91,7 +92,7 @@ interface IPoolManager {
         address indexed asset,
         uint256 tokenId,
         IVaultFactory factory,
-        address vault
+        IBaseVault vault
     );
     event PriceUpdate(
         PoolId indexed poolId,
@@ -112,10 +113,10 @@ interface IPoolManager {
     );
     event UpdateContract(PoolId indexed poolId, ShareClassId indexed scId, address target, bytes payload);
     event LinkVault(
-        PoolId indexed poolId, ShareClassId indexed scId, address indexed asset, uint256 tokenId, address vault
+        PoolId indexed poolId, ShareClassId indexed scId, address indexed asset, uint256 tokenId, IBaseVault vault
     );
     event UnlinkVault(
-        PoolId indexed poolId, ShareClassId indexed scId, address indexed asset, uint256 tokenId, address vault
+        PoolId indexed poolId, ShareClassId indexed scId, address indexed asset, uint256 tokenId, IBaseVault vault
     );
     event UpdateMaxSharePriceAge(PoolId indexed poolId, ShareClassId indexed scId, uint64 maxPriceAge);
     event UpdateMaxAssetPriceAge(
@@ -202,7 +203,7 @@ interface IPoolManager {
     /// @return address The address of the deployed vault
     function deployVault(PoolId poolId, ShareClassId scId, AssetId assetId, IVaultFactory factory)
         external
-        returns (address);
+        returns (IBaseVault);
 
     /// @notice Links a deployed vault to the given pool, share class and asset.
     ///
@@ -210,7 +211,7 @@ interface IPoolManager {
     /// @param scId The share class id
     /// @param assetId The asset id for which we want to deploy a vault
     /// @param vault The address of the deployed vault
-    function linkVault(PoolId poolId, ShareClassId scId, AssetId assetId, address vault) external;
+    function linkVault(PoolId poolId, ShareClassId scId, AssetId assetId, IBaseVault vault) external;
 
     /// @notice Removes the link between a vault and the given pool, share class and asset.
     ///
@@ -218,7 +219,7 @@ interface IPoolManager {
     /// @param scId The share class id
     /// @param assetId The asset id for which we want to deploy a vault
     /// @param vault The address of the deployed vault
-    function unlinkVault(PoolId poolId, ShareClassId scId, AssetId assetId, address vault) external;
+    function unlinkVault(PoolId poolId, ShareClassId scId, AssetId assetId, IBaseVault vault) external;
 
     /// @notice Returns whether the given pool id is active
     function isPoolActive(PoolId poolId) external view returns (bool);
@@ -236,7 +237,7 @@ interface IPoolManager {
     ///
     /// @param vault The address of the vault to be checked for
     /// @return details The details of the vault including the underlying asset address, token id, asset id
-    function vaultDetails(address vault) external view returns (VaultDetails memory details);
+    function vaultDetails(IBaseVault vault) external view returns (VaultDetails memory details);
 
     /// @notice Checks whether a given asset-vault pair is eligible for investing into a share class of a pool
     ///
@@ -245,7 +246,7 @@ interface IPoolManager {
     /// @param asset The address of the asset
     /// @param vault The address of the vault
     /// @return bool Whether vault is to a share class
-    function isLinked(PoolId poolId, ShareClassId scId, address asset, address vault) external view returns (bool);
+    function isLinked(PoolId poolId, ShareClassId scId, address asset, IBaseVault vault) external view returns (bool);
 
     /// @notice Returns the price per share for a given pool, share class, asset, and asset id. The provided price is
     /// defined as ASSET_UNIT/SHARE_UNIT.

--- a/src/vaults/interfaces/IVaultManager.sol
+++ b/src/vaults/interfaces/IVaultManager.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.5.0;
 import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
+import {IBaseVault} from "src/vaults/interfaces/IBaseVaults.sol";
 
 enum VaultKind {
     /// @dev Refers to AsyncVault
@@ -19,23 +20,23 @@ enum VaultKind {
 /// @dev Must be implemented by all vault managers
 interface IVaultManager {
     /// @notice Adds new vault for `poolId`, `scId` and `asset`.
-    function addVault(PoolId poolId, ShareClassId scId, address vault, address asset, AssetId assetId) external;
+    function addVault(PoolId poolId, ShareClassId scId, IBaseVault vault, address asset, AssetId assetId) external;
 
     /// @notice Removes `vault` from `who`'s authorized callers
-    function removeVault(PoolId poolId, ShareClassId scId, address vault, address asset, AssetId assetId) external;
+    function removeVault(PoolId poolId, ShareClassId scId, IBaseVault vault, address asset, AssetId assetId) external;
 
     /// @notice Returns the address of the vault for a given pool, share class and asset
     function vaultByAssetId(PoolId poolId, ShareClassId scId, AssetId assetId)
         external
         view
-        returns (address vaultAddr);
+        returns (IBaseVault vault);
 
     /// @notice Checks whether the vault is partially (a)synchronous and if so returns the address of the secondary
     /// manager.
     ///
-    /// @param vaultAddr The address of vault that is checked
+    /// @param vault The address of vault that is checked
     /// @return vaultKind_ The kind of the vault
     /// @return secondaryManager The address of the secondary manager if the vault is partially (a)synchronous, else
     /// points to zero address
-    function vaultKind(address vaultAddr) external view returns (VaultKind vaultKind_, address secondaryManager);
+    function vaultKind(IBaseVault vault) external view returns (VaultKind vaultKind_, address secondaryManager);
 }

--- a/src/vaults/interfaces/IVaultRouter.sol
+++ b/src/vaults/interfaces/IVaultRouter.sol
@@ -5,14 +5,15 @@ import {IMulticall} from "src/misc/interfaces/IMulticall.sol";
 
 import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {IBaseVault, IAsyncVault} from "src/vaults/interfaces/IBaseVaults.sol";
 
 interface IVaultRouter is IMulticall {
     // --- Events ---
     event LockDepositRequest(
-        address indexed vault, address indexed controller, address indexed owner, address sender, uint256 amount
+        IBaseVault indexed vault, address indexed controller, address indexed owner, address sender, uint256 amount
     );
-    event UnlockDepositRequest(address indexed vault, address indexed controller, address indexed receiver);
-    event ExecuteLockedDepositRequest(address indexed vault, address indexed controller, address sender);
+    event UnlockDepositRequest(IBaseVault indexed vault, address indexed controller, address indexed receiver);
+    event ExecuteLockedDepositRequest(IBaseVault indexed vault, address indexed controller, address sender);
 
     error InvalidOwner();
     error NoLockedBalance();
@@ -24,17 +25,17 @@ interface IVaultRouter is IMulticall {
 
     /// @notice Check how much of the `vault`'s asset is locked for the current `controller`.
     /// @dev    This is a getter method
-    function lockedRequests(address controller, address vault) external view returns (uint256 amount);
+    function lockedRequests(address controller, IBaseVault vault) external view returns (uint256 amount);
 
     // --- Manage permissionless claiming ---
     /// @notice Enable permissionless claiming
     /// @dev    After this is called, anyone can claim tokens to msg.sender.
     ///         Even any requests submitted directly to the vault (not through the VaultRouter) will be
     ///         permissionlessly claimable through the VaultRouter, until `disable()` is called.
-    function enable(address vault) external payable;
+    function enable(IBaseVault vault) external payable;
 
     /// @notice Disable permissionless claiming
-    function disable(address vault) external payable;
+    function disable(IBaseVault vault) external payable;
 
     // --- Deposit ---
     /// @notice Check `IERC7540Deposit.requestDeposit`.
@@ -45,7 +46,7 @@ interface IVaultRouter is IMulticall {
     /// @param  amount Check @param IERC7540Deposit.requestDeposit.assets
     /// @param  controller Check @param IERC7540Deposit.requestDeposit.controller
     /// @param  owner Check @param IERC7540Deposit.requestDeposit.owner
-    function requestDeposit(address vault, uint256 amount, address controller, address owner) external payable;
+    function requestDeposit(IAsyncVault vault, uint256 amount, address controller, address owner) external payable;
 
     /// @notice Locks `amount` of `vault`'s asset in an escrow before actually sending a deposit LockDepositRequest
     ///         There are users that would like to interact with the protocol but don't have permissions yet. They can
@@ -76,7 +77,7 @@ interface IVaultRouter is IMulticall {
     /// @param  amount Amount to invest
     /// @param  controller Address of the owner of the position
     /// @param  owner Where the  funds to be deposited will be take from
-    function lockDepositRequest(address vault, uint256 amount, address controller, address owner) external payable;
+    function lockDepositRequest(IBaseVault vault, uint256 amount, address controller, address owner) external payable;
 
     /// @notice Helper method to lock a deposit request, and enable permissionless claiming of that vault in 1 call.
     /// @dev    It starts interaction with the vault by calling `open`.
@@ -86,25 +87,25 @@ interface IVaultRouter is IMulticall {
     ///         else  amount is treat as an underlying asset one and it is wrapped.
     /// @param  vault Address of the vault
     /// @param  amount Amount to be deposited
-    function enableLockDepositRequest(address vault, uint256 amount) external payable;
+    function enableLockDepositRequest(IBaseVault vault, uint256 amount) external payable;
 
     /// @notice Unlocks all deposited assets of the current caller for a given vault
     ///
     /// @param  vault Address of the vault for which funds were locked
     /// @param  receiver Address of the received of the unlocked funds
-    function unlockDepositRequest(address vault, address receiver) external payable;
+    function unlockDepositRequest(IBaseVault vault, address receiver) external payable;
 
     /// @notice After the controller is given permissions, anyone can call this method and
     ///         actually request a deposit with the locked funds on the behalf of the `controller`
     /// @param  vault The vault for which funds are locked
     /// @param  controller Owner of the deposit position
-    function executeLockedDepositRequest(address vault, address controller) external payable;
+    function executeLockedDepositRequest(IAsyncVault vault, address controller) external payable;
 
     /// @notice Check IERC7540Deposit.mint
     /// @param  vault Address of the vault
     /// @param  receiver Check IERC7540Deposit.mint.receiver
     /// @param  controller Check IERC7540Deposit.mint.owner
-    function claimDeposit(address vault, address receiver, address controller) external payable;
+    function claimDeposit(IAsyncVault vault, address receiver, address controller) external payable;
 
     // --- Redeem ---
     /// @notice Check `IERC7540CancelDeposit.cancelDepositRequest`.
@@ -112,14 +113,14 @@ interface IVaultRouter is IMulticall {
     ///         The caller must call `VaultRouter.estimate` to get estimates how much the deposit will cost.
     ///
     /// @param  vault The vault where the deposit was initiated
-    function cancelDepositRequest(address vault) external payable;
+    function cancelDepositRequest(IAsyncVault vault) external payable;
 
     /// @notice Check IERC7540CancelDeposit.claimCancelDepositRequest
     ///
     /// @param  vault Address of the vault
     /// @param  receiver Check  IERC7540CancelDeposit.claimCancelDepositRequest.receiver
     /// @param  controller Check  IERC7540CancelDeposit.claimCancelDepositRequest.controller
-    function claimCancelDepositRequest(address vault, address receiver, address controller) external payable;
+    function claimCancelDepositRequest(IAsyncVault vault, address receiver, address controller) external payable;
 
     // --- Redeem ---
     /// @notice Check `IERC7540Redeem.requestRedeem`.
@@ -130,7 +131,7 @@ interface IVaultRouter is IMulticall {
     /// @param  amount Check @param IERC7540Redeem.requestRedeem.shares
     /// @param  controller Check @param IERC7540Redeem.requestRedeem.controller
     /// @param  owner Check @param IERC7540Redeem.requestRedeem.owner
-    function requestRedeem(address vault, uint256 amount, address controller, address owner) external payable;
+    function requestRedeem(IAsyncVault vault, uint256 amount, address controller, address owner) external payable;
 
     /// @notice Check IERC7575.withdraw
     /// @dev    If the underlying vault asset is a wrapped one,
@@ -139,21 +140,21 @@ interface IVaultRouter is IMulticall {
     /// @param  vault Address of the vault
     /// @param  receiver Check IERC7575.withdraw.receiver
     /// @param  controller Check IERC7575.withdraw.owner
-    function claimRedeem(address vault, address receiver, address controller) external payable;
+    function claimRedeem(IBaseVault vault, address receiver, address controller) external payable;
 
     /// @notice Check `IERC7540CancelRedeem.cancelRedeemRequest`.
     /// @dev    This adds a mandatory prepayment for all the costs that will incur during the transaction.
     ///         The caller must call `VaultRouter.estimate` to get estimates how much the deposit will cost.
     ///
     /// @param  vault The vault where the deposit was initiated
-    function cancelRedeemRequest(address vault) external payable;
+    function cancelRedeemRequest(IAsyncVault vault) external payable;
 
     /// @notice Check IERC7540CancelRedeem.claimableCancelRedeemRequest
     ///
     /// @param  vault Address of the vault
     /// @param  receiver Check  IERC7540CancelRedeem.claimCancelRedeemRequest.receiver
     /// @param  controller Check  IERC7540CancelRedeem.claimCancelRedeemRequest.controller
-    function claimCancelRedeemRequest(address vault, address receiver, address controller) external payable;
+    function claimCancelRedeemRequest(IAsyncVault vault, address receiver, address controller) external payable;
 
     // --- ERC20 permit ---
     /// @notice Check IERC20.permit
@@ -191,8 +192,8 @@ interface IVaultRouter is IMulticall {
     /// @param vault Address of the `vault` the `user` wants to operate on
     /// @param user Address of the `user` that will operates on the `vault`
     /// @return Whether `user` has permissions to operate on `vault`
-    function hasPermissions(address vault, address user) external view returns (bool);
+    function hasPermissions(IBaseVault vault, address user) external view returns (bool);
 
     /// @notice Returns whether the controller has called `enable()` for the given `vault`
-    function isEnabled(address vault, address controller) external view returns (bool);
+    function isEnabled(IBaseVault vault, address controller) external view returns (bool);
 }

--- a/src/vaults/interfaces/factories/IVaultFactory.sol
+++ b/src/vaults/interfaces/factories/IVaultFactory.sol
@@ -6,6 +6,7 @@ import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
 import {IShareToken} from "src/vaults/interfaces/token/IShareToken.sol";
 import {IPoolEscrow} from "src/vaults/interfaces/IEscrow.sol";
+import {IBaseVault} from "src/vaults/interfaces/IBaseVaults.sol";
 
 interface IVaultFactory {
     /// @notice Deploys new vault for `poolId`, `scId` and `asset`.
@@ -24,5 +25,5 @@ interface IVaultFactory {
         uint256 tokenId,
         IShareToken token,
         address[] calldata wards_
-    ) external returns (address);
+    ) external returns (IBaseVault);
 }

--- a/src/vaults/interfaces/investments/IAsyncDepositManager.sol
+++ b/src/vaults/interfaces/investments/IAsyncDepositManager.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.28;
 
 import {IDepositManager} from "src/vaults/interfaces/investments/IDepositManager.sol";
 import {IVaultManager} from "src/vaults/interfaces/IVaultManager.sol";
+import {IBaseVault} from "src/vaults/interfaces/IBaseVaults.sol";
 
 interface IAsyncDepositManager is IDepositManager, IVaultManager {
     /// @notice Requests assets deposit. Vaults have to request investments from Centrifuge before
@@ -14,7 +15,7 @@ interface IAsyncDepositManager is IDepositManager, IVaultManager {
     ///         owner to the escrow, even though the share payout can only happen after epoch execution.
     ///         The receiver becomes the owner of deposit request fulfillment.
     /// @param  source Deprecated
-    function requestDeposit(address vaultAddr, uint256 assets, address receiver, address owner, address source)
+    function requestDeposit(IBaseVault vault, uint256 assets, address receiver, address owner, address source)
         external
         returns (bool);
 
@@ -28,7 +29,7 @@ interface IAsyncDepositManager is IDepositManager, IVaultManager {
     /// @dev    The cancellation request might fail in case the pending deposit order already got fulfilled on
     ///         Centrifuge.
     /// @param  source Deprecated
-    function cancelDepositRequest(address vaultAddr, address owner, address source) external;
+    function cancelDepositRequest(IBaseVault vault, address owner, address source) external;
 
     /// @notice Processes owner's deposit request cancellation after the epoch has been executed on the corresponding CP
     /// instance and the
@@ -36,18 +37,18 @@ interface IAsyncDepositManager is IDepositManager, IVaultManager {
     ///         Assets are transferred from the escrow to the receiver.
     /// @dev    The assets required to fulfill the claim have already been reserved for the owner in escrow on
     ///         fulfillCancelDepositRequest.
-    function claimCancelDepositRequest(address vaultAddr, address receiver, address owner)
+    function claimCancelDepositRequest(IBaseVault vault, address receiver, address owner)
         external
         returns (uint256 assets);
 
     /// @notice Indicates whether a user has pending deposit requests and returns the total deposit request asset
     /// request value.
-    function pendingDepositRequest(address vaultAddr, address user) external view returns (uint256 assets);
+    function pendingDepositRequest(IBaseVault vault, address user) external view returns (uint256 assets);
 
     /// @notice Indicates whether a user has pending deposit request cancellations.
-    function pendingCancelDepositRequest(address vaultAddr, address user) external view returns (bool isPending);
+    function pendingCancelDepositRequest(IBaseVault vault, address user) external view returns (bool isPending);
 
     /// @notice Indicates whether a user has claimable deposit request cancellation and returns the total claim
     ///         value in assets.
-    function claimableCancelDepositRequest(address vaultAddr, address user) external view returns (uint256 assets);
+    function claimableCancelDepositRequest(IBaseVault vault, address user) external view returns (uint256 assets);
 }

--- a/src/vaults/interfaces/investments/IAsyncRedeemManager.sol
+++ b/src/vaults/interfaces/investments/IAsyncRedeemManager.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.28;
 
 import {IRedeemManager} from "src/vaults/interfaces/investments/IRedeemManager.sol";
 import {IVaultManager} from "src/vaults/interfaces/IVaultManager.sol";
+import {IBaseVault} from "src/vaults/interfaces/IBaseVaults.sol";
 
 interface IAsyncRedeemManager is IRedeemManager, IVaultManager {
     /// @notice Requests share redemption. Vaults have to request redemptions
@@ -14,7 +15,7 @@ interface IAsyncRedeemManager is IRedeemManager, IVaultManager {
     ///         owner to the escrow, even though the asset payout can only happen after epoch execution.
     ///         The receiver becomes the owner of redeem request fulfillment.
     /// @param  source Deprecated
-    function requestRedeem(address vaultAddr, uint256 shares, address receiver, address owner, address source)
+    function requestRedeem(IBaseVault vault, uint256 shares, address receiver, address owner, address source)
         external
         returns (bool);
 
@@ -27,7 +28,7 @@ interface IAsyncRedeemManager is IRedeemManager, IVaultManager {
     ///         if the orders could be cancelled successfully.
     /// @dev    The cancellation request might fail in case the pending redeem order already got fulfilled on
     ///         Centrifuge.
-    function cancelRedeemRequest(address vaultAddr, address owner, address source) external;
+    function cancelRedeemRequest(IBaseVault vault, address owner, address source) external;
 
     /// @notice Processes owner's redeem request cancellation after the epoch has been executed on the corresponding CP
     /// instance and the
@@ -36,17 +37,17 @@ interface IAsyncRedeemManager is IRedeemManager, IVaultManager {
     /// @dev    The shares required to fulfill the claim have already been reserved for the owner in escrow on
     ///         fulfillCancelRedeemRequest.
     ///         Receiver has to pass all the share token restrictions in order to receive the shares.
-    function claimCancelRedeemRequest(address vaultAddr, address receiver, address owner)
+    function claimCancelRedeemRequest(IBaseVault vault, address receiver, address owner)
         external
         returns (uint256 shares);
 
     /// @notice Indicates whether a user has pending redeem requests and returns the total share request value.
-    function pendingRedeemRequest(address vaultAddr, address user) external view returns (uint256 shares);
+    function pendingRedeemRequest(IBaseVault vault, address user) external view returns (uint256 shares);
 
     /// @notice Indicates whether a user has pending redeem request cancellations.
-    function pendingCancelRedeemRequest(address vaultAddr, address user) external view returns (bool isPending);
+    function pendingCancelRedeemRequest(IBaseVault vault, address user) external view returns (bool isPending);
 
     /// @notice Indicates whether a user has claimable redeem request cancellation and returns the total claim
     ///         value in shares.
-    function claimableCancelRedeemRequest(address vaultAddr, address user) external view returns (uint256 shares);
+    function claimableCancelRedeemRequest(IBaseVault vault, address user) external view returns (uint256 shares);
 }

--- a/src/vaults/interfaces/investments/IAsyncRequests.sol
+++ b/src/vaults/interfaces/investments/IAsyncRequests.sol
@@ -5,6 +5,7 @@ import {IInvestmentManagerGatewayHandler} from "src/common/interfaces/IGatewayHa
 
 import {IAsyncDepositManager} from "src/vaults/interfaces/investments/IAsyncDepositManager.sol";
 import {IAsyncRedeemManager} from "src/vaults/interfaces/investments/IAsyncRedeemManager.sol";
+import {IBaseVault} from "src/vaults/interfaces/IBaseVaults.sol";
 
 /// @dev Vault requests and deposit/redeem bookkeeping per user
 struct AsyncInvestmentState {
@@ -48,7 +49,7 @@ interface IAsyncRequests is IAsyncDepositManager, IAsyncRedeemManager, IInvestme
     error ExceedsRedeemLimits();
 
     /// @notice Returns the investment state
-    function investments(address vaultAddr, address investor)
+    function investments(IBaseVault vaultAddr, address investor)
         external
         view
         returns (

--- a/src/vaults/interfaces/investments/IBaseInvestmentManager.sol
+++ b/src/vaults/interfaces/investments/IBaseInvestmentManager.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.28;
 
 import {IPoolManager} from "src/vaults/interfaces/IPoolManager.sol";
+import {IBaseVault} from "src/vaults/interfaces/IBaseVaults.sol";
 
 interface IBaseInvestmentManager {
     // --- Events ---
@@ -16,13 +17,13 @@ interface IBaseInvestmentManager {
     function file(bytes32 what, address data) external;
 
     /// @notice Converts the assets value to share decimals.
-    function convertToShares(address vaultAddr, uint256 _assets) external view returns (uint256 shares);
+    function convertToShares(IBaseVault vault, uint256 _assets) external view returns (uint256 shares);
 
     /// @notice Converts the shares value to assets decimals.
-    function convertToAssets(address vaultAddr, uint256 _shares) external view returns (uint256 assets);
+    function convertToAssets(IBaseVault vault, uint256 _shares) external view returns (uint256 assets);
 
     /// @notice Returns the timestamp of the last share price update for a vaultAddr.
-    function priceLastUpdated(address vaultAddr) external view returns (uint64 lastUpdated);
+    function priceLastUpdated(IBaseVault vault) external view returns (uint64 lastUpdated);
 
     /// @notice Returns the PoolManager contract address.
     function poolManager() external view returns (IPoolManager poolManager);

--- a/src/vaults/interfaces/investments/IDepositManager.sol
+++ b/src/vaults/interfaces/investments/IDepositManager.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.28;
 
 import {IBaseInvestmentManager} from "src/vaults/interfaces/investments/IBaseInvestmentManager.sol";
+import {IBaseVault} from "src/vaults/interfaces/IBaseVaults.sol";
 
 interface IDepositManager is IBaseInvestmentManager {
     /// @notice Processes owner's asset deposit after the epoch has been executed on the corresponding CP instance and
@@ -13,7 +14,7 @@ interface IDepositManager is IBaseInvestmentManager {
     ///         The shares required to fulfill the deposit have already been minted and transferred to the escrow on
     ///         fulfillDepositRequest.
     ///         Receiver has to pass all the share token restrictions in order to receive the shares.
-    function deposit(address vaultAddr, uint256 assets, address receiver, address owner)
+    function deposit(IBaseVault vault, uint256 assets, address receiver, address owner)
         external
         returns (uint256 shares);
 
@@ -26,15 +27,15 @@ interface IDepositManager is IBaseInvestmentManager {
     ///         The shares required to fulfill the mint have already been minted and transferred to the escrow on
     ///         fulfillDepositRequest.
     ///         Receiver has to pass all the share token restrictions in order to receive the shares.
-    function mint(address vaultAddr, uint256 shares, address receiver, address owner)
+    function mint(IBaseVault vault, uint256 shares, address receiver, address owner)
         external
         returns (uint256 assets);
 
     /// @notice Returns the max amount of assets based on the unclaimed amount of shares after at least one successful
     ///         deposit order fulfillment on the corresponding CP instance.
-    function maxDeposit(address vaultAddr, address user) external view returns (uint256);
+    function maxDeposit(IBaseVault vault, address user) external view returns (uint256);
 
     /// @notice Returns the max amount of shares a user can claim after at least one successful deposit order
     ///         fulfillment on the corresponding CP instance.
-    function maxMint(address vaultAddr, address user) external view returns (uint256 shares);
+    function maxMint(IBaseVault vault, address user) external view returns (uint256 shares);
 }

--- a/src/vaults/interfaces/investments/IRedeemManager.sol
+++ b/src/vaults/interfaces/investments/IRedeemManager.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.28;
 
 import {IBaseInvestmentManager} from "src/vaults/interfaces/investments/IBaseInvestmentManager.sol";
+import {IBaseVault} from "src/vaults/interfaces/IBaseVaults.sol";
 
 interface IRedeemManager is IBaseInvestmentManager {
     event TriggerRedeemRequest(
@@ -22,7 +23,7 @@ interface IRedeemManager is IBaseInvestmentManager {
     ///         on fulfillRedeemRequest.
     ///         The assets required to fulfill the redemption have already been reserved in escrow on
     ///         fulfillRedeemtRequest.
-    function redeem(address vaultAddr, uint256 shares, address receiver, address owner)
+    function redeem(IBaseVault vault, uint256 shares, address receiver, address owner)
         external
         returns (uint256 assets);
 
@@ -35,15 +36,15 @@ interface IRedeemManager is IBaseInvestmentManager {
     ///         on fulfillRedeemRequest.
     ///         The assets required to fulfill the withdrawal have already been reserved in escrow on
     ///         fulfillRedeemtRequest.
-    function withdraw(address vaultAddr, uint256 assets, address receiver, address owner)
+    function withdraw(IBaseVault vault, uint256 assets, address receiver, address owner)
         external
         returns (uint256 shares);
 
     /// @notice Returns the max amount of shares based on the unclaimed number of assets after at least one successful
     ///         redeem order fulfillment on the corresponding CP instance.
-    function maxRedeem(address vaultAddr, address user) external view returns (uint256 shares);
+    function maxRedeem(IBaseVault vault, address user) external view returns (uint256 shares);
 
     /// @notice Returns the max amount of assets a user can claim after at least one successful redeem order fulfillment
     ///         on the corresponding CP instance.
-    function maxWithdraw(address vaultAddr, address user) external view returns (uint256 assets);
+    function maxWithdraw(IBaseVault vault, address user) external view returns (uint256 assets);
 }

--- a/src/vaults/interfaces/investments/ISyncDepositManager.sol
+++ b/src/vaults/interfaces/investments/ISyncDepositManager.sol
@@ -3,8 +3,9 @@ pragma solidity 0.8.28;
 
 import {IDepositManager} from "src/vaults/interfaces/investments/IDepositManager.sol";
 import {IVaultManager} from "src/vaults/interfaces/IVaultManager.sol";
+import {IBaseVault} from "src/vaults/interfaces/IBaseVaults.sol";
 
 interface ISyncDepositManager is IDepositManager, IVaultManager {
-    function previewDeposit(address vault, address sender, uint256 assets) external view returns (uint256);
-    function previewMint(address vault, address sender, uint256 shares) external view returns (uint256);
+    function previewDeposit(IBaseVault vault, address sender, uint256 assets) external view returns (uint256);
+    function previewMint(IBaseVault vault, address sender, uint256 shares) external view returns (uint256);
 }

--- a/src/vaults/legacy/LegacyVaultAdapter.sol
+++ b/src/vaults/legacy/LegacyVaultAdapter.sol
@@ -69,7 +69,7 @@ contract LegacyVaultAdapter is AsyncVault, ILegacyVaultAdapter, IInvestmentManag
         legacy
         returns (bool)
     {
-        return asyncManager().requestDeposit(address(this), assets, receiver, owner, source);
+        return asyncManager().requestDeposit(this, assets, receiver, owner, source);
     }
 
     /// @inheritdoc IInvestmentManager
@@ -78,83 +78,83 @@ contract LegacyVaultAdapter is AsyncVault, ILegacyVaultAdapter, IInvestmentManag
         legacy
         returns (bool)
     {
-        return asyncManager().requestRedeem(address(this), shares, receiver, owner, source);
+        return asyncManager().requestRedeem(this, shares, receiver, owner, source);
     }
 
     /// @inheritdoc IInvestmentManager
     function cancelDepositRequest(address, /* vault */ address owner, address source) public legacy {
-        return asyncManager().cancelDepositRequest(address(this), owner, source);
+        return asyncManager().cancelDepositRequest(this, owner, source);
     }
 
     /// @inheritdoc IInvestmentManager
     function cancelRedeemRequest(address, /* vault */ address owner, address source) public legacy {
-        return asyncManager().cancelRedeemRequest(address(this), owner, source);
+        return asyncManager().cancelRedeemRequest(this, owner, source);
     }
 
     // --- IInvestmentManager - View functions ---
     /// @inheritdoc IInvestmentManager
     function convertToShares(address, /* vault */ uint256 _assets) public view returns (uint256 shares) {
-        shares = manager.convertToShares(address(this), _assets);
+        shares = manager.convertToShares(this, _assets);
     }
 
     /// @inheritdoc IInvestmentManager
     function convertToAssets(address, /* vault */ uint256 _shares) public view returns (uint256 assets) {
-        assets = manager.convertToAssets(address(this), _shares);
+        assets = manager.convertToAssets(this, _shares);
     }
 
     /// @inheritdoc IInvestmentManager
     function maxDeposit(address, /* vault */ address user) public view returns (uint256 assets) {
-        assets = asyncManager().maxDeposit(address(this), user);
+        assets = asyncManager().maxDeposit(this, user);
     }
 
     /// @inheritdoc IInvestmentManager
     function maxMint(address, /* vault */ address user) public view returns (uint256 shares) {
-        shares = asyncManager().maxMint(address(this), user);
+        shares = asyncManager().maxMint(this, user);
     }
 
     /// @inheritdoc IInvestmentManager
     function maxWithdraw(address, /* vault */ address user) public view returns (uint256 assets) {
-        assets = asyncManager().maxWithdraw(address(this), user);
+        assets = asyncManager().maxWithdraw(this, user);
     }
 
     /// @inheritdoc IInvestmentManager
     function maxRedeem(address, /* vault */ address user) public view returns (uint256 shares) {
-        shares = asyncManager().maxRedeem(address(this), user);
+        shares = asyncManager().maxRedeem(this, user);
     }
 
     /// @inheritdoc IInvestmentManager
     function pendingDepositRequest(address, /* vault */ address user) public view returns (uint256 assets) {
-        assets = asyncManager().pendingDepositRequest(address(this), user);
+        assets = asyncManager().pendingDepositRequest(this, user);
     }
 
     /// @inheritdoc IInvestmentManager
     function pendingRedeemRequest(address, /* vault */ address user) public view returns (uint256 shares) {
-        shares = asyncManager().pendingRedeemRequest(address(this), user);
+        shares = asyncManager().pendingRedeemRequest(this, user);
     }
 
     /// @inheritdoc IInvestmentManager
     function pendingCancelDepositRequest(address, /* vault */ address user) public view returns (bool isPending) {
-        isPending = asyncManager().pendingCancelDepositRequest(address(this), user);
+        isPending = asyncManager().pendingCancelDepositRequest(this, user);
     }
 
     /// @inheritdoc IInvestmentManager
     function pendingCancelRedeemRequest(address, /* vault */ address user) public view returns (bool isPending) {
-        isPending = asyncManager().pendingCancelRedeemRequest(address(this), user);
+        isPending = asyncManager().pendingCancelRedeemRequest(this, user);
     }
 
     /// @inheritdoc IInvestmentManager
     function claimableCancelDepositRequest(address, /* vault */ address user) public view returns (uint256 assets) {
-        assets = asyncManager().claimableCancelDepositRequest(address(this), user);
+        assets = asyncManager().claimableCancelDepositRequest(this, user);
     }
 
     /// @inheritdoc IInvestmentManager
     function claimableCancelRedeemRequest(address, /* vault */ address user) public view returns (uint256 shares) {
-        shares = asyncManager().claimableCancelRedeemRequest(address(this), user);
+        shares = asyncManager().claimableCancelRedeemRequest(this, user);
     }
 
     /// @inheritdoc IInvestmentManager
     function priceLastUpdated(address /* vault */ ) public view returns (uint64 lastUpdated) {
-        lastUpdated = manager.priceLastUpdated(address(this));
+        lastUpdated = manager.priceLastUpdated(this);
     }
 
     // --- IInvestmentManager - Vault claim functions ---
@@ -164,7 +164,7 @@ contract LegacyVaultAdapter is AsyncVault, ILegacyVaultAdapter, IInvestmentManag
         legacy
         returns (uint256 shares)
     {
-        shares = asyncManager().deposit(address(this), assets, receiver, owner);
+        shares = asyncManager().deposit(this, assets, receiver, owner);
     }
 
     /// @inheritdoc IInvestmentManager
@@ -173,7 +173,7 @@ contract LegacyVaultAdapter is AsyncVault, ILegacyVaultAdapter, IInvestmentManag
         legacy
         returns (uint256 assets)
     {
-        assets = asyncManager().mint(address(this), shares, receiver, owner);
+        assets = asyncManager().mint(this, shares, receiver, owner);
     }
 
     /// @inheritdoc IInvestmentManager
@@ -182,7 +182,7 @@ contract LegacyVaultAdapter is AsyncVault, ILegacyVaultAdapter, IInvestmentManag
         legacy
         returns (uint256 assets)
     {
-        assets = asyncManager().redeem(address(this), shares, receiver, owner);
+        assets = asyncManager().redeem(this, shares, receiver, owner);
     }
 
     /// @inheritdoc IInvestmentManager
@@ -191,7 +191,7 @@ contract LegacyVaultAdapter is AsyncVault, ILegacyVaultAdapter, IInvestmentManag
         legacy
         returns (uint256 shares)
     {
-        shares = asyncManager().withdraw(address(this), assets, receiver, owner);
+        shares = asyncManager().withdraw(this, assets, receiver, owner);
     }
 
     /// @inheritdoc IInvestmentManager
@@ -200,7 +200,7 @@ contract LegacyVaultAdapter is AsyncVault, ILegacyVaultAdapter, IInvestmentManag
         legacy
         returns (uint256 assets)
     {
-        assets = asyncManager().claimCancelDepositRequest(address(this), receiver, owner);
+        assets = asyncManager().claimCancelDepositRequest(this, receiver, owner);
     }
 
     /// @inheritdoc IInvestmentManager
@@ -209,6 +209,6 @@ contract LegacyVaultAdapter is AsyncVault, ILegacyVaultAdapter, IInvestmentManag
         legacy
         returns (uint256 shares)
     {
-        shares = asyncManager().claimCancelRedeemRequest(address(this), receiver, owner);
+        shares = asyncManager().claimCancelRedeemRequest(this, receiver, owner);
     }
 }

--- a/test/vaults/integration/AssetShareConversion.t.sol
+++ b/test/vaults/integration/AssetShareConversion.t.sol
@@ -119,7 +119,7 @@ contract AssetShareConversionTest is BaseTest {
         (uint64 poolId, address vault_, uint128 assetId) =
             deployVault(VaultKind.Async, SHARE_TOKEN_DECIMALS, restrictedTransfers, scId, address(asset), 0, 0);
         AsyncVault vault = AsyncVault(vault_);
-        IShareToken(address(AsyncVault(vault_).share()));
+        IShareToken(address(vault.share()));
 
         assertEq(vault.priceLastUpdated(), block.timestamp);
         assertEq(vault.pricePerShare(), 1e6);
@@ -127,7 +127,7 @@ contract AssetShareConversionTest is BaseTest {
         assertEq(vault.priceLastUpdated(), uint64(block.timestamp));
         assertEq(vault.pricePerShare(), 1.2e6);
 
-        poolManager.unlinkVault(PoolId.wrap(poolId), ShareClassId.wrap(scId), AssetId.wrap(assetId), address(vault));
+        poolManager.unlinkVault(PoolId.wrap(poolId), ShareClassId.wrap(scId), AssetId.wrap(assetId), vault);
 
         assertEq(vault.priceLastUpdated(), uint64(block.timestamp));
         assertEq(vault.pricePerShare(), 1.2e6);

--- a/test/vaults/integration/AsyncRequests.t.sol
+++ b/test/vaults/integration/AsyncRequests.t.sol
@@ -9,6 +9,7 @@ import {VaultDetails} from "src/vaults/interfaces/IPoolManager.sol";
 import {IAsyncVault} from "src/vaults/interfaces/IBaseVaults.sol";
 import {IAsyncRequests} from "src/vaults/interfaces/investments/IAsyncRequests.sol";
 import {IBaseInvestmentManager} from "src/vaults/interfaces/investments/IBaseInvestmentManager.sol";
+import {IBaseVault} from "src/vaults/interfaces/IBaseVaults.sol";
 
 import "test/vaults/BaseTest.sol";
 
@@ -19,13 +20,13 @@ interface VaultLike {
 contract AsyncRequestsHarness is AsyncRequests {
     constructor(address root, address deployer) AsyncRequests(root, deployer) {}
 
-    function calculatePrice(address vault, uint128 assets, uint128 shares) external view returns (uint256 price) {
-        if (vault == address(0)) {
+    function calculatePrice(IBaseVault vault, uint128 assets, uint128 shares) external view returns (uint256 price) {
+        if (address(vault) == address(0)) {
             return VaultPricingLib.calculatePrice(address(0), shares, address(0), 0, assets);
         }
 
         VaultDetails memory vaultDetails = poolManager.vaultDetails(vault);
-        address shareToken = IAsyncVault(vault).share();
+        address shareToken = vault.share();
         return VaultPricingLib.calculatePrice(shareToken, shares, vaultDetails.asset, vaultDetails.tokenId, assets);
     }
 }
@@ -87,7 +88,7 @@ contract AsyncRequestsTest is BaseTest {
     // --- Price calculations ---
     function testPrice() public {
         AsyncRequestsHarness harness = new AsyncRequestsHarness(address(root), address(this));
-        assertEq(harness.calculatePrice(address(0), 1, 0), 0);
-        assertEq(harness.calculatePrice(address(0), 0, 1), 0);
+        assertEq(harness.calculatePrice(IBaseVault(address(0)), 1, 0), 0);
+        assertEq(harness.calculatePrice(IBaseVault(address(0)), 0, 1), 0);
     }
 }

--- a/test/vaults/integration/Deposit.t.sol
+++ b/test/vaults/integration/Deposit.t.sol
@@ -204,7 +204,7 @@ contract DepositTest is BaseTest {
             poolId, vault.scId().raw(), bytes32(bytes20(self)), assetId, assets, firstSharePayout
         );
 
-        (,, uint256 depositPrice,,,,,,,) = asyncRequests.investments(address(vault), self);
+        (,, uint256 depositPrice,,,,,,,) = asyncRequests.investments(vault, self);
         assertEq(depositPrice, 1400000000000000000);
 
         // second trigger executed collectInvest of the second 50% at a price of 1.2
@@ -213,7 +213,7 @@ contract DepositTest is BaseTest {
             poolId, vault.scId().raw(), bytes32(bytes20(self)), assetId, assets, secondSharePayout
         );
 
-        (,, depositPrice,,,,,,,) = asyncRequests.investments(address(vault), self);
+        (,, depositPrice,,,,,,,) = asyncRequests.investments(vault, self);
         assertEq(depositPrice, 1292307679384615384);
 
         // assert deposit & mint values adjusted
@@ -477,7 +477,7 @@ contract DepositTest is BaseTest {
         assertEq(vault.maxMint(self), firstSharePayout);
 
         // deposit price should be ~1.2*10**18
-        (,, uint256 depositPrice,,,,,,,) = asyncRequests.investments(address(vault), self);
+        (,, uint256 depositPrice,,,,,,,) = asyncRequests.investments(vault, self);
         assertEq(depositPrice, 1200000000000000000);
 
         // trigger executed collectInvest of the second 50% at a price of 1.4
@@ -507,7 +507,7 @@ contract DepositTest is BaseTest {
         );
 
         // redeem price should now be ~1.5*10**18.
-        (,,, uint256 redeemPrice,,,,,,) = asyncRequests.investments(address(vault), self);
+        (,,, uint256 redeemPrice,,,,,,) = asyncRequests.investments(vault, self);
         assertEq(redeemPrice, 1492615384615384615);
     }
 
@@ -538,7 +538,7 @@ contract DepositTest is BaseTest {
         assertEq(vault.maxMint(self), firstSharePayout);
 
         // deposit price should be ~1.2*10**18
-        (,, uint256 depositPrice,,,,,,,) = asyncRequests.investments(address(vault), self);
+        (,, uint256 depositPrice,,,,,,,) = asyncRequests.investments(vault, self);
         assertEq(depositPrice, 1200000019200000307);
 
         // trigger executed collectInvest of the second 50% at a price of 1.4
@@ -571,7 +571,7 @@ contract DepositTest is BaseTest {
         );
 
         // redeem price should now be ~1.5*10**18.
-        (,,, uint256 redeemPrice,,,,,,) = asyncRequests.investments(address(vault), self);
+        (,,, uint256 redeemPrice,,,,,,) = asyncRequests.investments(vault, self);
         assertEq(redeemPrice, 1492615411252828877);
 
         // collect the asset
@@ -614,7 +614,7 @@ contract DepositTest is BaseTest {
         assertEq(vault.maxMint(self), shares);
 
         // lp price is set to the deposit price
-        (,, uint256 depositPrice,,,,,,,) = asyncRequests.investments(address(vault), self);
+        (,, uint256 depositPrice,,,,,,,) = asyncRequests.investments(vault, self);
         assertEq(depositPrice, 1200000000000000000);
     }
 
@@ -653,7 +653,7 @@ contract DepositTest is BaseTest {
         assertEq(vault.maxMint(self), shares);
 
         // lp price is set to the deposit price
-        (,, uint256 depositPrice,,,,,,,) = asyncRequests.investments(address(vault), self);
+        (,, uint256 depositPrice,,,,,,,) = asyncRequests.investments(vault, self);
         assertEq(depositPrice, 1200000000000000000);
     }
 
@@ -732,7 +732,7 @@ contract DepositTest is BaseTest {
             vault.poolId().raw(), scId, bytes32(bytes20(self)), assetId.raw(), assets, firstSharePayout
         );
 
-        (,, uint256 depositPrice,,,,,,,) = asyncRequests.investments(address(vault), self);
+        (,, uint256 depositPrice,,,,,,,) = asyncRequests.investments(vault, self);
         assertEq(depositPrice, 1400000000000000000);
 
         // second trigger executed collectInvest of the second 50% at a price of 1.2
@@ -741,7 +741,7 @@ contract DepositTest is BaseTest {
             vault.poolId().raw(), scId, bytes32(bytes20(self)), assetId.raw(), assets, secondSharePayout
         );
 
-        (,, depositPrice,,,,,,,) = asyncRequests.investments(address(vault), self);
+        (,, depositPrice,,,,,,,) = asyncRequests.investments(vault, self);
         assertEq(depositPrice, 1292307679384615384);
 
         // assert deposit & mint values adjusted

--- a/test/vaults/integration/DepositRedeem.t.sol
+++ b/test/vaults/integration/DepositRedeem.t.sol
@@ -43,7 +43,7 @@ contract DepositRedeem is BaseTest {
             poolId, scId, bytes32(bytes20(self)), assetId.raw(), assets, firstSharePayout
         );
 
-        (,, uint256 depositPrice,,,,,,,) = asyncRequests.investments(address(vault), self);
+        (,, uint256 depositPrice,,,,,,,) = asyncRequests.investments(vault, self);
         assertEq(depositPrice, 1400000000000000000);
 
         // second trigger executed collectInvest of the second 50% at a price of 1.2
@@ -52,7 +52,7 @@ contract DepositRedeem is BaseTest {
             poolId, scId, bytes32(bytes20(self)), assetId.raw(), assets, secondSharePayout
         );
 
-        (,, depositPrice,,,,,,,) = asyncRequests.investments(address(vault), self);
+        (,, depositPrice,,,,,,,) = asyncRequests.investments(vault, self);
         assertEq(depositPrice, 1292307679384615384);
 
         // assert deposit & mint values adjusted
@@ -86,7 +86,7 @@ contract DepositRedeem is BaseTest {
 
         assertEq(vault.maxRedeem(self), firstShareRedeem);
 
-        (,,, uint256 redeemPrice,,,,,,) = asyncRequests.investments(address(vault), self);
+        (,,, uint256 redeemPrice,,,,,,) = asyncRequests.investments(vault, self);
         assertEq(redeemPrice, 1100000000000000000);
 
         // second trigger executed collectRedeem of the second 25 share class tokens at a price of 1.3
@@ -95,7 +95,7 @@ contract DepositRedeem is BaseTest {
             poolId, scId, bytes32(bytes20(self)), assetId.raw(), secondCurrencyPayout, secondShareRedeem
         );
 
-        (,,, redeemPrice,,,,,,) = asyncRequests.investments(address(vault), self);
+        (,,, redeemPrice,,,,,,) = asyncRequests.investments(vault, self);
         assertEq(redeemPrice, 1200000000000000000);
 
         assertApproxEqAbs(vault.maxWithdraw(self), firstCurrencyPayout + secondCurrencyPayout, 2);

--- a/test/vaults/integration/Redeem.t.sol
+++ b/test/vaults/integration/Redeem.t.sol
@@ -382,7 +382,7 @@ contract RedeemTest is BaseTest {
             poolId.raw(), scId.raw(), bytes32(bytes20(self)), assetId, uint128(investmentAmount), shares
         );
 
-        (,, uint256 depositPrice,,,,,,,) = asyncRequests.investments(address(vault), self);
+        (,, uint256 depositPrice,,,,,,,) = asyncRequests.investments(vault, self);
         assertEq(depositPrice, 1000000000000000000);
 
         // assert deposit & mint values adjusted
@@ -407,7 +407,7 @@ contract RedeemTest is BaseTest {
             poolId.raw(), scId.raw(), bytes32(bytes20(self)), assetId, assets, shares / 2
         );
 
-        (,,, uint256 redeemPrice,,,,,,) = asyncRequests.investments(address(vault), self);
+        (,,, uint256 redeemPrice,,,,,,) = asyncRequests.investments(vault, self);
         assertEq(redeemPrice, 1500000000000000000);
 
         // trigger second executed collectRedeem at a price of 1.0
@@ -418,7 +418,7 @@ contract RedeemTest is BaseTest {
             poolId.raw(), scId.raw(), bytes32(bytes20(self)), assetId, assets, shares / 2
         );
 
-        (,,, redeemPrice,,,,,,) = asyncRequests.investments(address(vault), self);
+        (,,, redeemPrice,,,,,,) = asyncRequests.investments(vault, self);
         assertEq(redeemPrice, 1250000000000000000);
     }
 
@@ -448,7 +448,7 @@ contract RedeemTest is BaseTest {
 
         assertEq(vault.maxRedeem(self), firstShareRedeem);
 
-        (,,, uint256 redeemPrice,,,,,,) = asyncRequests.investments(address(vault), self);
+        (,,, uint256 redeemPrice,,,,,,) = asyncRequests.investments(vault, self);
         assertEq(redeemPrice, 1100000000000000000);
 
         // second trigger executed collectRedeem of the second 25 share class tokens at a price of 1.3
@@ -462,7 +462,7 @@ contract RedeemTest is BaseTest {
             secondShareRedeem
         );
 
-        (,,, redeemPrice,,,,,,) = asyncRequests.investments(address(vault), self);
+        (,,, redeemPrice,,,,,,) = asyncRequests.investments(vault, self);
         assertEq(redeemPrice, 1200000000000000000);
 
         assertApproxEqAbs(vault.maxWithdraw(self), firstCurrencyPayout + secondCurrencyPayout, 2);

--- a/test/vaults/integration/SyncDeposit.t.sol
+++ b/test/vaults/integration/SyncDeposit.t.sol
@@ -20,6 +20,7 @@ import {IBalanceSheet} from "src/vaults/interfaces/IBalanceSheet.sol";
 import {SyncDepositVault} from "src/vaults/SyncDepositVault.sol";
 import {VaultDetails} from "src/vaults/interfaces/IPoolManager.sol";
 import {ISyncRequests} from "src/vaults/interfaces/investments/ISyncRequests.sol";
+import {IBaseVault} from "src/vaults/interfaces/IBaseVaults.sol";
 
 contract SyncDepositTestHelper is BaseTest {
     using CastLib for *;
@@ -53,7 +54,7 @@ contract SyncDepositTestHelper is BaseTest {
         ShareClassId scId = vault.scId();
         uint64 timestamp = uint64(block.timestamp);
         uint128 depositAssetAmount = vault.previewMint(shares).toUint128();
-        VaultDetails memory vaultDetails = poolManager.vaultDetails(address(vault));
+        VaultDetails memory vaultDetails = poolManager.vaultDetails(vault);
 
         vm.expectEmit();
         emit IBalanceSheet.Issue(poolId, scId, self, pricePoolPerShare, shares);
@@ -88,10 +89,10 @@ contract SyncDepositTest is SyncDepositTestHelper {
         IShareToken shareToken = IShareToken(address(syncVault.share()));
 
         // Retrieve async vault
-        address asyncVault_ =
+        IBaseVault asyncVault_ =
             syncVault.asyncRedeemManager().vaultByAssetId(syncVault.poolId(), syncVault.scId(), AssetId.wrap(assetId));
         assertNotEq(address(syncVault), address(0), "Failed to retrieve async vault");
-        AsyncVault asyncVault = AsyncVault(asyncVault_);
+        AsyncVault asyncVault = AsyncVault(address(asyncVault_));
 
         // Check price and max amounts
         uint256 shares = syncVault.previewDeposit(amount);

--- a/test/vaults/integration/SyncRequests.t.sol
+++ b/test/vaults/integration/SyncRequests.t.sol
@@ -14,6 +14,7 @@ import {SyncRequests} from "src/vaults/SyncRequests.sol";
 import {VaultPricingLib} from "src/vaults/libraries/VaultPricingLib.sol";
 import {SyncDepositVault} from "src/vaults/SyncDepositVault.sol";
 import {IBaseInvestmentManager} from "src/vaults/interfaces/investments/IBaseInvestmentManager.sol";
+import {IBaseVault} from "src/vaults/interfaces/IBaseVaults.sol";
 
 import "test/vaults/BaseTest.sol";
 
@@ -109,22 +110,24 @@ contract SyncRequestsUnauthorizedTest is SyncRequestsBaseTest {
 
     function testAddVaultUnauthorized(address nonWard) public {
         _expectUnauthorized(nonWard);
-        syncRequests.addVault(PoolId.wrap(0), ShareClassId.wrap(0), address(0), address(0), AssetId.wrap(0));
+        syncRequests.addVault(PoolId.wrap(0), ShareClassId.wrap(0), IBaseVault(address(0)), address(0), AssetId.wrap(0));
     }
 
     function testRemoveVaultUnauthorized(address nonWard) public {
         _expectUnauthorized(nonWard);
-        syncRequests.removeVault(PoolId.wrap(0), ShareClassId.wrap(0), address(0), address(0), AssetId.wrap(0));
+        syncRequests.removeVault(
+            PoolId.wrap(0), ShareClassId.wrap(0), IBaseVault(address(0)), address(0), AssetId.wrap(0)
+        );
     }
 
     function testDepositUnauthorized(address nonWard) public {
         _expectUnauthorized(nonWard);
-        syncRequests.deposit(address(0), 0, address(0), address(0));
+        syncRequests.deposit(IBaseVault(address(0)), 0, address(0), address(0));
     }
 
     function testMintUnauthorized(address nonWard) public {
         _expectUnauthorized(nonWard);
-        syncRequests.mint(address(0), 0, address(0), address(0));
+        syncRequests.mint(IBaseVault(address(0)), 0, address(0), address(0));
     }
 
     function testSetValuationUnauthorized(address nonWard) public {
@@ -271,10 +274,10 @@ contract SyncRequestsUpdateValuation is SyncRequestsBaseTest {
 
         uint256 shares = shareUnitAmount;
         uint256 assets = priceAssetPerShare.mulUint256(shares);
-        assertEq(syncRequests.convertToAssets(address(syncVault), shares), assets, "convertToAssets mismatch");
-        assertEq(syncRequests.previewMint(address(syncVault), address(0), shares), assets, "previewMint mismatch");
-        assertEq(syncRequests.convertToShares(address(syncVault), assets), shares, "convertToShares mismatch");
-        assertEq(syncRequests.previewDeposit(address(syncVault), address(0), assets), shares, "previewDeposit mismatch");
+        assertEq(syncRequests.convertToAssets(syncVault, shares), assets, "convertToAssets mismatch");
+        assertEq(syncRequests.previewMint(syncVault, address(0), shares), assets, "previewMint mismatch");
+        assertEq(syncRequests.convertToShares(syncVault, assets), shares, "convertToShares mismatch");
+        assertEq(syncRequests.previewDeposit(syncVault, address(0), assets), shares, "previewDeposit mismatch");
     }
 
     function testFuzzedConversionWithValuationERC20(uint128 pricePoolPerShare_, uint128 pricePoolPerAsset_) public {
@@ -297,9 +300,9 @@ contract SyncRequestsUpdateValuation is SyncRequestsBaseTest {
 
         uint256 shares = shareUnitAmount;
         uint256 assets = priceAssetPerShare.mulUint256(shares);
-        assertEq(syncRequests.convertToAssets(address(syncVault), shares), assets, "convertToAssets mismatch");
-        assertEq(syncRequests.previewMint(address(syncVault), address(0), shares), assets, "previewMint mismatch");
-        assertEq(syncRequests.convertToShares(address(syncVault), assets), shares, "convertToShares mismatch");
-        assertEq(syncRequests.previewDeposit(address(syncVault), address(0), assets), shares, "previewDeposit mismatch");
+        assertEq(syncRequests.convertToAssets(syncVault, shares), assets, "convertToAssets mismatch");
+        assertEq(syncRequests.previewMint(syncVault, address(0), shares), assets, "previewMint mismatch");
+        assertEq(syncRequests.convertToShares(syncVault, assets), shares, "convertToShares mismatch");
+        assertEq(syncRequests.previewDeposit(syncVault, address(0), assets), shares, "previewDeposit mismatch");
     }
 }

--- a/test/vaults/mocks/MockCentrifugeChain.sol
+++ b/test/vaults/mocks/MockCentrifugeChain.sol
@@ -15,6 +15,7 @@ import {PoolId} from "src/common/types/PoolId.sol";
 import {PoolManager} from "src/vaults/PoolManager.sol";
 import {SyncRequests} from "src/vaults/SyncRequests.sol";
 import {VaultDetails} from "src/vaults/interfaces/IPoolManager.sol";
+import {IBaseVault} from "src/vaults/interfaces/IBaseVaults.sol";
 
 interface AdapterLike {
     function execute(bytes memory _message) external;
@@ -41,7 +42,7 @@ contract MockCentrifugeChain is Test {
     }
 
     function unlinkVault(uint64 poolId, bytes16 scId, address vault) public {
-        VaultDetails memory vaultDetails = poolManager.vaultDetails(vault);
+        VaultDetails memory vaultDetails = poolManager.vaultDetails(IBaseVault(vault));
 
         execute(
             MessageLib.UpdateContract({
@@ -58,7 +59,7 @@ contract MockCentrifugeChain is Test {
     }
 
     function linkVault(uint64 poolId, bytes16 scId, address vault) public {
-        VaultDetails memory vaultDetails = poolManager.vaultDetails(vault);
+        VaultDetails memory vaultDetails = poolManager.vaultDetails(IBaseVault(vault));
 
         execute(
             MessageLib.UpdateContract({
@@ -75,7 +76,7 @@ contract MockCentrifugeChain is Test {
     }
 
     function updateMaxReserve(uint64 poolId, bytes16 scId, address vault, uint128 maxReserve) public {
-        VaultDetails memory vaultDetails = poolManager.vaultDetails(vault);
+        VaultDetails memory vaultDetails = poolManager.vaultDetails(IBaseVault(vault));
 
         execute(
             MessageLib.UpdateContract({


### PR DESCRIPTION
Right now, vaults as addresses are quite difficult to handle, given that they can be different vaults.

This PR adds static analysis to the vaults/router API to place the correct vault for the correct action. i.e. Only `AsyncVault` in `router.requestDeposit`. It also gives more trust to our code