### PR TITLE
Rename to ERC-7887, block locked requests for sync vaults

### DIFF
--- a/snapshots/VaultRouter.json
+++ b/snapshots/VaultRouter.json
@@ -1,7 +1,7 @@
 {
   "claimDeposit": "1580993",
   "enable": "60953",
-  "lockDepositRequest": "92316",
+  "lockDepositRequest": "95797",
   "requestDeposit": "553267",
   "requestRedeem": "2514599"
 }

--- a/src/misc/interfaces/IERC7540.sol
+++ b/src/misc/interfaces/IERC7540.sol
@@ -140,7 +140,7 @@ interface IERC7540Redeem is IERC7540Operator {
         returns (uint256 claimableShares);
 }
 
-interface IERC7540CancelDeposit {
+interface IERC7887Deposit {
     event CancelDepositRequest(address indexed controller, uint256 indexed requestId, address sender);
     event CancelDepositClaim(
         address indexed controller, address indexed receiver, uint256 indexed requestId, address sender, uint256 assets
@@ -191,7 +191,7 @@ interface IERC7540CancelDeposit {
         returns (uint256 assets);
 }
 
-interface IERC7540CancelRedeem {
+interface IERC7887Redeem {
     event CancelRedeemRequest(address indexed controller, uint256 indexed requestId, address sender);
     event CancelRedeemClaim(
         address indexed controller, address indexed receiver, uint256 indexed requestId, address sender, uint256 shares

--- a/src/vaults/AsyncVault.sol
+++ b/src/vaults/AsyncVault.sol
@@ -65,24 +65,24 @@ contract AsyncVault is BaseAsyncRedeemVault, IAsyncVault {
     // ERC-7887
     //----------------------------------------------------------------------------------------------
 
-    /// @inheritdoc IERC7540CancelDeposit
+    /// @inheritdoc IERC7887Deposit
     function cancelDepositRequest(uint256, address controller) external {
         _validateController(controller);
         asyncManager().cancelDepositRequest(this, controller, msg.sender);
         emit CancelDepositRequest(controller, REQUEST_ID, msg.sender);
     }
 
-    /// @inheritdoc IERC7540CancelDeposit
+    /// @inheritdoc IERC7887Deposit
     function pendingCancelDepositRequest(uint256, address controller) public view returns (bool isPending) {
         isPending = asyncManager().pendingCancelDepositRequest(this, controller);
     }
 
-    /// @inheritdoc IERC7540CancelDeposit
+    /// @inheritdoc IERC7887Deposit
     function claimableCancelDepositRequest(uint256, address controller) public view returns (uint256 claimableAssets) {
         claimableAssets = asyncManager().claimableCancelDepositRequest(this, controller);
     }
 
-    /// @inheritdoc IERC7540CancelDeposit
+    /// @inheritdoc IERC7887Deposit
     function claimCancelDepositRequest(uint256, address receiver, address controller)
         external
         returns (uint256 assets)
@@ -99,7 +99,7 @@ contract AsyncVault is BaseAsyncRedeemVault, IAsyncVault {
     /// @inheritdoc IERC165
     function supportsInterface(bytes4 interfaceId) public pure override(BaseAsyncRedeemVault, IERC165) returns (bool) {
         return interfaceId == type(IERC7540Deposit).interfaceId
-            || interfaceId == type(IERC7540CancelDeposit).interfaceId || super.supportsInterface(interfaceId);
+            || interfaceId == type(IERC7887Deposit).interfaceId || super.supportsInterface(interfaceId);
     }
 
     //----------------------------------------------------------------------------------------------

--- a/src/vaults/AsyncVault.sol
+++ b/src/vaults/AsyncVault.sol
@@ -98,8 +98,8 @@ contract AsyncVault is BaseAsyncRedeemVault, IAsyncVault {
 
     /// @inheritdoc IERC165
     function supportsInterface(bytes4 interfaceId) public pure override(BaseAsyncRedeemVault, IERC165) returns (bool) {
-        return interfaceId == type(IERC7540Deposit).interfaceId
-            || interfaceId == type(IERC7887Deposit).interfaceId || super.supportsInterface(interfaceId);
+        return interfaceId == type(IERC7540Deposit).interfaceId || interfaceId == type(IERC7887Deposit).interfaceId
+            || super.supportsInterface(interfaceId);
     }
 
     //----------------------------------------------------------------------------------------------

--- a/src/vaults/BaseVaults.sol
+++ b/src/vaults/BaseVaults.sol
@@ -260,24 +260,24 @@ abstract contract BaseAsyncRedeemVault is BaseVault, IAsyncRedeemVault {
     // ERC-7887
     //----------------------------------------------------------------------------------------------
 
-    /// @inheritdoc IERC7540CancelRedeem
+    /// @inheritdoc IERC7887Redeem
     function cancelRedeemRequest(uint256, address controller) external {
         _validateController(controller);
         asyncRedeemManager.cancelRedeemRequest(this, controller, msg.sender);
         emit CancelRedeemRequest(controller, REQUEST_ID, msg.sender);
     }
 
-    /// @inheritdoc IERC7540CancelRedeem
+    /// @inheritdoc IERC7887Redeem
     function pendingCancelRedeemRequest(uint256, address controller) public view returns (bool isPending) {
         isPending = asyncRedeemManager.pendingCancelRedeemRequest(this, controller);
     }
 
-    /// @inheritdoc IERC7540CancelRedeem
+    /// @inheritdoc IERC7887Redeem
     function claimableCancelRedeemRequest(uint256, address controller) public view returns (uint256 claimableShares) {
         claimableShares = asyncRedeemManager.claimableCancelRedeemRequest(this, controller);
     }
 
-    /// @inheritdoc IERC7540CancelRedeem
+    /// @inheritdoc IERC7887Redeem
     function claimCancelRedeemRequest(uint256, address receiver, address controller)
         external
         returns (uint256 shares)
@@ -332,7 +332,7 @@ abstract contract BaseAsyncRedeemVault is BaseVault, IAsyncRedeemVault {
     /// @inheritdoc IERC165
     function supportsInterface(bytes4 interfaceId) public pure virtual override(BaseVault, IERC165) returns (bool) {
         return super.supportsInterface(interfaceId) || interfaceId == type(IERC7540Redeem).interfaceId
-            || interfaceId == type(IERC7540CancelRedeem).interfaceId;
+            || interfaceId == type(IERC7887Redeem).interfaceId;
     }
 
     /// @inheritdoc IERC7575

--- a/src/vaults/VaultRouter.sol
+++ b/src/vaults/VaultRouter.sol
@@ -132,6 +132,7 @@ contract VaultRouter is Auth, Multicall, Recoverable, IVaultRouter {
         protected
     {
         require(owner == msg.sender || owner == address(this), InvalidOwner());
+        require(vault.supportsInterface(type(IERC7540Deposit).interfaceId), NonAsyncVault());
 
         lockedRequests[controller][vault] += amount;
 

--- a/src/vaults/VaultRouter.sol
+++ b/src/vaults/VaultRouter.sol
@@ -120,6 +120,7 @@ contract VaultRouter is Auth, Multicall, Recoverable, IVaultRouter {
 
         VaultDetails memory vaultDetails = poolManager.vaultDetails(vault);
         SafeTransferLib.safeTransferFrom(vaultDetails.asset, owner, address(this), assets);
+        _approveMax(vaultDetails.asset, address(vault));
 
         _pay();
         vault.deposit(assets, receiver);

--- a/src/vaults/interfaces/IBaseVaults.sol
+++ b/src/vaults/interfaces/IBaseVaults.sol
@@ -7,8 +7,8 @@ import {
     IERC7714,
     IERC7741,
     IERC7540Redeem,
-    IERC7540CancelRedeem,
-    IERC7540CancelDeposit,
+    IERC7887Redeem,
+    IERC7887Deposit,
     IERC7540Deposit
 } from "src/misc/interfaces/IERC7540.sol";
 import {IRecoverable} from "src/misc/interfaces/IRecoverable.sol";
@@ -54,7 +54,7 @@ interface IBaseVault is IERC7540Operator, IERC7741, IERC7714, IERC7575, IRecover
  * @dev    This is the specific set of interfaces used by the Centrifuge implementation of ERC7540,
  *         as a fully asynchronous Vault, with cancellation support, and authorize operator signature support.
  */
-interface IAsyncRedeemVault is IERC7540Redeem, IERC7540CancelRedeem, IBaseVault {
+interface IAsyncRedeemVault is IERC7540Redeem, IERC7887Redeem, IBaseVault {
     event RedeemClaimable(address indexed controller, uint256 indexed requestId, uint256 assets, uint256 shares);
     event CancelRedeemClaimable(address indexed controller, uint256 indexed requestId, uint256 shares);
 
@@ -71,7 +71,7 @@ interface IAsyncRedeemVault is IERC7540Redeem, IERC7540CancelRedeem, IBaseVault 
     function asyncRedeemManager() external view returns (IAsyncRedeemManager);
 }
 
-interface IAsyncVault is IERC7540Deposit, IERC7540CancelDeposit, IAsyncRedeemVault {
+interface IAsyncVault is IERC7540Deposit, IERC7887Deposit, IAsyncRedeemVault {
     event DepositClaimable(address indexed controller, uint256 indexed requestId, uint256 assets, uint256 shares);
     event CancelDepositClaimable(address indexed controller, uint256 indexed requestId, uint256 assets);
 

--- a/src/vaults/interfaces/IVaultRouter.sol
+++ b/src/vaults/interfaces/IVaultRouter.sol
@@ -24,6 +24,7 @@ interface IVaultRouter is IMulticall {
     error UnwrapFailed();
     error InvalidSender();
     error NonSyncDepositVault();
+    error NonAsyncVault();
 
     /// @notice Check how much of the `vault`'s asset is locked for the current `controller`.
     /// @dev    This is a getter method
@@ -120,18 +121,18 @@ interface IVaultRouter is IMulticall {
     function claimDeposit(IAsyncVault vault, address receiver, address controller) external payable;
 
     // --- Redeem ---
-    /// @notice Check `IERC7540CancelDeposit.cancelDepositRequest`.
+    /// @notice Check `IERC7887Deposit.cancelDepositRequest`.
     /// @dev    This adds a mandatory prepayment for all the costs that will incur during the transaction.
     ///         The caller must call `VaultRouter.estimate` to get estimates how much the deposit will cost.
     ///
     /// @param  vault The vault where the deposit was initiated
     function cancelDepositRequest(IAsyncVault vault) external payable;
 
-    /// @notice Check IERC7540CancelDeposit.claimCancelDepositRequest
+    /// @notice Check IERC7887Deposit.claimCancelDepositRequest
     ///
     /// @param  vault Address of the vault
-    /// @param  receiver Check  IERC7540CancelDeposit.claimCancelDepositRequest.receiver
-    /// @param  controller Check  IERC7540CancelDeposit.claimCancelDepositRequest.controller
+    /// @param  receiver Check  IERC7887Deposit.claimCancelDepositRequest.receiver
+    /// @param  controller Check  IERC7887Deposit.claimCancelDepositRequest.controller
     function claimCancelDepositRequest(IAsyncVault vault, address receiver, address controller) external payable;
 
     // --- Redeem ---
@@ -154,18 +155,18 @@ interface IVaultRouter is IMulticall {
     /// @param  controller Check IERC7575.withdraw.owner
     function claimRedeem(IBaseVault vault, address receiver, address controller) external payable;
 
-    /// @notice Check `IERC7540CancelRedeem.cancelRedeemRequest`.
+    /// @notice Check `IERC7887Redeem.cancelRedeemRequest`.
     /// @dev    This adds a mandatory prepayment for all the costs that will incur during the transaction.
     ///         The caller must call `VaultRouter.estimate` to get estimates how much the deposit will cost.
     ///
     /// @param  vault The vault where the deposit was initiated
     function cancelRedeemRequest(IAsyncVault vault) external payable;
 
-    /// @notice Check IERC7540CancelRedeem.claimableCancelRedeemRequest
+    /// @notice Check IERC7887Redeem.claimableCancelRedeemRequest
     ///
     /// @param  vault Address of the vault
-    /// @param  receiver Check  IERC7540CancelRedeem.claimCancelRedeemRequest.receiver
-    /// @param  controller Check  IERC7540CancelRedeem.claimCancelRedeemRequest.controller
+    /// @param  receiver Check  IERC7887Redeem.claimCancelRedeemRequest.receiver
+    /// @param  controller Check  IERC7887Redeem.claimCancelRedeemRequest.controller
     function claimCancelRedeemRequest(IAsyncVault vault, address receiver, address controller) external payable;
 
     // --- ERC20 permit ---

--- a/test/vaults/integration/BalanceSheet.t.sol
+++ b/test/vaults/integration/BalanceSheet.t.sol
@@ -481,7 +481,9 @@ contract BalanceSheetTest is BaseTest {
         balanceSheet.transferSharesFrom(POOL_A, defaultTypedShareClassId, address(this), address(1), defaultAmount);
 
         vm.expectRevert(IBalanceSheet.CannotTransferFromEndorsedContract.selector);
-        balanceSheet.transferSharesFrom(POOL_A, defaultTypedShareClassId, address(globalEscrow), address(1), defaultAmount);
+        balanceSheet.transferSharesFrom(
+            POOL_A, defaultTypedShareClassId, address(globalEscrow), address(1), defaultAmount
+        );
 
         balanceSheet.transferSharesFrom(POOL_A, defaultTypedShareClassId, address(this), address(1), defaultAmount);
 

--- a/test/vaults/integration/BalanceSheet.t.sol
+++ b/test/vaults/integration/BalanceSheet.t.sol
@@ -480,6 +480,9 @@ contract BalanceSheetTest is BaseTest {
         vm.expectRevert(IAuth.NotAuthorized.selector);
         balanceSheet.transferSharesFrom(POOL_A, defaultTypedShareClassId, address(this), address(1), defaultAmount);
 
+        vm.expectRevert(IBalanceSheet.CannotTransferFromEndorsedContract.selector);
+        balanceSheet.transferSharesFrom(POOL_A, defaultTypedShareClassId, address(globalEscrow), address(1), defaultAmount);
+
         balanceSheet.transferSharesFrom(POOL_A, defaultTypedShareClassId, address(this), address(1), defaultAmount);
 
         assertEq(token.balanceOf(address(this)), defaultAmount * 2);

--- a/test/vaults/unit/AsyncVault.t.sol
+++ b/test/vaults/unit/AsyncVault.t.sol
@@ -108,8 +108,8 @@ contract AsyncVaultTest is BaseTest {
         assertEq(type(IERC7540Operator).interfaceId, asyncVaultOperator);
         assertEq(type(IERC7540Deposit).interfaceId, asyncVaultDeposit);
         assertEq(type(IERC7540Redeem).interfaceId, asyncVaultRedeem);
-        assertEq(type(IERC7540CancelDeposit).interfaceId, asyncVaultCancelDeposit);
-        assertEq(type(IERC7540CancelRedeem).interfaceId, asyncVaultCancelRedeem);
+        assertEq(type(IERC7887Deposit).interfaceId, asyncVaultCancelDeposit);
+        assertEq(type(IERC7887Redeem).interfaceId, asyncVaultCancelRedeem);
         assertEq(type(IERC7741).interfaceId, erc7741);
         assertEq(type(IERC7714).interfaceId, erc7714);
 

--- a/test/vaults/unit/VaultRouter.t.sol
+++ b/test/vaults/unit/VaultRouter.t.sol
@@ -41,7 +41,7 @@ contract MaliciousVault {
 }
 
 contract NonAsyncVault {
-    function supportsInterface(bytes4 interfaceId) public pure returns (bool) {
+    function supportsInterface(bytes4) public pure returns (bool) {
         return false;
     }
 }

--- a/test/vaults/unit/VaultRouter.t.sol
+++ b/test/vaults/unit/VaultRouter.t.sol
@@ -93,7 +93,7 @@ contract VaultRouterTest is BaseTest {
     }
 
     function testRouterSyncDeposit() public {
-        (, address vault_,) = deploySimpleVault(VaultKind.SyncDepositAsyncRedeem);
+        (uint64 poolId, address vault_,) = deploySimpleVault(VaultKind.SyncDepositAsyncRedeem);
         vm.label(vault_, "vault");
         SyncDepositVault vault = SyncDepositVault(vault_);
         uint256 amount = 100 * 10 ** 18;
@@ -109,8 +109,9 @@ contract VaultRouterTest is BaseTest {
         vm.expectRevert(IGateway.NotEnoughTransactionGas.selector);
         vaultRouter.deposit{value: gas - 1}(vault, amount, self, self);
 
+        erc20.approve(address(vaultRouter), amount);
         vaultRouter.deposit{value: gas}(vault, amount, self, self);
-        assertEq(erc20.balanceOf(address(globalEscrow)), amount);
+        assertEq(erc20.balanceOf(address(balanceSheet.poolEscrowProvider().escrow(PoolId.wrap(poolId)))), amount);
     }
 
     function testLockDepositRequests() public {


### PR DESCRIPTION
- Add test for sync deposits through router, fix missing allowance
- Block locking request for sync vaults in router
- Rename interfaces to ERC-7887