### PR TITLE
Fix: issueShares payment

### DIFF
--- a/src/hub/Hub.sol
+++ b/src/hub/Hub.sol
@@ -346,10 +346,11 @@ contract Hub is Multicall, Auth, Recoverable, IHub, IHubGatewayHandler {
         uint32 nowIssueEpochId,
         D18 navPoolPerShare
     ) external payable returns (uint128 issuedShareAmount, uint128 depositAssetAmount, uint128 depositPoolAmount) {
-        _isManager(poolId);
+        _isManagerAndPaid(poolId);
 
         (issuedShareAmount, depositAssetAmount, depositPoolAmount) =
             shareClassManager.issueShares(poolId, scId, depositAssetId, nowIssueEpochId, navPoolPerShare);
+
         sender.sendIssuedShares(poolId, scId, depositAssetId, issuedShareAmount, navPoolPerShare);
     }
 

--- a/test/hub/integration/BaseTest.sol
+++ b/test/hub/integration/BaseTest.sol
@@ -48,6 +48,12 @@ contract BaseTest is HubDeployer, Test {
     uint128 constant APPROVED_SHARE_AMOUNT = SHARE_AMOUNT / 5;
     D18 immutable NAV_PER_SHARE = d18(2, 1);
 
+    AccountId constant ASSET_USDC_ACCOUNT = AccountId.wrap(0x01);
+    AccountId constant EQUITY_ACCOUNT = AccountId.wrap(0x02);
+    AccountId constant LOSS_ACCOUNT = AccountId.wrap(0x03);
+    AccountId constant GAIN_ACCOUNT = AccountId.wrap(0x04);
+    AccountId constant ASSET_EUR_STABLE_ACCOUNT = AccountId.wrap(0x05);
+
     uint64 constant GAS = 100 wei;
 
     MockVaults cv;

--- a/test/hub/integration/Cases.t.sol
+++ b/test/hub/integration/Cases.t.sol
@@ -34,30 +34,24 @@ contract TestCases is BaseTest {
         hub.addShareClass(poolId, SC_NAME, SC_SYMBOL, SC_SALT);
         hub.notifyPool{value: GAS}(poolId, CHAIN_CV);
         hub.notifyShareClass{value: GAS}(poolId, scId, CHAIN_CV, SC_HOOK);
-        hub.createAccount(poolId, AccountId.wrap(0x01), true);
-        hub.createAccount(poolId, AccountId.wrap(0x02), false);
-        hub.createAccount(poolId, AccountId.wrap(0x03), false);
-        hub.createAccount(poolId, AccountId.wrap(0x04), false);
-        hub.createAccount(poolId, AccountId.wrap(0x05), true);
+
+        hub.createAccount(poolId, ASSET_USDC_ACCOUNT, true);
+        hub.createAccount(poolId, EQUITY_ACCOUNT, false);
+        hub.createAccount(poolId, LOSS_ACCOUNT, false);
+        hub.createAccount(poolId, GAIN_ACCOUNT, false);
+        hub.createAccount(poolId, ASSET_EUR_STABLE_ACCOUNT, true);
         hub.createHolding(
-            poolId,
-            scId,
-            USDC_C2,
-            identityValuation,
-            AccountId.wrap(0x01),
-            AccountId.wrap(0x02),
-            AccountId.wrap(0x03),
-            AccountId.wrap(0x04)
+            poolId, scId, USDC_C2, identityValuation, ASSET_USDC_ACCOUNT, EQUITY_ACCOUNT, LOSS_ACCOUNT, GAIN_ACCOUNT
         );
         hub.createHolding(
             poolId,
             scId,
             EUR_STABLE_C2,
             transientValuation,
-            AccountId.wrap(0x05),
-            AccountId.wrap(0x02),
-            AccountId.wrap(0x03),
-            AccountId.wrap(0x04)
+            ASSET_EUR_STABLE_ACCOUNT,
+            EQUITY_ACCOUNT,
+            LOSS_ACCOUNT,
+            GAIN_ACCOUNT
         );
         hub.updateContract{value: GAS}(
             poolId,
@@ -70,15 +64,11 @@ contract TestCases is BaseTest {
                 kind: uint8(VaultUpdateKind.DeployAndLink)
             }).serialize()
         );
-        vm.stopPrank();
 
-        assertEq(hubRegistry.metadata(poolId), "Testing pool");
-        assertEq(shareClassManager.exists(poolId, scId), true);
-
-        MessageLib.NotifyPool memory m0 = MessageLib.deserializeNotifyPool(cv.lastMessages(0));
+        MessageLib.NotifyPool memory m0 = MessageLib.deserializeNotifyPool(cv.popMessage());
         assertEq(m0.poolId, poolId.raw());
 
-        MessageLib.NotifyShareClass memory m1 = MessageLib.deserializeNotifyShareClass(cv.lastMessages(1));
+        MessageLib.NotifyShareClass memory m1 = MessageLib.deserializeNotifyShareClass(cv.popMessage());
         assertEq(m1.poolId, poolId.raw());
         assertEq(m1.scId, scId.raw());
         assertEq(m1.name, SC_NAME);
@@ -87,7 +77,7 @@ contract TestCases is BaseTest {
         assertEq(m1.salt, SC_SALT);
         assertEq(m1.hook, SC_HOOK);
 
-        MessageLib.UpdateContract memory m2 = MessageLib.deserializeUpdateContract(cv.lastMessages(2));
+        MessageLib.UpdateContract memory m2 = MessageLib.deserializeUpdateContract(cv.popMessage());
         assertEq(m2.scId, scId.raw());
         assertEq(m2.target, bytes32("target"));
 
@@ -95,8 +85,6 @@ contract TestCases is BaseTest {
         assertEq(m3.assetId, USDC_C2.raw());
         assertEq(m3.vaultOrFactory, bytes32("factory"));
         assertEq(m3.kind, uint8(VaultUpdateKind.DeployAndLink));
-
-        cv.resetMessages();
     }
 
     /// forge-config: default.isolate = true
@@ -109,30 +97,35 @@ contract TestCases is BaseTest {
         hub.approveDeposits{value: GAS}(
             poolId, scId, USDC_C2, shareClassManager.nowDepositEpoch(scId, USDC_C2), APPROVED_INVESTOR_AMOUNT
         );
-        hub.issueShares(poolId, scId, USDC_C2, shareClassManager.nowIssueEpoch(scId, USDC_C2), NAV_PER_SHARE);
-        vm.stopPrank();
+        hub.issueShares{value: GAS}(
+            poolId, scId, USDC_C2, shareClassManager.nowIssueEpoch(scId, USDC_C2), NAV_PER_SHARE
+        );
 
-        vm.prank(ANY);
+        vm.startPrank(ANY);
         vm.deal(ANY, GAS);
         hub.notifyDeposit{value: GAS}(
             poolId, scId, USDC_C2, INVESTOR, shareClassManager.maxDepositClaims(scId, INVESTOR, USDC_C2)
         );
 
-        assertEq(cv.messageCount(), 2);
-        MessageLib.ApprovedDeposits memory m0 = MessageLib.deserializeApprovedDeposits(cv.lastMessages(0));
+        MessageLib.ApprovedDeposits memory m0 = MessageLib.deserializeApprovedDeposits(cv.popMessage());
         assertEq(m0.poolId, poolId.raw());
         assertEq(m0.scId, scId.raw());
         assertEq(m0.assetId, USDC_C2.raw());
         assertEq(m0.assetAmount, APPROVED_INVESTOR_AMOUNT);
 
-        MessageLib.FulfilledDepositRequest memory m1 = MessageLib.deserializeFulfilledDepositRequest(cv.lastMessages(1));
+        MessageLib.IssuedShares memory m1 = MessageLib.deserializeIssuedShares(cv.popMessage());
         assertEq(m1.poolId, poolId.raw());
         assertEq(m1.scId, scId.raw());
-        assertEq(m1.investor, INVESTOR);
-        assertEq(m1.assetId, USDC_C2.raw());
-        assertEq(m1.assetAmount, APPROVED_INVESTOR_AMOUNT);
+        assertEq(m1.pricePoolPerShare, NAV_PER_SHARE.raw());
+
+        MessageLib.FulfilledDepositRequest memory m2 = MessageLib.deserializeFulfilledDepositRequest(cv.popMessage());
+        assertEq(m2.poolId, poolId.raw());
+        assertEq(m2.scId, scId.raw());
+        assertEq(m2.investor, INVESTOR);
+        assertEq(m2.assetId, USDC_C2.raw());
+        assertEq(m2.assetAmount, APPROVED_INVESTOR_AMOUNT);
         assertEq(
-            m1.shareAmount,
+            m2.shareAmount,
             PricingLib.convertWithPrice(
                 APPROVED_INVESTOR_AMOUNT,
                 hubRegistry.decimals(USDC_C2),
@@ -140,8 +133,6 @@ contract TestCases is BaseTest {
                 NAV_PER_SHARE.reciprocal()
             ).toUint128()
         );
-
-        cv.resetMessages();
     }
 
     /// forge-config: default.isolate = true
@@ -161,23 +152,20 @@ contract TestCases is BaseTest {
         hub.revokeShares{value: GAS}(
             poolId, scId, USDC_C2, shareClassManager.nowRevokeEpoch(scId, USDC_C2), NAV_PER_SHARE
         );
-        vm.stopPrank();
 
-        vm.prank(ANY);
+        vm.startPrank(ANY);
         vm.deal(ANY, GAS);
         hub.notifyRedeem{value: GAS}(
             poolId, scId, USDC_C2, INVESTOR, shareClassManager.maxRedeemClaims(scId, INVESTOR, USDC_C2)
         );
 
-        assertEq(cv.messageCount(), 2);
-
-        MessageLib.RevokedShares memory m0 = MessageLib.deserializeRevokedShares(cv.lastMessages(0));
+        MessageLib.RevokedShares memory m0 = MessageLib.deserializeRevokedShares(cv.popMessage());
         assertEq(m0.poolId, poolId.raw());
         assertEq(m0.scId, scId.raw());
         assertEq(m0.assetId, USDC_C2.raw());
         assertEq(m0.assetAmount, revokedAssetAmount);
 
-        MessageLib.FulfilledRedeemRequest memory m1 = MessageLib.deserializeFulfilledRedeemRequest(cv.lastMessages(1));
+        MessageLib.FulfilledRedeemRequest memory m1 = MessageLib.deserializeFulfilledRedeemRequest(cv.popMessage());
         assertEq(m1.poolId, poolId.raw());
         assertEq(m1.scId, scId.raw());
         assertEq(m1.investor, INVESTOR);
@@ -192,22 +180,19 @@ contract TestCases is BaseTest {
         uint128 poolDecimals = (10 ** hubRegistry.decimals(USD.raw())).toUint128();
         uint128 assetDecimals = (10 ** hubRegistry.decimals(USDC_C2.raw())).toUint128();
 
-        AccountId equityAccount = holdings.accountId(poolId, scId, USDC_C2, uint8(AccountType.Equity));
-        AccountId assetAccount = holdings.accountId(poolId, scId, USDC_C2, uint8(AccountType.Asset));
-
         cv.updateHoldingAmount(poolId, scId, USDC_C2, 1000 * assetDecimals, D18.wrap(1e18), true);
 
         assertEq(holdings.amount(poolId, scId, USDC_C2), 1000 * assetDecimals);
         assertEq(holdings.value(poolId, scId, USDC_C2), 1000 * poolDecimals);
-        _assertEqAccountValue(poolId, equityAccount, true, 1000 * poolDecimals);
-        _assertEqAccountValue(poolId, assetAccount, true, 1000 * poolDecimals);
+        _assertEqAccountValue(poolId, EQUITY_ACCOUNT, true, 1000 * poolDecimals);
+        _assertEqAccountValue(poolId, ASSET_USDC_ACCOUNT, true, 1000 * poolDecimals);
 
         cv.updateHoldingAmount(poolId, scId, USDC_C2, 600 * assetDecimals, D18.wrap(1e18), false);
 
         assertEq(holdings.amount(poolId, scId, USDC_C2), 400 * assetDecimals);
         assertEq(holdings.value(poolId, scId, USDC_C2), 400 * poolDecimals);
-        _assertEqAccountValue(poolId, assetAccount, true, 400 * poolDecimals);
-        _assertEqAccountValue(poolId, equityAccount, true, 400 * poolDecimals);
+        _assertEqAccountValue(poolId, ASSET_USDC_ACCOUNT, true, 400 * poolDecimals);
+        _assertEqAccountValue(poolId, EQUITY_ACCOUNT, true, 400 * poolDecimals);
     }
 
     /// forge-config: default.isolate = true
@@ -239,14 +224,12 @@ contract TestCases is BaseTest {
         hub.notifyAssetPrice{value: GAS}(poolId, scId, EUR_STABLE_C2);
         hub.notifyAssetPrice{value: GAS}(poolId, scId, USDC_C2);
         hub.notifySharePrice{value: GAS}(poolId, scId, CHAIN_CV);
-        vm.stopPrank();
 
-        assertEq(cv.messageCount(), 3);
-
-        MessageLib.NotifyPricePoolPerShare memory m0 = MessageLib.deserializeNotifyPricePoolPerShare(cv.popMessage());
+        MessageLib.NotifyPricePoolPerAsset memory m0 = MessageLib.deserializeNotifyPricePoolPerAsset(cv.popMessage());
         assertEq(m0.poolId, poolId.raw());
         assertEq(m0.scId, scId.raw());
-        assertEq(m0.price, sharePrice.raw(), "Share price mismatch");
+        assertEq(m0.assetId, EUR_STABLE_C2.raw());
+        assertEq(m0.price, poolPerEurPrice.inner(), "EUR price mismatch");
         assertEq(m0.timestamp, block.timestamp.toUint64());
 
         MessageLib.NotifyPricePoolPerAsset memory m1 = MessageLib.deserializeNotifyPricePoolPerAsset(cv.popMessage());
@@ -256,11 +239,10 @@ contract TestCases is BaseTest {
         assertEq(m1.price, identityPrice.inner(), "USDC price mismatch");
         assertEq(m1.timestamp, block.timestamp.toUint64());
 
-        MessageLib.NotifyPricePoolPerAsset memory m2 = MessageLib.deserializeNotifyPricePoolPerAsset(cv.popMessage());
+        MessageLib.NotifyPricePoolPerShare memory m2 = MessageLib.deserializeNotifyPricePoolPerShare(cv.popMessage());
         assertEq(m2.poolId, poolId.raw());
         assertEq(m2.scId, scId.raw());
-        assertEq(m2.assetId, EUR_STABLE_C2.raw());
-        assertEq(m2.price, poolPerEurPrice.inner(), "EUR price mismatch");
+        assertEq(m2.price, sharePrice.raw(), "Share price mismatch");
         assertEq(m2.timestamp, block.timestamp.toUint64());
     }
 }

--- a/test/hub/mocks/MockVaults.sol
+++ b/test/hub/mocks/MockVaults.sol
@@ -26,7 +26,6 @@ contract MockVaults is Test, Auth, IAdapter {
     IMessageHandler public handler;
     uint16 public sourceChainId;
 
-    uint32[] public lastChainDestinations;
     bytes[] public lastMessages;
 
     constructor(uint16 centrifugeId, IMessageHandler handler_) Auth(msg.sender) {
@@ -70,13 +69,7 @@ contract MockVaults is Test, Auth, IAdapter {
         );
     }
 
-    function send(uint16 centrifugeId, bytes memory data, uint256, address)
-        external
-        payable
-        returns (bytes32 adapterData)
-    {
-        lastChainDestinations.push(centrifugeId);
-
+    function send(uint16, bytes memory data, uint256, address) external payable returns (bytes32 adapterData) {
         while (data.length > 0) {
             uint16 messageLength = data.messageLength();
             bytes memory message = data.slice(0, messageLength);
@@ -130,7 +123,6 @@ contract MockVaults is Test, Auth, IAdapter {
     }
 
     function resetMessages() external {
-        delete lastChainDestinations;
         delete lastMessages;
     }
 
@@ -138,11 +130,15 @@ contract MockVaults is Test, Auth, IAdapter {
         return lastMessages.length;
     }
 
-    function popMessage() external returns (bytes memory) {
+    function popMessage() external returns (bytes memory message) {
         require(lastMessages.length > 0, "mockVaults/no-msgs");
 
-        bytes memory popped = lastMessages[lastMessages.length - 1];
+        message = lastMessages[0];
+
+        for (uint256 i = 1; i < lastMessages.length; i++) {
+            lastMessages[i - 1] = lastMessages[i];
+        }
+
         lastMessages.pop();
-        return popped;
     }
 }

--- a/test/integration/EndToEnd.t.sol
+++ b/test/integration/EndToEnd.t.sol
@@ -256,17 +256,19 @@ contract TestEndToEnd is Test {
         ERC20(asset).approve(address(vault), INVESTOR_A_AMOUNT);
         vault.requestDeposit(INVESTOR_A_AMOUNT, INVESTOR_A, INVESTOR_A);
 
-        uint32 depositEpochId = h.hub.shareClassManager().nowDepositEpoch(scId, assetId);
         vm.startPrank(FM);
+        uint32 depositEpochId = h.hub.shareClassManager().nowDepositEpoch(scId, assetId);
         h.hub.approveDeposits{value: GAS}(poolId, scId, assetId, depositEpochId, INVESTOR_A_AMOUNT);
-        h.hub.issueShares(poolId, scId, assetId, depositEpochId, IDENTITY_PRICE);
+        h.hub.issueShares{value: GAS}(poolId, scId, assetId, depositEpochId, IDENTITY_PRICE);
 
         vm.startPrank(ANY);
-        h.hub.notifyDeposit{value: GAS}(poolId, scId, assetId, INVESTOR_A.toBytes32(), 1);
+        uint32 maxClaims = h.shareClassManager.maxDepositClaims(scId, INVESTOR_A.toBytes32(), assetId);
+        h.hub.notifyDeposit{value: GAS}(poolId, scId, assetId, INVESTOR_A.toBytes32(), maxClaims);
 
-        //vault.mint(INVESTOR_A_AMOUNT, INVESTOR_A);
+        vm.startPrank(INVESTOR_A);
+        vault.mint(INVESTOR_A_AMOUNT, INVESTOR_A);
 
-        //assertEq(shareToken.balanceOf(INVESTOR_A), INVESTOR_A_AMOUNT);
+        assertEq(shareToken.balanceOf(INVESTOR_A), INVESTOR_A_AMOUNT);
     }
 
     /// forge-config: default.isolate = true


### PR DESCRIPTION
`hub.issueShares` did not take into account the payment, so all value paid was skipped, making the message fail, and the user's funds lost.

Along with this fix, I added some test simplifications to `Cases.t.sol`