### PR TITLE
Fix: Majors

### DIFF
--- a/snapshots/AsyncVault.json
+++ b/snapshots/AsyncVault.json
@@ -1,4 +1,4 @@
 {
-  "fulfillDepositRequest": "943228",
-  "requestDeposit": "472208"
+  "fulfillDepositRequest": "945557",
+  "requestDeposit": "471826"
 }

--- a/snapshots/VaultRouter.json
+++ b/snapshots/VaultRouter.json
@@ -1,7 +1,7 @@
 {
-  "claimDeposit": "1192216",
+  "claimDeposit": "1194273",
   "enable": "60975",
   "lockDepositRequest": "92339",
-  "requestDeposit": "563450",
-  "requestRedeem": "2101898"
+  "requestDeposit": "563134",
+  "requestRedeem": "2103617"
 }

--- a/src/common/MessageProcessor.sol
+++ b/src/common/MessageProcessor.sol
@@ -259,13 +259,18 @@ contract MessageProcessor is Auth, IMessageProcessor {
             }
         } else if (kind == MessageType.ApprovedDeposits) {
             MessageLib.ApprovedDeposits memory m = message.deserializeApprovedDeposits();
-            balanceSheet.approvedDeposits(
-                PoolId.wrap(m.poolId), ShareClassId.wrap(m.scId), AssetId.wrap(m.assetId), m.assetAmount
+            investmentManager.approvedDeposits(
+                PoolId.wrap(m.poolId), ShareClassId.wrap(m.scId), AssetId.wrap(m.assetId), m.assetAmount, m.pricePoolPerAsset
+            );
+        } else if (kind == MessageType.IssuedShares) {
+            MessageLib.IssuedShares memory m = message.deserializeIssuedShares();
+            investmentManager.issuedShares(
+                PoolId.wrap(m.poolId), ShareClassId.wrap(m.scId), m.shareAmount, m.pricePoolPerShare
             );
         } else if (kind == MessageType.RevokedShares) {
             MessageLib.RevokedShares memory m = message.deserializeRevokedShares();
-            balanceSheet.revokedShares(
-                PoolId.wrap(m.poolId), ShareClassId.wrap(m.scId), AssetId.wrap(m.assetId), m.assetAmount
+            investmentManager.revokedShares(
+                PoolId.wrap(m.poolId), ShareClassId.wrap(m.scId), AssetId.wrap(m.assetId), m.assetAmount, m.shareAmount, m.pricePoolPerShare
             );
         } else {
             revert InvalidMessage(uint8(kind));

--- a/src/common/interfaces/IGatewayHandlers.sol
+++ b/src/common/interfaces/IGatewayHandlers.sol
@@ -147,6 +147,28 @@ interface IPoolManagerGatewayHandler {
 
 /// @notice Interface for CV methods related to async investments called by messages
 interface IInvestmentManagerGatewayHandler {
+    /// @notice Signal from the Hub that an asynchronous investment order has been approved
+    ///
+    /// @dev This message needs to trigger making the asset amounts available to the pool-share-class.
+    function approvedDeposits(PoolId poolId, ShareClassId scId, AssetId assetId, uint128 assetAmount, D18 pricePoolPerAsset) external;
+
+    /// @notice Signal from the Hub that an asynchronous investment order has been finalized. Shares have been issued.
+    ///
+    /// @dev This message needs to trigger minting the new amount of shares.
+    function issuedShares(PoolId poolId, ShareClassId scId, uint128 shareAmount, D18 pricePoolPerShare) external;
+
+    /// @notice Signal from the Hub that an asynchronous redeem order has been finalized.
+    ///
+    /// @dev This messages needs to trigger reserving the asset amount for claims of redemptions by users.
+    function revokedShares(
+        PoolId poolId,
+        ShareClassId scId,
+        AssetId assetId,
+        uint128 assetAmount,
+        uint128 shareAmount,
+        D18 pricePoolPerShare
+    ) external;
+
     // --- Deposits ---
     /// @notice Fulfills pending deposit requests after successful epoch execution on CP.
     ///         The amount of shares that can be claimed by the user is minted and moved to the escrow contract.
@@ -284,8 +306,4 @@ interface IBalanceSheetGatewayHandler {
 
     function triggerRevokeShares(PoolId poolId, ShareClassId scId, address from, D18 pricePoolPerShare, uint128 shares)
         external;
-
-    function approvedDeposits(PoolId poolId, ShareClassId scId, AssetId assetId, uint128 assetAmount) external;
-
-    function revokedShares(PoolId poolId, ShareClassId scId, AssetId assetId, uint128 assetAmount) external;
 }

--- a/src/common/interfaces/IGatewaySenders.sol
+++ b/src/common/interfaces/IGatewaySenders.sol
@@ -115,10 +115,13 @@ interface IPoolMessageSender is ILocalCentrifugeId {
     ) external;
 
     /// @notice Creates and send the message
-    function sendApprovedDeposits(PoolId poolId, ShareClassId scId, AssetId assetId, uint128 assetAmount) external;
+    function sendApprovedDeposits(PoolId poolId, ShareClassId scId, AssetId assetId, uint128 assetAmount, D18 pricePoolPerAsset) external;
+
+    // @notice Creates and send the message
+    function sendIssuedShares(PoolId poolId, ShareClassId scId, uint128 shareAmount, D18 pricePoolPerShare) external;
 
     /// @notice Creates and send the message
-    function sendRevokedShares(PoolId poolId, ShareClassId scId, AssetId assetId, uint128 assetAmount) external;
+    function sendRevokedShares(PoolId poolId, ShareClassId scId, AssetId assetId, uint128 assetAmount, uint128 shareAmount, D18 pricePoolPerShare) external;
 }
 
 /// @notice Interface for dispatch-only gateway

--- a/src/common/libraries/MessageLib.sol
+++ b/src/common/libraries/MessageLib.sol
@@ -1083,6 +1083,7 @@ library MessageLib {
         bytes16 scId;
         uint128 assetId;
         uint128 assetAmount;
+        uint128 pricePoolPerAsset;
     }
 
     function deserializeApprovedDeposits(bytes memory data) internal pure returns (ApprovedDeposits memory) {
@@ -1092,12 +1093,39 @@ library MessageLib {
             poolId: data.toUint64(1),
             scId: data.toBytes16(9),
             assetId: data.toUint128(25),
-            assetAmount: data.toUint128(41)
+            assetAmount: data.toUint128(41),
+            pricePoolPerAsset: data.toUint128(57)
         });
     }
 
     function serialize(ApprovedDeposits memory t) internal pure returns (bytes memory) {
-        return abi.encodePacked(MessageType.ApprovedDeposits, t.poolId, t.scId, t.assetId, t.assetAmount);
+        return abi.encodePacked(MessageType.ApprovedDeposits, t.poolId, t.scId, t.assetId, t.assetAmount, t.pricePoolPerAsset);
+    }
+
+    //---------------------------------------
+    //    IssuedShares
+    //---------------------------------------
+
+    struct IssuedShares {
+        uint64 poolId;
+        bytes16 scId;
+        uint128 shareAmount;
+        uint128 pricePoolPerShare;
+    }
+
+    function deserializeIssuedShares(bytes memory data) internal pure returns (IssuedShares memory) {
+        require(messageType(data) == MessageType.IssuedShares, UnknownMessageType());
+
+        return IssuedShares({
+            poolId: data.toUint64(1),
+            scId: data.toBytes16(9),
+            shareAmount: data.toUint128(25),
+            pricePoolPerShare: data.toUint128(41)
+        });
+    }
+
+    function serialize(IssuedShares memory t) internal pure returns (bytes memory) {
+        return abi.encodePacked(MessageType.IssuedShares, t.poolId, t.scId, t.shareAmount, t.pricePoolPerShare);
     }
 
     //---------------------------------------
@@ -1108,6 +1136,8 @@ library MessageLib {
         uint64 poolId;
         bytes16 scId;
         uint128 assetId;
+        uint128 shareAmount;
+        uint128 pricePoolPerShare;
         uint128 assetAmount;
     }
 
@@ -1118,12 +1148,14 @@ library MessageLib {
             poolId: data.toUint64(1),
             scId: data.toBytes16(9),
             assetId: data.toUint128(25),
-            assetAmount: data.toUint128(41)
+            assetAmount: data.toUint128(41),
+            shareAmount: data.toUint128(57),
+            pricePoolPerShare: data.toUint128(73)
         });
     }
 
     function serialize(RevokedShares memory t) internal pure returns (bytes memory) {
-        return abi.encodePacked(MessageType.RevokedShares, t.poolId, t.scId, t.assetId, t.assetAmount);
+        return abi.encodePacked(MessageType.RevokedShares, t.poolId, t.scId, t.assetId, t.assetAmount, t.shareAmount, t.pricePoolPerShare);
     }
 
     //---------------------------------------

--- a/src/hub/Hub.sol
+++ b/src/hub/Hub.sol
@@ -233,7 +233,8 @@ contract Hub is Multicall, Auth, Recoverable, IHub, IHubGatewayHandler {
         (uint128 approvedAssetAmount,) =
             shareClassManager.approveDeposits(poolId, scId, maxApproval, paymentAssetId, valuation);
 
-        sender.sendApprovedDeposits(poolId, scId, paymentAssetId, approvedAssetAmount);
+        // TODO: Fix price once SCM refactor is in
+        sender.sendApprovedDeposits(poolId, scId, paymentAssetId, approvedAssetAmount, d18(1,1));
     }
 
     /// @inheritdoc IHub
@@ -251,6 +252,9 @@ contract Hub is Multicall, Auth, Recoverable, IHub, IHubGatewayHandler {
         _protected(poolId);
 
         shareClassManager.issueShares(poolId, scId, depositAssetId, navPerShare);
+
+        // TODO: Fix shareAmount once SCM refactor is in
+        sender.sendIssuedShares(poolId, scId, 0, navPerShare);
     }
 
     /// @inheritdoc IHub
@@ -263,7 +267,8 @@ contract Hub is Multicall, Auth, Recoverable, IHub, IHubGatewayHandler {
         (uint128 payoutAssetAmount,) =
             shareClassManager.revokeShares(poolId, scId, payoutAssetId, navPerShare, valuation);
 
-        sender.sendRevokedShares(poolId, scId, payoutAssetId, payoutAssetAmount);
+        // TODO: Fix shareAmount once SCM refactor is in
+        sender.sendRevokedShares(poolId, scId, payoutAssetId, payoutAssetAmount, 0, navPerShare);
     }
 
     /// @inheritdoc IHub

--- a/src/vaults/BalanceSheet.sol
+++ b/src/vaults/BalanceSheet.sol
@@ -88,10 +88,12 @@ contract BalanceSheet is Auth, Recoverable, IBalanceSheet, IBalanceSheetGatewayH
         D18 pricePoolPerAsset
     ) external authOrManager(poolId, scId) {
         AssetId assetId = poolManager.assetToId(asset, tokenId);
-        _deposit(poolId, scId, assetId, asset, tokenId, provider, amount, pricePoolPerAsset, true);
+        _noteDeposit(poolId, scId, assetId, asset, tokenId, provider, amount, pricePoolPerAsset);
+        _executeDeposit(poolId, asset, tokenId, provider, amount);
     }
 
     /// @inheritdoc IBalanceSheet
+    /// @dev This function is mostly useful to keep higher level integrations CEI adherent.
     function noteDeposit(
         PoolId poolId,
         ShareClassId scId,
@@ -102,7 +104,7 @@ contract BalanceSheet is Auth, Recoverable, IBalanceSheet, IBalanceSheetGatewayH
         D18 pricePoolPerAsset
     ) external authOrManager(poolId, scId) {
         AssetId assetId = poolManager.assetToId(asset, tokenId);
-        _deposit(poolId, scId, assetId, asset, tokenId, provider, amount, pricePoolPerAsset, false);
+        _noteDeposit(poolId, scId, assetId, asset, tokenId, provider, amount, pricePoolPerAsset);
     }
 
     /// @inheritdoc IBalanceSheet
@@ -120,19 +122,29 @@ contract BalanceSheet is Auth, Recoverable, IBalanceSheet, IBalanceSheetGatewayH
     }
 
     /// @inheritdoc IBalanceSheet
-    function revoke(PoolId poolId, ShareClassId scId, address from, D18 pricePoolPerShare, uint128 shares)
-        external
-        authOrManager(poolId, scId)
-    {
-        _revoke(poolId, scId, from, pricePoolPerShare, shares);
-    }
-
-    /// @inheritdoc IBalanceSheet
     function issue(PoolId poolId, ShareClassId scId, address to, D18 pricePoolPerShare, uint128 shares)
         external
         authOrManager(poolId, scId)
     {
         _issue(poolId, scId, to, pricePoolPerShare, shares);
+    }
+
+    /// @inheritdoc IBalanceSheet
+    function revoke(PoolId poolId, ShareClassId scId, address from, D18 pricePoolPerShare, uint128 shares)
+        external
+        authOrManager(poolId, scId)
+    {
+        _noteRevoke(poolId, scId, from, pricePoolPerShare, shares);
+        _executeRevoke(poolId, scId, from, shares);
+    }
+
+    /// @inheritdoc IBalanceSheet
+    /// @dev This function is mostly useful to keep higher level integrations CEI adherent.
+    function noteRevoke(PoolId poolId, ShareClassId scId, address from, D18 pricePoolPerShare, uint128 shares)
+        external
+        authOrManager(poolId, scId)
+    {
+        _noteRevoke(poolId, scId, from, pricePoolPerShare, shares);
     }
 
     /// --- IBalanceSheetHandler ---
@@ -143,11 +155,11 @@ contract BalanceSheet is Auth, Recoverable, IBalanceSheet, IBalanceSheetGatewayH
         AssetId assetId,
         address provider,
         uint128 amount,
-        D18 priceAssetPerShare
+        D18 pricePoolPerAsset
     ) external auth {
         (address asset, uint256 tokenId) = poolManager.idToAsset(assetId);
-
-        _deposit(poolId, scId, assetId, asset, tokenId, provider, amount, priceAssetPerShare, true);
+        _noteDeposit(poolId, scId, assetId, asset, tokenId, provider, amount, pricePoolPerAsset);
+        _executeDeposit(poolId, asset, tokenId, provider, amount);
     }
 
     /// @inheritdoc IBalanceSheetGatewayHandler
@@ -157,10 +169,10 @@ contract BalanceSheet is Auth, Recoverable, IBalanceSheet, IBalanceSheetGatewayH
         AssetId assetId,
         address receiver,
         uint128 amount,
-        D18 priceAssetPerShare
+        D18 pricePoolPerAsset
     ) external auth {
         (address asset, uint256 tokenId) = poolManager.idToAsset(assetId);
-        _withdraw(poolId, scId, assetId, asset, tokenId, receiver, amount, priceAssetPerShare);
+        _withdraw(poolId, scId, assetId, asset, tokenId, receiver, amount, pricePoolPerAsset);
     }
 
     /// @inheritdoc IBalanceSheetGatewayHandler
@@ -176,42 +188,55 @@ contract BalanceSheet is Auth, Recoverable, IBalanceSheet, IBalanceSheetGatewayH
         external
         auth
     {
-        _revoke(poolId, scId, from, pricePoolPerShare, shares);
-    }
-
-    /// @inheritdoc IBalanceSheetGatewayHandler
-    function approvedDeposits(PoolId poolId, ShareClassId scId, AssetId assetId, uint128 assetAmount) external auth {
-        (address asset, uint256 tokenId) = poolManager.idToAsset(assetId);
-        Prices memory prices = sharePriceProvider.prices(poolId.raw(), scId.raw(), assetId.raw(), asset, tokenId);
-
-        IPoolEscrow escrow = poolEscrowProvider.escrow(poolId.raw());
-        escrow.deposit(scId.raw(), asset, tokenId, assetAmount);
-        sender.sendUpdateHoldingAmount(poolId, scId, assetId, address(escrow), assetAmount, prices.poolPerAsset, true);
-    }
-
-    /// @inheritdoc IBalanceSheetGatewayHandler
-    function revokedShares(PoolId poolId, ShareClassId scId, AssetId assetId, uint128 assetAmount) external auth {
-        (address asset, uint256 tokenId) = poolManager.idToAsset(assetId);
-
-        // Lock assets to ensure they are not withdrawn and are available for the redeeming user
-        poolEscrowProvider.escrow(poolId.raw()).reserveIncrease(scId.raw(), asset, tokenId, assetAmount);
+        _noteRevoke(poolId, scId, from, pricePoolPerShare, shares);
+        _executeRevoke(poolId, scId, from, shares);
     }
 
     // --- Internal ---
     function _issue(PoolId poolId, ShareClassId scId, address to, D18 pricePoolPerShare, uint128 shares) internal {
-        IShareToken token = poolManager.shareToken(poolId, scId);
-        token.mint(address(to), shares);
-
         emit Issue(poolId, scId, to, pricePoolPerShare, shares);
         sender.sendUpdateShares(poolId, scId, to, pricePoolPerShare, shares, true);
+        IShareToken token = poolManager.shareToken(poolId, scId);
+        token.mint(to, shares);
     }
 
-    function _revoke(PoolId poolId, ShareClassId scId, address from, D18 pricePoolPerShare, uint128 shares) internal {
-        IShareToken token = poolManager.shareToken(poolId, scId);
-        token.burn(address(from), shares);
-
+    function _noteRevoke(PoolId poolId, ShareClassId scId, address from, D18 pricePoolPerShare, uint128 shares)
+        internal
+    {
         emit Revoke(poolId, scId, from, pricePoolPerShare, shares);
         sender.sendUpdateShares(poolId, scId, from, pricePoolPerShare, shares, false);
+    }
+
+    function _executeRevoke(PoolId poolId, ShareClassId scId, address from, uint128 shares) internal {
+        IShareToken token = poolManager.shareToken(poolId, scId);
+        token.burn(from, shares);
+    }
+
+    function _noteDeposit(
+        PoolId poolId,
+        ShareClassId scId,
+        AssetId assetId,
+        address asset,
+        uint256 tokenId,
+        address provider,
+        uint128 amount,
+        D18 pricePoolPerAsset
+    ) internal {
+        IPoolEscrow escrow = poolEscrowProvider.escrow(poolId.raw());
+        escrow.deposit(scId.raw(), asset, tokenId, amount);
+        emit Deposit(poolId, scId, asset, tokenId, provider, amount, pricePoolPerAsset);
+        sender.sendUpdateHoldingAmount(poolId, scId, assetId, provider, amount, pricePoolPerAsset, true);
+    }
+
+    function _executeDeposit(PoolId poolId, address asset, uint256 tokenId, address provider, uint128 amount)
+        internal
+    {
+        IPoolEscrow escrow = poolEscrowProvider.escrow(poolId.raw());
+        if (tokenId == 0) {
+            SafeTransferLib.safeTransferFrom(asset, provider, address(escrow), amount);
+        } else {
+            IERC6909(asset).transferFrom(provider, address(escrow), tokenId, amount);
+        }
     }
 
     function _withdraw(
@@ -226,45 +251,9 @@ contract BalanceSheet is Auth, Recoverable, IBalanceSheet, IBalanceSheetGatewayH
     ) internal {
         IPoolEscrow escrow = poolEscrowProvider.escrow(poolId.raw());
         escrow.withdraw(scId.raw(), asset, tokenId, amount);
-
-        if (tokenId == 0) {
-            SafeTransferLib.safeTransferFrom(asset, address(escrow), receiver, amount);
-        } else {
-            IERC6909(asset).transferFrom(address(escrow), receiver, tokenId, amount);
-        }
-
-        emit Withdraw(poolId, scId, asset, tokenId, receiver, amount, pricePoolPerAsset, uint64(block.timestamp));
+        emit Withdraw(poolId, scId, asset, tokenId, receiver, amount, pricePoolPerAsset);
         sender.sendUpdateHoldingAmount(poolId, scId, assetId, receiver, amount, pricePoolPerAsset, false);
-    }
-
-    function _deposit(
-        PoolId poolId,
-        ShareClassId scId,
-        AssetId assetId,
-        address asset,
-        uint256 tokenId,
-        address provider,
-        uint128 amount,
-        D18 pricePoolPerAsset,
-        bool preDepositTransfer
-    ) internal {
-        IPoolEscrow escrow = poolEscrowProvider.escrow(poolId.raw());
-
-        if (preDepositTransfer) {
-            if (tokenId == 0) {
-                SafeTransferLib.safeTransferFrom(asset, provider, address(escrow), amount);
-            } else {
-                IERC6909(asset).transferFrom(provider, address(escrow), tokenId, amount);
-            }
-        }
-        emit Deposit(poolId, scId, asset, tokenId, provider, amount, pricePoolPerAsset, uint64(block.timestamp));
-
-        // Do escrow balance sufficiency check only if we executed the transfer
-        if (preDepositTransfer) {
-            escrow.deposit(scId.raw(), asset, tokenId, amount);
-        } else {
-            escrow.noteDeposit(scId.raw(), asset, tokenId, amount);
-        }
-        sender.sendUpdateHoldingAmount(poolId, scId, assetId, provider, amount, pricePoolPerAsset, true);
+        // TODO: More specific error would be great here
+        escrow.authTransferTo(asset, tokenId, receiver, amount);
     }
 }

--- a/src/vaults/SyncDepositVault.sol
+++ b/src/vaults/SyncDepositVault.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {BaseVault, AsyncRedeemVault, BaseSyncDepositVault} from "src/vaults/BaseVaults.sol";
+import {BaseVault, BaseAsyncRedeemVault, BaseSyncDepositVault} from "src/vaults/BaseVaults.sol";
 import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
 import {ISyncRequests} from "src/vaults/interfaces/investments/ISyncRequests.sol";
 import {IPoolEscrowProvider} from "src/vaults/interfaces/factories/IPoolEscrowFactory.sol";
@@ -16,7 +16,7 @@ import "src/vaults/interfaces/IERC7575.sol";
 ///
 /// @dev    Each vault issues shares of Centrifuge share class tokens as restricted ERC-20 or ERC-6909 tokens
 ///         against asset deposits based on the current share price.
-contract SyncDepositVault is BaseSyncDepositVault, AsyncRedeemVault {
+contract SyncDepositVault is BaseSyncDepositVault, BaseAsyncRedeemVault {
     constructor(
         uint64 poolId_,
         bytes16 scId_,
@@ -30,14 +30,14 @@ contract SyncDepositVault is BaseSyncDepositVault, AsyncRedeemVault {
     )
         BaseVault(poolId_, scId_, asset_, tokenId_, token_, root_, syncDepositManager_, poolEscrowProvider_)
         BaseSyncDepositVault(syncDepositManager_)
-        AsyncRedeemVault(asyncRedeemManager_)
+        BaseAsyncRedeemVault(asyncRedeemManager_)
     {}
 
     /// @inheritdoc IERC165
     function supportsInterface(bytes4 interfaceId)
         public
         pure
-        override(AsyncRedeemVault, BaseSyncDepositVault)
+        override(BaseAsyncRedeemVault, BaseSyncDepositVault)
         returns (bool)
     {
         return super.supportsInterface(interfaceId);

--- a/src/vaults/SyncRequests.sol
+++ b/src/vaults/SyncRequests.sol
@@ -55,7 +55,9 @@ contract SyncRequests is BaseInvestmentManager, ISyncRequests {
     mapping(uint64 poolId => mapping(bytes16 scId => mapping(address asset => mapping(uint256 tokenId => IERC7726))))
         public valuation;
 
-    constructor(address root_, address deployer) BaseInvestmentManager(root_, deployer) {}
+    constructor(IPoolEscrow globalEscrow_, address root_, address deployer)
+        BaseInvestmentManager(globalEscrow_, root_, deployer)
+    {}
 
     // --- Administration ---
     /// @inheritdoc IBaseInvestmentManager
@@ -108,10 +110,10 @@ contract SyncRequests is BaseInvestmentManager, ISyncRequests {
         vault[poolId][scId][assetId] = vaultAddr;
 
         (, uint256 tokenId) = poolManager.idToAsset(AssetId.wrap(assetId));
-        maxReserve[poolId][scId][asset_][tokenId] = type(uint128).max;
+        setMaxReserve(poolId, scId, asset_, tokenId, type(uint128).max);
 
         IAuth(token).rely(vaultAddr);
-        IShareToken(token).updateVault(vault_.asset(), vaultAddr);
+        IShareToken(token).updateVault(asset_, vaultAddr);
         rely(vaultAddr);
 
         (VaultKind vaultKind_, address secondaryManager) = vaultKind(vaultAddr);
@@ -154,6 +156,7 @@ contract SyncRequests is BaseInvestmentManager, ISyncRequests {
         auth
         returns (uint256 assets)
     {
+        require(maxMint(vaultAddr, owner) >= shares, ExceedsMaxMint());
         assets = previewMint(vaultAddr, owner, shares);
 
         _issueShares(vaultAddr, shares.toUint128(), receiver, owner, assets.toUint128());
@@ -212,15 +215,18 @@ contract SyncRequests is BaseInvestmentManager, ISyncRequests {
 
     // --- IDepositManager Reads ---
     /// @inheritdoc IDepositManager
-    function maxMint(address, /* vaultAddr */ address /* owner */ ) public pure returns (uint256) {
-        // TODO(follow-up PR): implement rate limit
-        return type(uint256).max;
+    function maxMint(address vaultAddr, address /* owner */ ) public view returns (uint256) {
+        SyncDepositVault vault_ = SyncDepositVault(vaultAddr);
+        VaultDetails memory vaultDetails = poolManager.vaultDetails(address(vault_));
+        uint128 maxAssets = _maxDeposit(vault_.poolId(), vault_.scId(), vaultDetails.asset, vaultDetails.tokenId);
+        return convertToShares(vaultAddr, maxAssets);
     }
 
     /// @inheritdoc IDepositManager
-    function maxDeposit(address, /* vaultAddr */ address /* owner */ ) public pure returns (uint256) {
-        // TODO(follow-up PR): implement rate limit
-        return type(uint256).max;
+    function maxDeposit(address vaultAddr, address /* owner */ ) public view returns (uint256) {
+        SyncDepositVault vault_ = SyncDepositVault(vaultAddr);
+        VaultDetails memory vaultDetails = poolManager.vaultDetails(address(vault_));
+        return _maxDeposit(vault_.poolId(), vault_.scId(), vaultDetails.asset, vaultDetails.tokenId);
     }
 
     // --- IVaultManager Views ---
@@ -315,35 +321,33 @@ contract SyncRequests is BaseInvestmentManager, ISyncRequests {
         ShareClassId scId = ShareClassId.wrap(vault_.scId());
         VaultDetails memory vaultDetails = poolManager.vaultDetails(vaultAddr);
 
-        _checkMaxReserve(poolId, scId, vaultDetails.asset, vaultDetails.tokenId, depositAssetAmount);
-
         Prices memory priceData =
             prices(poolId.raw(), scId.raw(), vaultDetails.assetId.raw(), vault_.asset(), vaultDetails.tokenId);
 
         // Mint shares for receiver & notify CP about issued shares
         balanceSheet.issue(poolId, scId, receiver, priceData.poolPerShare, shares);
 
-        // Notice deposit of shares and notify CP about holding update
-        // NOTE: Does not transfer shares from escrow to owner and assumes that to be handled elsewhere, i.e. in
-        // SyncDepositVault.{mint, deposit}
+        // NOTE:
+        // - Transfer is handled by the vault to the pool escrow afterwards
         balanceSheet.noteDeposit(
-            poolId, scId, vaultDetails.asset, vaultDetails.tokenId, owner, depositAssetAmount, priceData.poolPerAsset
+            poolId, scId, vaultDetails.asset, vaultDetails.tokenId, receiver, depositAssetAmount, priceData.poolPerAsset
         );
     }
 
-    function _checkMaxReserve(
-        PoolId poolId,
-        ShareClassId scId,
-        address asset,
-        uint256 tokenId,
-        uint128 depositAssetAmount
-    ) internal view {
-        uint256 availableBalance =
-            poolEscrowProvider.escrow(poolId.raw()).availableBalanceOf(scId.raw(), asset, tokenId);
-        require(
-            availableBalance + depositAssetAmount <= maxReserve[poolId.raw()][scId.raw()][asset][tokenId],
-            ExceedsMaxReserve()
-        );
+    function _maxDeposit(uint64 poolId, bytes16 scId, address asset, uint256 tokenId)
+        internal
+        view
+        returns (uint128 maxDeposit_)
+    {
+        uint128 availableBalance =
+            poolEscrowProvider.escrow(poolId).availableBalanceOf(scId, asset, tokenId).toUint128();
+        uint128 maxReserve_ = maxReserve[poolId][scId][asset][tokenId];
+
+        if (maxReserve_ < availableBalance) {
+            maxDeposit_ = 0;
+        } else {
+            maxDeposit_ = maxReserve_ - availableBalance;
+        }
     }
 
     function _priceAssetPerShare(uint64 poolId, bytes16 scId, uint128 assetId, address asset, uint256 tokenId)

--- a/src/vaults/interfaces/IBalanceSheet.sol
+++ b/src/vaults/interfaces/IBalanceSheet.sol
@@ -37,7 +37,6 @@ interface IBalanceSheet {
     // --- Errors ---
     error FileUnrecognizedParam();
 
-    /// @notice Overloaded increase with asset transfer
     function deposit(
         PoolId poolId,
         ShareClassId scId,
@@ -48,7 +47,6 @@ interface IBalanceSheet {
         D18 pricePoolPerAsset
     ) external;
 
-    /// @notice Overloaded increase without asset transfer
     function noteDeposit(
         PoolId poolId,
         ShareClassId scId,
@@ -72,4 +70,7 @@ interface IBalanceSheet {
     function issue(PoolId poolId, ShareClassId scId, address to, D18 pricePoolPerShare, uint128 shares) external;
 
     function revoke(PoolId poolId, ShareClassId scId, address from, D18 pricePoolPerShare, uint128 shares) external;
+
+    function noteRevoke(PoolId poolId, ShareClassId scId, address from, D18 pricePoolPerShare, uint128 shares)
+        external;
 }

--- a/src/vaults/interfaces/IEscrow.sol
+++ b/src/vaults/interfaces/IEscrow.sol
@@ -19,6 +19,14 @@ interface IEscrow {
     /// @param value The new total allowance
     event Approve(address indexed asset, uint256 indexed tokenId, address indexed spender, uint256 value);
 
+    /// @notice Emitted when an authTransferTo is made
+    /// @dev Needed as allowances increase attack surface
+    event AuthTransferTo(address indexed asset, uint256 indexed tokenId, address reciver, uint256 value);
+
+    /// @notice Emitted when an authTransferTo is made
+    /// @dev Needed as allowances increase attack surface
+    event AuthTransferTo(address indexed asset, address reciver, uint256 value);
+
     // --- Token approvals ---
     /// @notice sets the allowance of `spender` to `type(uint256).max` if it is currently 0
     function approveMax(address asset, uint256 tokenId, address spender) external;
@@ -31,6 +39,12 @@ interface IEscrow {
 
     /// @notice sets the allowance of `spender` to 0
     function unapprove(address asset, address spender) external;
+
+    /// @notice
+    function authTransferTo(address asset, uint256 tokenId, address receiver, uint256 value) external;
+
+    /// @notice
+    function authTransferTo(address asset, address receiver, uint256 value) external;
 }
 
 struct Holding {
@@ -110,17 +124,6 @@ interface IPoolEscrow is IEscrow, IRecoverable {
     /// @param tokenId The id of the asset - 0 for ERC20
     /// @param value The amount to deposit
     function deposit(bytes16 scId, address asset, uint256 tokenId, uint256 value) external;
-
-    /// @notice Notices the deposit of `value` of `asset` in underlying `poolId` and given `scId`
-    ///
-    /// @dev NOTE: Assumes to not perform sufficiency checks in order to support scenarios in which the actual transfer
-    /// occurs after noting a deposit for security reasons.
-    ///
-    /// @param scId The id of the share class
-    /// @param asset The address of the asset to be deposited
-    /// @param tokenId The id of the asset - 0 for ERC20
-    /// @param value The amount to deposit
-    function noteDeposit(bytes16 scId, address asset, uint256 tokenId, uint256 value) external;
 
     /// @notice Withdraws `value` of `asset` in underlying `poolId` and given `scId`
     /// @dev MUST ensure that reserved amounts are not withdrawn

--- a/src/vaults/interfaces/investments/IBaseInvestmentManager.sol
+++ b/src/vaults/interfaces/investments/IBaseInvestmentManager.sol
@@ -2,6 +2,8 @@
 pragma solidity 0.8.28;
 
 import {IPoolManager} from "src/vaults/interfaces/IPoolManager.sol";
+import {IPoolEscrow, IEscrow} from "src/vaults/interfaces/IEscrow.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
 
 interface IBaseInvestmentManager {
     // --- Events ---
@@ -26,4 +28,10 @@ interface IBaseInvestmentManager {
 
     /// @notice Returns the PoolManager contract address.
     function poolManager() external view returns (IPoolManager poolManager);
+
+    /// @notice The global escrow used for funds that are not yet free to be used for a specific pool
+    function globalEscrow() external view returns (IEscrow escrow);
+
+    /// @notice Escrow per pool. Funds are associated to a specific pool
+    function poolEscrow(PoolId poolId) external view returns (IPoolEscrow);
 }

--- a/src/vaults/interfaces/investments/ISyncRequests.sol
+++ b/src/vaults/interfaces/investments/ISyncRequests.sol
@@ -15,12 +15,12 @@ interface ISyncRequests is ISyncDepositManager, ISharePriceProvider, IUpdateCont
     );
 
     error ExceedsMaxDeposit();
+    error ExceedsMaxMint();
     error AssetNotAllowed();
     error VaultDoesNotExist();
     error VaultAlreadyExists();
     error ShareTokenDoesNotExist();
     error AssetMismatch();
-    error ExceedsMaxReserve();
 
     /// @notice Sets the valuation for a specific pool, share class and asset.
     ///

--- a/src/vaults/legacy/LegacyVaultAdapter.sol
+++ b/src/vaults/legacy/LegacyVaultAdapter.sol
@@ -55,7 +55,7 @@ contract LegacyVaultAdapter is AsyncVault, ILegacyVaultAdapter, IInvestmentManag
 
     // --- IInvestmentManager impl ---
     function escrow() public view returns (address) {
-        return address(_poolEscrowProvider.escrow(poolId));
+        return address(manager().globalEscrow());
     }
 
     /// @inheritdoc IInvestmentManager

--- a/test/vaults/integration/BalanceSheet.t.sol
+++ b/test/vaults/integration/BalanceSheet.t.sol
@@ -181,39 +181,6 @@ contract BalanceSheetTest is BaseTest {
         assertEq(erc20.balanceOf(address(this)), 0);
     }
 
-    function testNoteDeposit() public {
-        vm.prank(randomUser);
-        vm.expectRevert(IAuth.NotAuthorized.selector);
-        balanceSheet.deposit(
-            POOL_A, defaultTypedShareClassId, address(erc20), erc20TokenId, address(this), defaultAmount, d18(100, 5)
-        );
-
-        vm.expectEmit();
-        emit IBalanceSheet.Deposit(
-            POOL_A,
-            defaultTypedShareClassId,
-            address(erc20),
-            erc20TokenId,
-            address(this),
-            defaultAmount,
-            d18(100, 5),
-            uint64(block.timestamp)
-        );
-        balanceSheet.noteDeposit(
-            POOL_A, defaultTypedShareClassId, address(erc20), erc20TokenId, address(this), defaultAmount, d18(100, 5)
-        );
-
-        // Ensure no balance transfer occurred but escrow holding was incremented nevertheless
-        assertEq(erc20.balanceOf(address(this)), 0);
-        assertEq(erc20.balanceOf(address(poolEscrowFactory.escrow(POOL_A.raw()))), 0);
-        assertEq(
-            poolEscrowFactory.escrow(POOL_A.raw()).availableBalanceOf(
-                defaultTypedShareClassId.raw(), address(erc20), erc20TokenId
-            ),
-            defaultAmount
-        );
-    }
-
     function testWithdraw() public {
         testDeposit();
 

--- a/test/vaults/integration/SyncDeposit.t.sol
+++ b/test/vaults/integration/SyncDeposit.t.sol
@@ -94,8 +94,12 @@ contract SyncDepositTest is SyncDepositTestHelper {
         uint256 assetsForShares = syncVault.previewMint(shares);
         assertEq(shares, amount / assetsPerShare, "shares, amount / assetsPerShare");
         assertEq(assetsForShares, amount, "assetsForShares, amount");
-        assertEq(syncVault.maxDeposit(self), type(uint256).max, "syncVault.maxDeposit(self), type(uint256).max");
-        assertEq(syncVault.maxMint(self), type(uint256).max, "syncVault.maxMint(self), type(uint256).max");
+        assertEq(syncVault.maxDeposit(self), MAX_UINT128, "syncVault.maxDeposit(self) != type(uint128).max");
+        assertEq(
+            syncVault.maxMint(self),
+            syncVault.convertToShares(MAX_UINT128),
+            "syncVault.maxMint(self) != convertToShares(MAX_UINT128)"
+        );
 
         // Will fail - user not member: can not send funds
         vm.expectRevert(IHook.TransferBlocked.selector);
@@ -113,7 +117,7 @@ contract SyncDepositTest is SyncDepositTestHelper {
         // Will fail - above max reserve
         centrifugeChain.updateMaxReserve(syncVault.poolId(), syncVault.scId(), address(syncVault), uint128(amount / 2));
 
-        vm.expectRevert(ISyncRequests.ExceedsMaxReserve.selector);
+        vm.expectRevert(ISyncRequests.ExceedsMaxDeposit.selector);
         syncVault.deposit(amount, self);
 
         centrifugeChain.updateMaxReserve(syncVault.poolId(), syncVault.scId(), address(syncVault), uint128(amount));

--- a/test/vaults/unit/Escrow.t.sol
+++ b/test/vaults/unit/Escrow.t.sol
@@ -126,17 +126,6 @@ contract PoolEscrowTestBase is EscrowTestBase {
         assertEq(escrow.availableBalanceOf(scId, asset, tokenId), 500, "holdings should be 500 after deposit");
     }
 
-    function _testNoteDeposit(uint64 poolId, bytes16 scId, uint256 tokenId) internal {
-        address asset = _asset(tokenId);
-        PoolEscrow escrow = new PoolEscrow(poolId, address(this));
-
-        vm.expectEmit();
-        emit IPoolEscrow.Deposit(asset, tokenId, poolId, scId, 300);
-        escrow.noteDeposit(scId, asset, tokenId, 300);
-
-        assertEq(escrow.availableBalanceOf(scId, asset, tokenId), 300, "holdings should be 300 after noting deposit");
-    }
-
     function _testReserveIncrease(uint64 poolId, bytes16 scId, uint256 tokenId) internal {
         address asset = _asset(tokenId);
         PoolEscrow escrow = new PoolEscrow(poolId, address(this));
@@ -237,12 +226,6 @@ contract PoolEscrowTestERC20 is PoolEscrowTestBase {
         _testDeposit(poolId, scId, tokenId);
     }
 
-    function testNoteDeposit(uint64 poolId, bytes16 scId) public {
-        _testNoteDeposit(poolId, scId, tokenId);
-
-        assertEq(erc20.balanceOf(address(escrow)), 0, "Escrow should not hold any tokens after noting");
-    }
-
     function testReserveIncrease(uint64 poolId, bytes16 scId) public {
         _testReserveIncrease(poolId, scId, tokenId);
     }
@@ -267,12 +250,6 @@ contract PoolEscrowTestERC6909 is PoolEscrowTestBase {
         _testDeposit(poolId, scId, tokenId);
 
         assertEq(erc6909.balanceOf(address(escrow), tokenId), 0, "Escrow should not hold any tokens after noting");
-    }
-
-    function testNoteDeposit(uint64 poolId, bytes16 scId, uint8 tokenId_) public {
-        uint256 tokenId = uint256(bound(tokenId_, 2, 18));
-
-        _testNoteDeposit(poolId, scId, tokenId);
     }
 
     function testReserveIncrease(uint64 poolId, bytes16 scId, uint8 tokenId_) public {


### PR DESCRIPTION
High level changes
1. Escrow `authTransferTo` instead of BSM having infinite allowance on PoolEscrow
2. Burn / mint shares not in `Fulfilled*` but in `{Issued, Revoked}Shares`
3. For async flow, pending amounts are held in a global escrow and transferred to the user during claiming