### PR TITLE
refactor: rm ISharePriceProvider

### DIFF
--- a/src/vaults/SyncRequests.sol
+++ b/src/vaults/SyncRequests.sol
@@ -24,12 +24,7 @@ import {IVaultManager, VaultKind} from "src/vaults/interfaces/IVaultManager.sol"
 import {IPoolManager, VaultDetails} from "src/vaults/interfaces/IPoolManager.sol";
 import {IBalanceSheet} from "src/vaults/interfaces/IBalanceSheet.sol";
 import {IBaseInvestmentManager} from "src/vaults/interfaces/investments/IBaseInvestmentManager.sol";
-import {
-    ISharePriceProvider,
-    Prices,
-    ISyncDepositValuation
-} from "src/vaults/interfaces/investments/ISharePriceProvider.sol";
-import {ISyncRequests} from "src/vaults/interfaces/investments/ISyncRequests.sol";
+import {ISyncRequests, Prices, ISyncDepositValuation} from "src/vaults/interfaces/investments/ISyncRequests.sol";
 import {IDepositManager} from "src/vaults/interfaces/investments/IDepositManager.sol";
 import {ISyncDepositManager} from "src/vaults/interfaces/investments/ISyncDepositManager.sol";
 import {IUpdateContract} from "src/vaults/interfaces/IUpdateContract.sol";
@@ -274,7 +269,7 @@ contract SyncRequests is BaseInvestmentManager, ISyncRequests {
         }
     }
 
-    /// @inheritdoc ISharePriceProvider
+    /// @inheritdoc ISyncRequests
     function prices(PoolId poolId, ShareClassId scId, AssetId assetId) public view returns (Prices memory priceData) {
         priceData.poolPerShare = pricePoolPerShare(poolId, scId);
         (priceData.poolPerAsset,) = poolManager.pricePoolPerAsset(poolId, scId, assetId, true);

--- a/src/vaults/interfaces/investments/ISharePriceProvider.sol
+++ b/src/vaults/interfaces/investments/ISharePriceProvider.sol
@@ -7,35 +7,4 @@ import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
 
-/// @dev Solely used locally as protection against stack-too-deep
-struct Prices {
-    /// @dev Price of 1 asset unit per share unit
-    D18 assetPerShare;
-    /// @dev Price of 1 pool unit per asset unit
-    D18 poolPerAsset;
-    /// @dev Price of 1 pool unit per share unit
-    D18 poolPerShare;
-}
 
-interface ISyncDepositValuation {
-    /// @notice Returns the pool price per share for a given pool and share class, asset, and asset id.
-    // The provided price is defined as POOL_UNIT/SHARE_UNIT.
-    ///
-    /// @param poolId The pool id
-    /// @param scId The share class id
-    /// @return price The pool price per share
-    function pricePoolPerShare(PoolId poolId, ShareClassId scId) external view returns (D18 price);
-}
-
-interface ISharePriceProvider is ISyncDepositValuation {
-    /// @notice Returns the all three prices for a given pool, share class, asset, and asset id.
-    ///
-    /// @param poolId The pool id
-    /// @param scId The share class id
-    /// @param assetId The asset id corresponding to the asset and tokenId
-    /// @return priceData The asset price per share, pool price per asset, and pool price per share
-    function prices(PoolId poolId, ShareClassId scId, AssetId assetId)
-        external
-        view
-        returns (Prices memory priceData);
-}

--- a/src/vaults/interfaces/investments/ISharePriceProvider.sol
+++ b/src/vaults/interfaces/investments/ISharePriceProvider.sol
@@ -6,5 +6,3 @@ import {D18} from "src/misc/types/D18.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
-
-

--- a/src/vaults/interfaces/investments/ISyncRequests.sol
+++ b/src/vaults/interfaces/investments/ISyncRequests.sol
@@ -3,14 +3,35 @@ pragma solidity 0.8.28;
 
 import {D18} from "src/misc/types/D18.sol";
 
-import {IUpdateContract} from "src/vaults/interfaces/IUpdateContract.sol";
-import {IVaultManager} from "src/vaults/interfaces/IVaultManager.sol";
-import {ISyncDepositManager} from "src/vaults/interfaces/investments/ISyncDepositManager.sol";
-import {ISharePriceProvider} from "src/vaults/interfaces/investments/ISharePriceProvider.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
-interface ISyncRequests is ISyncDepositManager, ISharePriceProvider, IUpdateContract {
+import {IUpdateContract} from "src/vaults/interfaces/IUpdateContract.sol";
+import {IVaultManager} from "src/vaults/interfaces/IVaultManager.sol";
+import {ISyncDepositManager} from "src/vaults/interfaces/investments/ISyncDepositManager.sol";
+
+/// @dev Solely used locally as protection against stack-too-deep
+struct Prices {
+    /// @dev Price of 1 asset unit per share unit
+    D18 assetPerShare;
+    /// @dev Price of 1 pool unit per asset unit
+    D18 poolPerAsset;
+    /// @dev Price of 1 pool unit per share unit
+    D18 poolPerShare;
+}
+
+interface ISyncDepositValuation {
+    /// @notice Returns the pool price per share for a given pool and share class, asset, and asset id.
+    // The provided price is defined as POOL_UNIT/SHARE_UNIT.
+    ///
+    /// @param poolId The pool id
+    /// @param scId The share class id
+    /// @return price The pool price per share
+    function pricePoolPerShare(PoolId poolId, ShareClassId scId) external view returns (D18 price);
+}
+
+interface ISyncRequests is ISyncDepositManager, ISyncDepositValuation, IUpdateContract {
     event SetValuation(PoolId indexed poolId, ShareClassId indexed scId, address valuation);
     event SetMaxReserve(
         PoolId indexed poolId, ShareClassId indexed scId, address asset, uint256 tokenId, uint128 maxReserve
@@ -40,4 +61,15 @@ interface ISyncRequests is ISyncDepositManager, ISharePriceProvider, IUpdateCont
     /// @param maxReserve The amount of maximum reserve
     function setMaxReserve(PoolId poolId, ShareClassId scId, address asset, uint256 tokenId, uint128 maxReserve)
         external;
+
+    /// @notice Returns the all three prices for a given pool, share class, asset, and asset id.
+    ///
+    /// @param poolId The pool id
+    /// @param scId The share class id
+    /// @param assetId The asset id corresponding to the asset and tokenId
+    /// @return priceData The asset price per share, pool price per asset, and pool price per share
+    function prices(PoolId poolId, ShareClassId scId, AssetId assetId)
+        external
+        view
+        returns (Prices memory priceData);
 }

--- a/test/vaults/integration/SyncRequests.t.sol
+++ b/test/vaults/integration/SyncRequests.t.sol
@@ -8,13 +8,11 @@ import {MathLib} from "src/misc/libraries/MathLib.sol";
 import {MessageLib} from "src/common/libraries/MessageLib.sol";
 import {PricingLib} from "src/common/libraries/PricingLib.sol";
 
-import {Prices} from "src/vaults/interfaces/investments/ISharePriceProvider.sol";
-import {ISyncRequests} from "src/vaults/interfaces/investments/ISyncRequests.sol";
+import {ISyncRequests, Prices, ISyncDepositValuation} from "src/vaults/interfaces/investments/ISyncRequests.sol";
 import {SyncRequests} from "src/vaults/SyncRequests.sol";
 import {SyncDepositVault} from "src/vaults/SyncDepositVault.sol";
 import {IBaseInvestmentManager} from "src/vaults/interfaces/investments/IBaseInvestmentManager.sol";
 import {IBaseVault} from "src/vaults/interfaces/IBaseVaults.sol";
-import {ISyncDepositValuation} from "src/vaults/interfaces/investments/ISharePriceProvider.sol";
 
 import "test/vaults/BaseTest.sol";
 


### PR DESCRIPTION
* Removes `ISharePriceProvider` as it is not and should not be used outside of the impl `SyncRequests` ([ref comment](https://github.com/centrifuge/protocol-v3/pull/313#discussion_r2061317723))
* Moves `ISyncDepositValuation` and `struct` Prices to `ISyncRequests.sol`