### PR TITLE
Use `authTransferFrom` everywhere, add sync support to `VaultRouter`

### DIFF
--- a/script/VaultsDeployer.s.sol
+++ b/script/VaultsDeployer.s.sol
@@ -61,7 +61,7 @@ contract VaultsDeployer is CommonDeployer {
         vaultFactories[1] = syncDepositVaultFactory;
 
         poolManager = new PoolManager(tokenFactory, vaultFactories, deployer);
-        balanceSheet = new BalanceSheet(deployer);
+        balanceSheet = new BalanceSheet(root, deployer);
         vaultRouter = new VaultRouter(address(routerEscrow), gateway, poolManager, messageDispatcher, deployer);
 
         // Hooks

--- a/snapshots/AsyncVault.json
+++ b/snapshots/AsyncVault.json
@@ -1,4 +1,4 @@
 {
   "fulfillDepositRequest": "1340833",
-  "requestDeposit": "516093"
+  "requestDeposit": "516101"
 }

--- a/snapshots/AsyncVault.json
+++ b/snapshots/AsyncVault.json
@@ -1,4 +1,4 @@
 {
-  "fulfillDepositRequest": "1340833",
+  "fulfillDepositRequest": "1340522",
   "requestDeposit": "516101"
 }

--- a/snapshots/AsyncVault.json
+++ b/snapshots/AsyncVault.json
@@ -1,4 +1,4 @@
 {
-  "fulfillDepositRequest": "1340855",
-  "requestDeposit": "516175"
+  "fulfillDepositRequest": "1340833",
+  "requestDeposit": "516093"
 }

--- a/snapshots/VaultRouter.json
+++ b/snapshots/VaultRouter.json
@@ -1,7 +1,7 @@
 {
-  "claimDeposit": "1580716",
+  "claimDeposit": "1580993",
   "enable": "60953",
-  "lockDepositRequest": "92358",
+  "lockDepositRequest": "92316",
   "requestDeposit": "553267",
-  "requestRedeem": "2514322"
+  "requestRedeem": "2514599"
 }

--- a/snapshots/VaultRouter.json
+++ b/snapshots/VaultRouter.json
@@ -2,6 +2,6 @@
   "claimDeposit": "1580716",
   "enable": "60953",
   "lockDepositRequest": "92358",
-  "requestDeposit": "553259",
-  "requestRedeem": "2514363"
+  "requestDeposit": "553267",
+  "requestRedeem": "2514322"
 }

--- a/snapshots/VaultRouter.json
+++ b/snapshots/VaultRouter.json
@@ -1,7 +1,7 @@
 {
-  "claimDeposit": "1580737",
+  "claimDeposit": "1580716",
   "enable": "60953",
   "lockDepositRequest": "92358",
   "requestDeposit": "553259",
-  "requestRedeem": "2514384"
+  "requestRedeem": "2514363"
 }

--- a/snapshots/VaultRouter.json
+++ b/snapshots/VaultRouter.json
@@ -1,7 +1,7 @@
 {
-  "claimDeposit": "1580716",
+  "claimDeposit": "1580737",
   "enable": "60953",
   "lockDepositRequest": "92358",
   "requestDeposit": "553259",
-  "requestRedeem": "2514363"
+  "requestRedeem": "2514384"
 }

--- a/snapshots/VaultRouter.json
+++ b/snapshots/VaultRouter.json
@@ -1,7 +1,7 @@
 {
-  "claimDeposit": "1580765",
+  "claimDeposit": "1580716",
   "enable": "60953",
   "lockDepositRequest": "92358",
-  "requestDeposit": "553341",
-  "requestRedeem": "2517320"
+  "requestDeposit": "553259",
+  "requestRedeem": "2514363"
 }

--- a/src/vaults/AsyncRequests.sol
+++ b/src/vaults/AsyncRequests.sol
@@ -223,17 +223,12 @@ contract AsyncRequests is BaseInvestmentManager, IAsyncRequests {
         uint128 shareAmount,
         D18 pricePoolPerShare
     ) external auth {
-        (address asset, uint256 tokenId) = poolManager.idToAsset(assetId);
         // Lock assets to ensure they are not withdrawn and are available for the redeeming user
+        (address asset, uint256 tokenId) = poolManager.idToAsset(assetId);
         poolEscrowProvider.escrow(poolId).reserveIncrease(scId, asset, tokenId, assetAmount);
 
-        IAsyncVault vault_ = IAsyncVault(vault[poolId][scId][assetId]);
-
-        // Need to transfer to the balance sheet so that it can burn from itself
-        globalEscrow.authTransferTo(vault_.share(), address(balanceSheet), shareAmount);
-
         balanceSheet.overridePricePoolPerShare(poolId, scId, pricePoolPerShare);
-        balanceSheet.revoke(poolId, scId, address(balanceSheet), shareAmount);
+        balanceSheet.revoke(poolId, scId, address(globalEscrow), shareAmount);
     }
 
     /// @inheritdoc IInvestmentManagerGatewayHandler

--- a/src/vaults/AsyncVault.sol
+++ b/src/vaults/AsyncVault.sol
@@ -45,9 +45,7 @@ contract AsyncVault is BaseAsyncRedeemVault, IAsyncVault {
         require(IERC20(asset).balanceOf(owner) >= assets, InsufficientBalance());
 
         require(asyncManager().requestDeposit(this, assets, controller, owner, msg.sender), RequestDepositFailed());
-
-        address escrow = address(manager.globalEscrow());
-        SafeTransferLib.safeTransferFrom(asset, owner, escrow, assets);
+        SafeTransferLib.safeTransferFrom(asset, owner, address(manager.globalEscrow()), assets);
 
         emit DepositRequest(controller, owner, REQUEST_ID, msg.sender, assets);
         return REQUEST_ID;

--- a/src/vaults/BalanceSheet.sol
+++ b/src/vaults/BalanceSheet.sol
@@ -235,9 +235,7 @@ contract BalanceSheet is Auth, Recoverable, IBalanceSheet, IBalanceSheetGatewayH
         }
     }
 
-    function _executeDeposit(PoolId poolId, address asset, uint256 tokenId, address owner, uint128 amount)
-        internal
-    {
+    function _executeDeposit(PoolId poolId, address asset, uint256 tokenId, address owner, uint128 amount) internal {
         IPoolEscrow escrow = poolEscrowProvider.escrow(poolId);
         if (tokenId == 0) {
             SafeTransferLib.safeTransferFrom(asset, owner, address(escrow), amount);
@@ -257,7 +255,7 @@ contract BalanceSheet is Auth, Recoverable, IBalanceSheet, IBalanceSheetGatewayH
     ) internal {
         IPoolEscrow escrow = poolEscrowProvider.escrow(poolId);
         escrow.withdraw(scId, asset, tokenId, amount);
-        
+
         D18 pricePoolPerAsset_ = _pricePoolPerAsset(poolId, scId, assetId);
         emit Withdraw(poolId, scId, asset, tokenId, receiver, amount, pricePoolPerAsset_);
 
@@ -295,6 +293,7 @@ contract BalanceSheet is Auth, Recoverable, IBalanceSheet, IBalanceSheetGatewayH
 
     function _executeRevoke(PoolId poolId, ShareClassId scId, address from, uint128 shares) internal {
         IShareToken token = poolManager.shareToken(poolId, scId);
+        // token.authTransferFrom(from, from, address(this), shares);
         token.burn(from, shares);
     }
 

--- a/src/vaults/BalanceSheet.sol
+++ b/src/vaults/BalanceSheet.sol
@@ -293,6 +293,7 @@ contract BalanceSheet is Auth, Recoverable, IBalanceSheet, IBalanceSheetGatewayH
 
     function _executeRevoke(PoolId poolId, ShareClassId scId, address from, uint128 shares) internal {
         IShareToken token = poolManager.shareToken(poolId, scId);
+        // TODO: how to make work with shares that don't support authTransferFrom
         token.authTransferFrom(from, from, address(this), shares);
         token.burn(address(this), shares);
     }

--- a/src/vaults/BalanceSheet.sol
+++ b/src/vaults/BalanceSheet.sol
@@ -293,8 +293,8 @@ contract BalanceSheet is Auth, Recoverable, IBalanceSheet, IBalanceSheetGatewayH
 
     function _executeRevoke(PoolId poolId, ShareClassId scId, address from, uint128 shares) internal {
         IShareToken token = poolManager.shareToken(poolId, scId);
-        // token.authTransferFrom(from, from, address(this), shares);
-        token.burn(from, shares);
+        token.authTransferFrom(from, from, address(this), shares);
+        token.burn(address(this), shares);
     }
 
     function _submitQueuedShares(PoolId poolId, ShareClassId scId) internal {

--- a/src/vaults/BalanceSheet.sol
+++ b/src/vaults/BalanceSheet.sol
@@ -299,7 +299,6 @@ contract BalanceSheet is Auth, Recoverable, IBalanceSheet, IBalanceSheetGatewayH
 
     function _executeRevoke(PoolId poolId, ShareClassId scId, address from, uint128 shares) internal {
         IShareToken token = poolManager.shareToken(poolId, scId);
-        // TODO: how to make work with shares that don't support authTransferFrom
         token.authTransferFrom(from, from, address(this), shares);
         token.burn(address(this), shares);
     }

--- a/src/vaults/BaseVaults.sol
+++ b/src/vaults/BaseVaults.sol
@@ -240,13 +240,7 @@ abstract contract BaseAsyncRedeemVault is BaseVault, IAsyncRedeemVault {
         address sender = isOperator[owner][msg.sender] ? owner : msg.sender;
 
         require(asyncRedeemManager.requestRedeem(this, shares, controller, owner, sender), RequestRedeemFailed());
-
-        address escrow = address(manager.globalEscrow());
-        try IShareToken(share).authTransferFrom(sender, owner, escrow, shares) returns (bool) {}
-        catch {
-            // Support share class tokens that block authTransferFrom. In this case ERC20 approval needs to be set
-            require(IShareToken(share).transferFrom(owner, escrow, shares), TransferFromFailed());
-        }
+        IShareToken(share).authTransferFrom(sender, owner, address(manager.globalEscrow()), shares);
 
         emit RedeemRequest(controller, owner, REQUEST_ID, msg.sender, shares);
         return REQUEST_ID;

--- a/src/vaults/Escrow.sol
+++ b/src/vaults/Escrow.sol
@@ -16,7 +16,7 @@ contract Escrow is Auth, IEscrow {
     constructor(address deployer) Auth(deployer) {}
 
     /// @inheritdoc IEscrow
-    function authTransferTo(address asset, uint256 tokenId, address receiver, uint256 amount) external auth {
+    function authTransferTo(address asset, uint256 tokenId, address receiver, uint256 amount) public auth {
         if (tokenId == 0) {
             uint256 balance = IERC20(asset).balanceOf(address(this));
             require(balance >= amount, InsufficientBalance(asset, tokenId, amount, balance));
@@ -34,11 +34,7 @@ contract Escrow is Auth, IEscrow {
 
     /// @inheritdoc IEscrow
     function authTransferTo(address asset, address receiver, uint256 amount) external auth {
-        uint256 balance = IERC20(asset).balanceOf(address(this));
-        require(balance >= amount, InsufficientBalance(asset, 0, amount, balance));
-
-        SafeTransferLib.safeTransfer(asset, receiver, amount);
-        emit AuthTransferTo(asset, receiver, amount);
+        authTransferTo(asset, 0, receiver, amount);
     }
 }
 

--- a/src/vaults/Escrow.sol
+++ b/src/vaults/Escrow.sol
@@ -46,8 +46,6 @@ contract Escrow is Auth, IEscrow {
 /// @notice Escrow contract that holds assets for a specific pool separated by share classes.
 ///         Only wards can approve funds to be taken out.
 contract PoolEscrow is Escrow, Recoverable, IPoolEscrow {
-    using MathLib for uint256;
-
     /// @dev The underlying pool id
     PoolId public immutable poolId;
 
@@ -60,35 +58,35 @@ contract PoolEscrow is Escrow, Recoverable, IPoolEscrow {
     receive() external payable {}
 
     /// @inheritdoc IPoolEscrow
-    function deposit(ShareClassId scId, address asset, uint256 tokenId, uint256 value) external auth {
-        holding[scId][asset][tokenId].total += value.toUint128();
+    function deposit(ShareClassId scId, address asset, uint256 tokenId, uint128 value) external auth {
+        holding[scId][asset][tokenId].total += value;
 
         emit Deposit(asset, tokenId, poolId, scId, value);
     }
 
     /// @inheritdoc IPoolEscrow
-    function withdraw(ShareClassId scId, address asset, uint256 tokenId, uint256 value) external auth {
+    function withdraw(ShareClassId scId, address asset, uint256 tokenId, uint128 value) external auth {
         Holding storage holding_ = holding[scId][asset][tokenId];
-        uint256 balance = holding_.total - holding_.reserved;
+        uint128 balance = holding_.total - holding_.reserved;
         require(balance >= value, InsufficientBalance(asset, tokenId, value, balance));
 
-        holding_.total -= value.toUint128();
+        holding_.total -= value;
 
         emit Withdraw(asset, tokenId, poolId, scId, value);
     }
 
     /// @inheritdoc IPoolEscrow
-    function reserveIncrease(ShareClassId scId, address asset, uint256 tokenId, uint256 value) external auth {
-        uint128 newValue = holding[scId][asset][tokenId].reserved + value.toUint128();
+    function reserveIncrease(ShareClassId scId, address asset, uint256 tokenId, uint128 value) external auth {
+        uint128 newValue = holding[scId][asset][tokenId].reserved + value;
         holding[scId][asset][tokenId].reserved = newValue;
 
         emit IncreaseReserve(asset, tokenId, poolId, scId, value, newValue);
     }
 
     /// @inheritdoc IPoolEscrow
-    function reserveDecrease(ShareClassId scId, address asset, uint256 tokenId, uint256 value) external auth {
+    function reserveDecrease(ShareClassId scId, address asset, uint256 tokenId, uint128 value) external auth {
         uint128 prevValue = holding[scId][asset][tokenId].reserved;
-        uint128 value_ = value.toUint128();
+        uint128 value_ = value;
         require(prevValue >= value_, InsufficientReservedAmount());
 
         uint128 newValue = prevValue - value_;
@@ -98,7 +96,7 @@ contract PoolEscrow is Escrow, Recoverable, IPoolEscrow {
     }
 
     /// @inheritdoc IPoolEscrow
-    function availableBalanceOf(ShareClassId scId, address asset, uint256 tokenId) public view returns (uint256) {
+    function availableBalanceOf(ShareClassId scId, address asset, uint256 tokenId) public view returns (uint128) {
         Holding storage holding_ = holding[scId][asset][tokenId];
         if (holding_.total < holding_.reserved) return 0;
         return holding_.total - holding_.reserved;

--- a/src/vaults/PoolManager.sol
+++ b/src/vaults/PoolManager.sol
@@ -126,12 +126,7 @@ contract PoolManager is
 
         gateway.payTransaction{value: msg.value}(msg.sender);
 
-        try share.authTransferFrom(msg.sender, msg.sender, address(this), amount) returns (bool) {}
-        catch {
-            // Support share class tokens that block authTransferFrom. In this case ERC20 approval needs to be set
-            require(share.transferFrom(msg.sender, address(this), amount), TransferFromFailed());
-        }
-
+        share.authTransferFrom(msg.sender, msg.sender, address(this), amount);
         share.burn(address(this), amount);
 
         emit TransferShares(centrifugeId, poolId, scId, msg.sender, receiver, amount);

--- a/src/vaults/SyncRequests.sol
+++ b/src/vaults/SyncRequests.sol
@@ -286,13 +286,9 @@ contract SyncRequests is BaseInvestmentManager, ISyncRequests {
 
     /// @dev Issues shares to the receiver and instruct the balance sheet
     //       to react on the issuance and the updated holding.
-    function _issueShares(
-        IBaseVault vault_,
-        uint128 shares,
-        address receiver,
-        address, /* owner */
-        uint128 assets
-    ) internal {
+    function _issueShares(IBaseVault vault_, uint128 shares, address receiver, address, /* owner */ uint128 assets)
+        internal
+    {
         PoolId poolId = vault_.poolId();
         ShareClassId scId = vault_.scId();
         VaultDetails memory vaultDetails = poolManager.vaultDetails(vault_);

--- a/src/vaults/VaultRouter.sol
+++ b/src/vaults/VaultRouter.sol
@@ -7,7 +7,7 @@ import {MathLib} from "src/misc/libraries/MathLib.sol";
 import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {IERC20, IERC20Permit, IERC20Wrapper} from "src/misc/interfaces/IERC20.sol";
-import {IERC6909} from "src/misc/interfaces/IERC6909.sol";
+import {IERC7540Deposit} from "src/misc/interfaces/IERC7540.sol";
 import {Recoverable} from "src/misc/Recoverable.sol";
 
 import {IGateway} from "src/common/interfaces/IGateway.sol";
@@ -15,11 +15,11 @@ import {IMessageDispatcher} from "src/common/interfaces/IMessageDispatcher.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
-import {IAsyncVault} from "src/vaults/interfaces/IBaseVaults.sol";
+import {IAsyncVault, IBaseVault} from "src/vaults/interfaces/IBaseVaults.sol";
 import {IVaultRouter} from "src/vaults/interfaces/IVaultRouter.sol";
 import {IPoolManager, VaultDetails} from "src/vaults/interfaces/IPoolManager.sol";
 import {IEscrow} from "src/vaults/interfaces/IEscrow.sol";
-import {IBaseVault} from "src/vaults/interfaces/IBaseVaults.sol";
+import {BaseSyncDepositVault} from "src/vaults/BaseVaults.sol";
 
 /// @title  VaultRouter
 /// @notice This is a helper contract, designed to be the entrypoint for EOAs.
@@ -102,11 +102,27 @@ contract VaultRouter is Auth, Multicall, Recoverable, IVaultRouter {
 
         VaultDetails memory vaultDetails = poolManager.vaultDetails(vault);
         if (owner == address(this)) {
-            _approveMax(vaultDetails.asset, vaultDetails.tokenId, address(vault));
+            _approveMax(vaultDetails.asset, address(vault));
         }
 
         _pay();
         vault.requestDeposit(amount, controller, owner);
+    }
+
+    /// @inheritdoc IVaultRouter
+    function deposit(BaseSyncDepositVault vault, uint256 assets, address receiver, address owner)
+        external
+        payable
+        protected
+    {
+        require(owner == msg.sender || owner == address(this), InvalidOwner());
+        require(!vault.supportsInterface(type(IERC7540Deposit).interfaceId), NonSyncDepositVault());
+
+        VaultDetails memory vaultDetails = poolManager.vaultDetails(vault);
+        SafeTransferLib.safeTransferFrom(vaultDetails.asset, owner, address(this), assets);
+
+        _pay();
+        vault.deposit(assets, receiver);
     }
 
     /// @inheritdoc IVaultRouter
@@ -120,12 +136,7 @@ contract VaultRouter is Auth, Multicall, Recoverable, IVaultRouter {
         lockedRequests[controller][vault] += amount;
 
         VaultDetails memory vaultDetails = poolManager.vaultDetails(vault);
-
-        if (vaultDetails.tokenId == 0) {
-            SafeTransferLib.safeTransferFrom(vaultDetails.asset, owner, address(escrow), amount);
-        } else {
-            IERC6909(vaultDetails.asset).transferFrom(owner, address(escrow), vaultDetails.tokenId, amount);
-        }
+        SafeTransferLib.safeTransferFrom(vaultDetails.asset, owner, address(escrow), amount);
 
         emit LockDepositRequest(vault, controller, owner, msg.sender, amount);
     }
@@ -137,8 +148,7 @@ contract VaultRouter is Auth, Multicall, Recoverable, IVaultRouter {
         VaultDetails memory vaultDetails = poolManager.vaultDetails(vault);
 
         uint256 assetBalance;
-        if (vaultDetails.tokenId == 0) assetBalance = IERC20(vaultDetails.asset).balanceOf(msg.sender);
-        else assetBalance = IERC6909(vaultDetails.asset).balanceOf(msg.sender, vaultDetails.tokenId);
+        assetBalance = IERC20(vaultDetails.asset).balanceOf(msg.sender);
 
         if (vaultDetails.isWrapper && assetBalance < amount) {
             wrap(vaultDetails.asset, amount, address(this), msg.sender);
@@ -155,7 +165,7 @@ contract VaultRouter is Auth, Multicall, Recoverable, IVaultRouter {
         lockedRequests[msg.sender][vault] = 0;
 
         VaultDetails memory vaultDetails = poolManager.vaultDetails(vault);
-        escrow.authTransferTo(vaultDetails.asset, vaultDetails.tokenId, receiver, lockedRequest);
+        escrow.authTransferTo(vaultDetails.asset, receiver, lockedRequest);
 
         emit UnlockDepositRequest(vault, msg.sender, receiver);
     }
@@ -167,10 +177,10 @@ contract VaultRouter is Auth, Multicall, Recoverable, IVaultRouter {
         lockedRequests[controller][vault] = 0;
 
         VaultDetails memory vaultDetails = poolManager.vaultDetails(vault);
-        escrow.authTransferTo(vaultDetails.asset, vaultDetails.tokenId, address(this), lockedRequest);
+        escrow.authTransferTo(vaultDetails.asset, address(this), lockedRequest);
 
         _pay();
-        _approveMax(vaultDetails.asset, vaultDetails.tokenId, address(vault));
+        _approveMax(vaultDetails.asset, address(vault));
         vault.requestDeposit(lockedRequest, controller, address(this));
         emit ExecuteLockedDepositRequest(vault, controller, msg.sender);
     }
@@ -265,7 +275,7 @@ contract VaultRouter is Auth, Multicall, Recoverable, IVaultRouter {
         require(amount != 0, ZeroBalance());
         SafeTransferLib.safeTransferFrom(underlying, owner, address(this), amount);
 
-        _approveMax(underlying, 0, wrapper);
+        _approveMax(underlying, wrapper);
         require(IERC20Wrapper(wrapper).depositFor(receiver, amount), WrapFailed());
     }
 
@@ -302,11 +312,9 @@ contract VaultRouter is Auth, Multicall, Recoverable, IVaultRouter {
 
     /// @notice Gives the max approval to `to` for spending the given `asset` if not already approved.
     /// @dev    Assumes that `type(uint256).max` is large enough to never have to increase the allowance again.
-    function _approveMax(address asset, uint256 tokenId, address spender) internal {
-        if (tokenId == 0 && IERC20(asset).allowance(address(this), spender) == 0) {
+    function _approveMax(address asset, address spender) internal {
+        if (IERC20(asset).allowance(address(this), spender) == 0) {
             SafeTransferLib.safeApprove(asset, spender, type(uint256).max);
-        } else if (tokenId != 0 && IERC6909(asset).allowance(address(this), spender, tokenId) == 0) {
-            IERC6909(asset).approve(spender, tokenId, type(uint256).max);
         }
     }
 

--- a/src/vaults/interfaces/IBalanceSheet.sol
+++ b/src/vaults/interfaces/IBalanceSheet.sol
@@ -41,6 +41,7 @@ interface IBalanceSheet {
 
     // --- Errors ---
     error FileUnrecognizedParam();
+    error CannotTransferFromEndorsedContract();
 
     /// @notice Overloaded increase with asset transfer
     function deposit(PoolId poolId, ShareClassId scId, address asset, uint256 tokenId, address provider, uint128 amount)

--- a/src/vaults/interfaces/IEscrow.sol
+++ b/src/vaults/interfaces/IEscrow.sol
@@ -13,10 +13,6 @@ interface IEscrow {
     /// @dev Needed as allowances increase attack surface
     event AuthTransferTo(address indexed asset, uint256 indexed tokenId, address reciver, uint256 value);
 
-    /// @notice Emitted when an authTransferTo is made
-    /// @dev Needed as allowances increase attack surface
-    event AuthTransferTo(address indexed asset, address reciver, uint256 value);
-
     /// @notice Emitted when the escrow has insufficient balance for an action - virtual or actual balance
     error InsufficientBalance(address asset, uint256 tokenId, uint256 value, uint256 balance);
 

--- a/src/vaults/interfaces/IEscrow.sol
+++ b/src/vaults/interfaces/IEscrow.sol
@@ -42,7 +42,7 @@ interface IPoolEscrow is IEscrow, IRecoverable {
     /// @param scId The id of the share class
     /// @param value The amount deposited
     event Deposit(
-        address indexed asset, uint256 indexed tokenId, PoolId indexed poolId, ShareClassId scId, uint256 value
+        address indexed asset, uint256 indexed tokenId, PoolId indexed poolId, ShareClassId scId, uint128 value
     );
 
     /// @notice Emitted when an amount is reserved
@@ -58,7 +58,7 @@ interface IPoolEscrow is IEscrow, IRecoverable {
         PoolId indexed poolId,
         ShareClassId scId,
         uint256 delta,
-        uint256 value
+        uint128 value
     );
 
     /// @notice Emitted when an amount is unreserved
@@ -74,7 +74,7 @@ interface IPoolEscrow is IEscrow, IRecoverable {
         PoolId indexed poolId,
         ShareClassId scId,
         uint256 delta,
-        uint256 value
+        uint128 value
     );
 
     /// @notice Emitted when a withdraw is made
@@ -84,7 +84,7 @@ interface IPoolEscrow is IEscrow, IRecoverable {
     /// @param scId The id of the share class
     /// @param value The amount withdrawn
     event Withdraw(
-        address indexed asset, uint256 indexed tokenId, PoolId indexed poolId, ShareClassId scId, uint256 value
+        address indexed asset, uint256 indexed tokenId, PoolId indexed poolId, ShareClassId scId, uint128 value
     );
 
     // --- Errors ---
@@ -104,7 +104,7 @@ interface IPoolEscrow is IEscrow, IRecoverable {
     /// @param asset The address of the asset to be deposited
     /// @param tokenId The id of the asset - 0 for ERC20
     /// @param value The amount to deposit
-    function deposit(ShareClassId scId, address asset, uint256 tokenId, uint256 value) external;
+    function deposit(ShareClassId scId, address asset, uint256 tokenId, uint128 value) external;
 
     /// @notice Withdraws `value` of `asset` in underlying `poolId` and given `scId`
     /// @dev MUST ensure that reserved amounts are not withdrawn
@@ -112,7 +112,7 @@ interface IPoolEscrow is IEscrow, IRecoverable {
     /// @param asset The address of the asset to be withdrawn
     /// @param tokenId The id of the asset - 0 for ERC20
     /// @param value The amount to withdraw
-    function withdraw(ShareClassId scId, address asset, uint256 tokenId, uint256 value) external;
+    function withdraw(ShareClassId scId, address asset, uint256 tokenId, uint128 value) external;
 
     /// @notice Increases the reserved amount of `value` for `asset` in underlying `poolId` and given `scId`
     /// @dev MUST prevent the reserved amount from being withdrawn
@@ -120,7 +120,7 @@ interface IPoolEscrow is IEscrow, IRecoverable {
     /// @param asset The address of the asset to be reserved
     /// @param tokenId The id of the asset - 0 for ERC20
     /// @param value The amount to reserve
-    function reserveIncrease(ShareClassId scId, address asset, uint256 tokenId, uint256 value) external;
+    function reserveIncrease(ShareClassId scId, address asset, uint256 tokenId, uint128 value) external;
 
     /// @notice Decreases the reserved amount of `value` for `asset` in underlying `poolId` and given `scId`
     /// @dev MUST fail if `value` is greater than the current reserved amount
@@ -128,7 +128,7 @@ interface IPoolEscrow is IEscrow, IRecoverable {
     /// @param asset The address of the asset to be reserved
     /// @param tokenId The id of the asset - 0 for ERC20
     /// @param value The amount to decrease
-    function reserveDecrease(ShareClassId scId, address asset, uint256 tokenId, uint256 value) external;
+    function reserveDecrease(ShareClassId scId, address asset, uint256 tokenId, uint128 value) external;
 
     /// @notice Provides the available balance of `asset` in underlying `poolId` and given `scId`
     /// @dev MUST return the balance minus the reserved amount
@@ -136,5 +136,5 @@ interface IPoolEscrow is IEscrow, IRecoverable {
     /// @param asset The address of the asset to be checked
     /// @param tokenId The id of the asset - 0 for ERC20
     /// @return The available balance
-    function availableBalanceOf(ShareClassId scId, address asset, uint256 tokenId) external view returns (uint256);
+    function availableBalanceOf(ShareClassId scId, address asset, uint256 tokenId) external view returns (uint128);
 }

--- a/src/vaults/interfaces/IVaultRouter.sol
+++ b/src/vaults/interfaces/IVaultRouter.sol
@@ -58,9 +58,7 @@ interface IVaultRouter is IMulticall {
     /// @param  assets Check @param IERC4626.deposit.assets
     /// @param  receiver Check @param IERC4626.deposit.receiver
     /// @param  owner User from which to transfer the assets, either msg.sender or the VaultRouter
-    function deposit(BaseSyncDepositVault vault, uint256 assets, address receiver, address owner)
-        external
-        payable;
+    function deposit(BaseSyncDepositVault vault, uint256 assets, address receiver, address owner) external payable;
 
     /// @notice Locks `amount` of `vault`'s asset in an escrow before actually sending a deposit LockDepositRequest
     ///         There are users that would like to interact with the protocol but don't have permissions yet. They can

--- a/src/vaults/interfaces/IVaultRouter.sol
+++ b/src/vaults/interfaces/IVaultRouter.sol
@@ -6,6 +6,7 @@ import {IMulticall} from "src/misc/interfaces/IMulticall.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 import {IBaseVault, IAsyncVault} from "src/vaults/interfaces/IBaseVaults.sol";
+import {BaseSyncDepositVault} from "src/vaults/BaseVaults.sol";
 
 interface IVaultRouter is IMulticall {
     // --- Events ---
@@ -22,6 +23,7 @@ interface IVaultRouter is IMulticall {
     error WrapFailed();
     error UnwrapFailed();
     error InvalidSender();
+    error NonSyncDepositVault();
 
     /// @notice Check how much of the `vault`'s asset is locked for the current `controller`.
     /// @dev    This is a getter method
@@ -47,6 +49,18 @@ interface IVaultRouter is IMulticall {
     /// @param  controller Check @param IERC7540Deposit.requestDeposit.controller
     /// @param  owner Check @param IERC7540Deposit.requestDeposit.owner
     function requestDeposit(IAsyncVault vault, uint256 amount, address controller, address owner) external payable;
+
+    /// @notice Check `IERC4626.deposit`.
+    /// @dev    This adds a mandatory prepayment for all the costs that will incur during the transaction.
+    ///         The caller must call `VaultRouter.estimate` to get estimates how much the deposit will cost.
+    ///
+    /// @param  vault The vault to deposit into
+    /// @param  assets Check @param IERC4626.deposit.assets
+    /// @param  receiver Check @param IERC4626.deposit.receiver
+    /// @param  owner User from which to transfer the assets, either msg.sender or the VaultRouter
+    function deposit(BaseSyncDepositVault vault, uint256 assets, address receiver, address owner)
+        external
+        payable;
 
     /// @notice Locks `amount` of `vault`'s asset in an escrow before actually sending a deposit LockDepositRequest
     ///         There are users that would like to interact with the protocol but don't have permissions yet. They can

--- a/src/vaults/interfaces/token/IHook.sol
+++ b/src/vaults/interfaces/token/IHook.sol
@@ -38,8 +38,8 @@ interface IHook is IERC165 {
         returns (bytes4);
 
     /// @notice Callback on authorized ERC20 transfer.
-    /// @dev    MUST return bytes4(keccak256("onERC20AuthTransfer(address,address,address,uint256,(bytes16,bytes16))"))
-    ///         if successful
+    /// @dev    Cannot be blocked, can only be used to update state.
+    ///         Return value is ignored, only kept for compatibility with V2 share tokens.
     function onERC20AuthTransfer(address sender, address from, address to, uint256 value, HookData calldata hookdata)
         external
         returns (bytes4);

--- a/src/vaults/token/ShareToken.sol
+++ b/src/vaults/token/ShareToken.sol
@@ -129,12 +129,9 @@ contract ShareToken is ERC20, IShareToken {
     {
         success = _transferFrom(sender, from, to, value);
         address hook_ = hook;
-        require(
-            hook_ == address(0)
-                || IHook(hook_).onERC20AuthTransfer(sender, from, to, value, HookData(hookDataOf(from), hookDataOf(to)))
-                    == IHook.onERC20AuthTransfer.selector,
-            RestrictionsFailed()
-        );
+        if (hook_ != address(0)) {
+            IHook(hook_).onERC20AuthTransfer(sender, from, to, value, HookData(hookDataOf(from), hookDataOf(to)));
+        }
     }
 
     //----------------------------------------------------------------------------------------------

--- a/test/vaults/integration/BalanceSheet.t.sol
+++ b/test/vaults/integration/BalanceSheet.t.sol
@@ -67,7 +67,7 @@ contract BalanceSheetTest is BaseTest {
         );
 
         // redeploying within test to increase coverage
-        new BalanceSheet(address(this));
+        new BalanceSheet(root, address(this));
 
         // values set correctly
         assertEq(address(balanceSheet.gateway()), address(gateway));

--- a/test/vaults/integration/BalanceSheet.t.sol
+++ b/test/vaults/integration/BalanceSheet.t.sol
@@ -288,12 +288,8 @@ contract BalanceSheetTest is BaseTest {
         vm.expectRevert(IAuth.NotAuthorized.selector);
         balanceSheet.revoke(POOL_A, defaultTypedShareClassId, address(this), defaultAmount);
 
-        vm.expectRevert(IERC20.InsufficientAllowance.selector);
-        balanceSheet.revoke(POOL_A, defaultTypedShareClassId, address(this), defaultAmount);
-
         balanceSheet.overridePricePoolPerShare(POOL_A, defaultTypedShareClassId, defaultPricePoolPerShare);
 
-        token.approve(address(balanceSheet), defaultAmount * 3);
         vm.expectEmit();
         emit IBalanceSheet.Revoke(
             POOL_A, defaultTypedShareClassId, address(this), defaultPricePoolPerShare, defaultAmount


### PR DESCRIPTION
- Remove ability for hooks to block `authTransferFrom`
- Some renamings in `BalanceSheet`
- Use `authTransferFrom` in `BalanceSheet.revoke` to not need an allowance
- Remove ERC6909 support from `VaultRouter`
- Add sync deposit flow support to `VaultRouter`