### PR TITLE
Hub: Expose BSM messages

### DIFF
--- a/src/common/MessageDispatcher.sol
+++ b/src/common/MessageDispatcher.sol
@@ -401,6 +401,65 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
     }
 
     /// @inheritdoc IPoolMessageSender
+    function sendTriggerUpdateHoldingAmount(
+        PoolId poolId,
+        ShareClassId scId,
+        AssetId assetId,
+        address who,
+        uint128 amount,
+        bool isIncrease
+    ) external auth {
+        if (assetId.centrifugeId() == localCentrifugeId) {
+            if (isIncrease) {
+                balanceSheet.triggerDeposit(poolId, scId, assetId, who, amount);
+            } else {
+                balanceSheet.triggerWithdraw(poolId, scId, assetId, who, amount);
+            }
+        } else {
+            gateway.send(
+                assetId.centrifugeId(),
+                MessageLib.TriggerUpdateHoldingAmount({
+                    poolId: poolId.raw(),
+                    scId: scId.raw(),
+                    assetId: assetId.raw(),
+                    who: who.toBytes32(),
+                    amount: amount,
+                    isIncrease: isIncrease
+                }).serialize()
+            );
+        }
+    }
+
+    /// @inheritdoc IPoolMessageSender
+    function sendTriggerUpdateShares(
+        uint16 centrifugeId,
+        PoolId poolId,
+        ShareClassId scId,
+        address who,
+        uint128 shares,
+        bool isIssuance
+    ) external auth {
+        if (centrifugeId == localCentrifugeId) {
+            if (isIssuance) {
+                balanceSheet.triggerIssueShares(poolId, scId, who, shares);
+            } else {
+                balanceSheet.triggerRevokeShares(poolId, scId, who, shares);
+            }
+        } else {
+            gateway.send(
+                centrifugeId,
+                MessageLib.TriggerUpdateShares({
+                    poolId: poolId.raw(),
+                    scId: scId.raw(),
+                    who: who.toBytes32(),
+                    shares: shares,
+                    isIssuance: isIssuance
+                }).serialize()
+            );
+        }
+    }
+
+    /// @inheritdoc IPoolMessageSender
     function sendTriggerSubmitQueuedShares(uint16 centrifugeId, PoolId poolId, ShareClassId scId) external auth {
         if (centrifugeId == localCentrifugeId) {
             balanceSheet.submitQueuedShares(poolId, scId);

--- a/src/common/interfaces/IGatewaySenders.sol
+++ b/src/common/interfaces/IGatewaySenders.sol
@@ -155,6 +155,26 @@ interface IPoolMessageSender is ILocalCentrifugeId {
     ) external;
 
     /// @notice Creates and send the message
+    function sendTriggerUpdateHoldingAmount(
+        PoolId poolId,
+        ShareClassId scId,
+        AssetId assetId,
+        address who,
+        uint128 amount,
+        bool isIncrease
+    ) external;
+
+    /// @notice Creates and send the message
+    function sendTriggerUpdateShares(
+        uint16 centrifugeId,
+        PoolId poolId,
+        ShareClassId scId,
+        address who,
+        uint128 shares,
+        bool isIssuance
+    ) external;
+
+    /// @notice Creates and send the message
     function sendTriggerSubmitQueuedShares(uint16 centrifugeId, PoolId poolId, ShareClassId scId) external;
 
     /// @notice Creates and send the message

--- a/src/common/libraries/MessageLib.sol
+++ b/src/common/libraries/MessageLib.sol
@@ -117,7 +117,7 @@ library MessageLib {
         (89  << uint8(MessageType.FulfilledCancelRedeemRequest) * 8) +
         (114 << uint8(MessageType.UpdateHoldingAmount) * 8) +
         (50  << uint8(MessageType.UpdateShares) * 8) +
-        (106 << uint8(MessageType.TriggerUpdateHoldingAmount) * 8) +
+        (90 << uint8(MessageType.TriggerUpdateHoldingAmount) * 8) +
         (74 << uint8(MessageType.TriggerUpdateShares) * 8);
 
     // forgefmt: disable-next-item
@@ -1146,7 +1146,6 @@ library MessageLib {
         uint128 assetId;
         bytes32 who;
         uint128 amount;
-        uint128 pricePerUnit;
         bool isIncrease; // Signals whether this is an increase or a decrease
     }
 
@@ -1163,21 +1162,13 @@ library MessageLib {
             assetId: data.toUint128(25),
             who: data.toBytes32(41),
             amount: data.toUint128(73),
-            pricePerUnit: data.toUint128(89),
-            isIncrease: data.toBool(105)
+            isIncrease: data.toBool(89)
         });
     }
 
     function serialize(TriggerUpdateHoldingAmount memory t) internal pure returns (bytes memory) {
         return abi.encodePacked(
-            MessageType.TriggerUpdateHoldingAmount,
-            t.poolId,
-            t.scId,
-            t.assetId,
-            t.who,
-            t.amount,
-            t.pricePerUnit,
-            t.isIncrease
+            MessageType.TriggerUpdateHoldingAmount, t.poolId, t.scId, t.assetId, t.who, t.amount, t.isIncrease
         );
     }
 

--- a/src/hub/Hub.sol
+++ b/src/hub/Hub.sol
@@ -231,6 +231,34 @@ contract Hub is Multicall, Auth, Recoverable, IHub, IHubGatewayHandler {
     }
 
     /// @inheritdoc IHub
+    function sendTriggerUpdateHoldingAmount(
+        PoolId poolId,
+        ShareClassId scId,
+        AssetId assetId,
+        address who,
+        uint128 amount,
+        bool isIncrease
+    ) public payable {
+        _protectedAndPaid(poolId);
+
+        sender.sendTriggerUpdateHoldingAmount(poolId, scId, assetId, who, amount, isIncrease);
+    }
+
+    /// @inheritdoc IHub
+    function sendTriggerUpdateShares(
+        uint16 centrifugeId,
+        PoolId poolId,
+        ShareClassId scId,
+        address who,
+        uint128 shares,
+        bool isIssuance
+    ) public payable {
+        _protectedAndPaid(poolId);
+
+        sender.sendTriggerUpdateShares(centrifugeId, poolId, scId, who, shares, isIssuance);
+    }
+
+    /// @inheritdoc IHub
     function sendTriggerSubmitQueuedShares(uint16 centrifugeId, PoolId poolId, ShareClassId scId) public payable {
         _protectedAndPaid(poolId);
 

--- a/src/hub/interfaces/IHub.sol
+++ b/src/hub/interfaces/IHub.sol
@@ -191,6 +191,26 @@ interface IHub {
         D18 navPoolPerShare
     ) external payable returns (uint128 revokedShareAmount, uint128 payoutAssetAmount, uint128 payoutPoolAmount);
 
+    /// @notice Tells the BalanceSheet to deposit/withdraw assets.
+    function sendTriggerUpdateHoldingAmount(
+        PoolId poolId,
+        ShareClassId scId,
+        AssetId assetId,
+        address who,
+        uint128 amount,
+        bool isIncrease
+    ) external payable;
+
+    /// @notice Tells the BalanceSheet to issue/revoke shares.
+    function sendTriggerUpdateShares(
+        uint16 centrifugeId,
+        PoolId poolId,
+        ShareClassId scId,
+        address who,
+        uint128 shares,
+        bool isIssuance
+    ) external payable;
+
     /// @notice Tell the BalanceSheet to send a message back with the queued issued/revoked shares.
     function sendTriggerSubmitQueuedShares(uint16 centrifugeId, PoolId poolId, ShareClassId scId) external payable;
 

--- a/test/common/unit/libraries/MessageLib.t.sol
+++ b/test/common/unit/libraries/MessageLib.t.sol
@@ -641,7 +641,6 @@ contract TestMessageLibIdentities is Test {
         uint128 assetId,
         bytes32 who,
         uint128 amount,
-        uint128 pricePerUnit,
         bool isIncrease
     ) public pure {
         MessageLib.TriggerUpdateHoldingAmount memory a = MessageLib.TriggerUpdateHoldingAmount({
@@ -650,7 +649,6 @@ contract TestMessageLibIdentities is Test {
             assetId: assetId,
             who: who,
             amount: amount,
-            pricePerUnit: pricePerUnit,
             isIncrease: isIncrease
         });
 
@@ -661,7 +659,6 @@ contract TestMessageLibIdentities is Test {
         assertEq(a.assetId, b.assetId);
         assertEq(a.who, b.who);
         assertEq(a.amount, b.amount);
-        assertEq(a.pricePerUnit, b.pricePerUnit);
         assertEq(a.isIncrease, b.isIncrease);
 
         assertEq(a.serialize().messageLength(), a.serialize().length);

--- a/test/hub/unit/Hub.t.sol
+++ b/test/hub/unit/Hub.t.sol
@@ -175,6 +175,12 @@ contract TestMainMethodsChecks is TestCommon {
         hub.updateJournal(POOL_A, EMPTY, EMPTY);
 
         vm.expectRevert(IHub.NotManager.selector);
+        hub.sendTriggerUpdateHoldingAmount(POOL_A, ShareClassId.wrap(0), AssetId.wrap(0), address(0), 0, false);
+
+        vm.expectRevert(IHub.NotManager.selector);
+        hub.sendTriggerUpdateShares(0, POOL_A, ShareClassId.wrap(0), address(0), 0, false);
+
+        vm.expectRevert(IHub.NotManager.selector);
         hub.sendTriggerSubmitQueuedShares(0, POOL_A, ShareClassId.wrap(0));
 
         vm.expectRevert(IHub.NotManager.selector);


### PR DESCRIPTION
Expose TriggerUpdateHoldingAmount and TriggerUpdateShares.
Removed unused pricePerAsset from TriggerUpdateHoldingAmount