### PR TITLE
Remove hub from common dep & gateway dep

### DIFF
--- a/script/VaultsDeployer.s.sol
+++ b/script/VaultsDeployer.s.sol
@@ -188,7 +188,6 @@ contract VaultsDeployer is CommonDeployer {
         syncRequestManager.file("poolEscrowProvider", address(poolEscrowFactory));
 
         balanceSheet.file("poolManager", address(poolManager));
-        balanceSheet.file("gateway", address(gateway));
         balanceSheet.file("sender", address(messageDispatcher));
         balanceSheet.file("poolEscrowProvider", address(poolEscrowFactory));
 

--- a/snapshots/AsyncVault.json
+++ b/snapshots/AsyncVault.json
@@ -1,4 +1,4 @@
 {
-  "fulfillDepositRequest": "1340461",
+  "fulfillDepositRequest": "1340416",
   "requestDeposit": "516123"
 }

--- a/snapshots/VaultRouter.json
+++ b/snapshots/VaultRouter.json
@@ -1,7 +1,7 @@
 {
-  "claimDeposit": "1580932",
+  "claimDeposit": "1580887",
   "enable": "60953",
   "lockDepositRequest": "95797",
   "requestDeposit": "553289",
-  "requestRedeem": "2514538"
+  "requestRedeem": "2514493"
 }

--- a/src/common/Guardian.sol
+++ b/src/common/Guardian.sol
@@ -9,15 +9,14 @@ import {IRoot} from "src/common/interfaces/IRoot.sol";
 import {IAdapter} from "src/common/interfaces/IAdapter.sol";
 import {IGuardian, ISafe} from "src/common/interfaces/IGuardian.sol";
 import {IRootMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
-
-import {IHub} from "src/hub/interfaces/IHub.sol";
+import {IHubGuardianActions} from "src/common/interfaces/IGuardianActions.sol";
 
 contract Guardian is IGuardian {
     using CastLib for address;
 
     IRoot public immutable root;
 
-    IHub public hub;
+    IHubGuardianActions public hub;
     ISafe public safe;
     IRootMessageSender public sender;
 
@@ -45,7 +44,7 @@ contract Guardian is IGuardian {
     function file(bytes32 what, address data) external onlySafe {
         if (what == "safe") safe = ISafe(data);
         else if (what == "sender") sender = IRootMessageSender(data);
-        else if (what == "hub") hub = IHub(data);
+        else if (what == "hub") hub = IHubGuardianActions(data);
         else revert FileUnrecognizedParam();
 
         emit File(what, data);

--- a/src/common/interfaces/IGuardianActions.sol
+++ b/src/common/interfaces/IGuardianActions.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity >=0.5.0;
+
+import {AssetId} from "src/common/types/AssetId.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
+
+interface IHubGuardianActions {
+    /// @notice Creates a new pool. `msg.sender` will be the admin of the created pool.
+    /// @param currency The pool currency. Usually an AssetId identifying by a ISO4217 code.
+    function createPool(PoolId poolId, address admin, AssetId currency) external payable;
+}

--- a/src/hub/Hub.sol
+++ b/src/hub/Hub.sol
@@ -11,7 +11,7 @@ import {Recoverable} from "src/misc/Recoverable.sol";
 import {IGateway} from "src/common/interfaces/IGateway.sol";
 import {IHubGatewayHandler} from "src/common/interfaces/IGatewayHandlers.sol";
 import {IPoolMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
-
+import {IHubGuardianActions} from "src/common/interfaces/IGuardianActions.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
 import {AccountId} from "src/common/types/AccountId.sol";
@@ -28,7 +28,7 @@ import {IHub, AccountType} from "src/hub/interfaces/IHub.sol";
 ///         Pools can assign hub managers which have full rights over all actions.
 ///
 ///         Also acts as the central contract that routes messages from other chains to the Hub contracts.
-contract Hub is Multicall, Auth, Recoverable, IHub, IHubGatewayHandler {
+contract Hub is Multicall, Auth, Recoverable, IHub, IHubGatewayHandler, IHubGuardianActions {
     using MathLib for uint256;
 
     IHubRegistry public immutable hubRegistry;
@@ -88,7 +88,7 @@ contract Hub is Multicall, Auth, Recoverable, IHub, IHubGatewayHandler {
         }
     }
 
-    /// @inheritdoc IHub
+    /// @inheritdoc IHubGuardianActions
     function createPool(PoolId poolId, address admin, AssetId currency) external payable {
         _auth();
 

--- a/src/hub/interfaces/IHub.sol
+++ b/src/hub/interfaces/IHub.sol
@@ -79,10 +79,6 @@ interface IHub {
     /// sender' as string value.
     function file(bytes32 what, address data) external;
 
-    /// @notice Creates a new pool. `msg.sender` will be the admin of the created pool.
-    /// @param currency The pool currency. Usually an AssetId identifying by a ISO4217 code.
-    function createPool(PoolId poolId, address admin, AssetId currency) external payable;
-
     /// @notice Notify a deposit for an investor address located in the chain where the asset belongs
     function notifyDeposit(PoolId poolId, ShareClassId scId, AssetId depositAssetId, bytes32 investor, uint32 maxClaims)
         external

--- a/src/vaults/BalanceSheet.sol
+++ b/src/vaults/BalanceSheet.sol
@@ -41,7 +41,6 @@ contract BalanceSheet is Auth, Recoverable, IBalanceSheet, IBalanceSheetGatewayH
 
     IRoot public immutable root;
 
-    IGateway public gateway;
     IPoolManager public poolManager;
     IVaultMessageSender public sender;
     IPoolEscrowProvider public poolEscrowProvider;
@@ -66,8 +65,7 @@ contract BalanceSheet is Auth, Recoverable, IBalanceSheet, IBalanceSheetGatewayH
     //----------------------------------------------------------------------------------------------
 
     function file(bytes32 what, address data) external auth {
-        if (what == "gateway") gateway = IGateway(data);
-        else if (what == "poolManager") poolManager = IPoolManager(data);
+        if (what == "poolManager") poolManager = IPoolManager(data);
         else if (what == "sender") sender = IVaultMessageSender(data);
         else if (what == "poolEscrowProvider") poolEscrowProvider = IPoolEscrowProvider(data);
         else revert FileUnrecognizedParam();

--- a/test/vaults/integration/BalanceSheet.t.sol
+++ b/test/vaults/integration/BalanceSheet.t.sol
@@ -62,8 +62,8 @@ contract BalanceSheetTest is BaseTest {
     function testDeployment(address nonWard) public {
         vm.assume(
             nonWard != address(root) && nonWard != address(asyncRequestManager)
-                && nonWard != address(syncRequestManager) && nonWard != address(gateway)
-                && nonWard != address(messageProcessor) && nonWard != address(messageDispatcher) && nonWard != address(this)
+                && nonWard != address(syncRequestManager) && nonWard != address(messageProcessor)
+                && nonWard != address(messageDispatcher) && nonWard != address(this)
         );
 
         // redeploying within test to increase coverage
@@ -71,7 +71,6 @@ contract BalanceSheetTest is BaseTest {
 
         // values set correctly
         assertEq(address(balanceSheet.root()), address(root));
-        assertEq(address(balanceSheet.gateway()), address(gateway));
         assertEq(address(balanceSheet.poolManager()), address(poolManager));
         assertEq(address(balanceSheet.sender()), address(messageDispatcher));
         assertEq(address(balanceSheet.poolEscrowProvider()), address(poolEscrowFactory));
@@ -91,12 +90,9 @@ contract BalanceSheetTest is BaseTest {
         vm.expectRevert(IBalanceSheet.FileUnrecognizedParam.selector);
         balanceSheet.file("random", self);
 
-        assertEq(address(balanceSheet.gateway()), address(gateway));
         // success
         balanceSheet.file("poolManager", randomUser);
         assertEq(address(balanceSheet.poolManager()), randomUser);
-        balanceSheet.file("gateway", randomUser);
-        assertEq(address(balanceSheet.gateway()), randomUser);
         balanceSheet.file("sender", randomUser);
         assertEq(address(balanceSheet.sender()), randomUser);
         balanceSheet.file("poolEscrowProvider", randomUser);


### PR DESCRIPTION
- Remove unused `gateway` dependency in `BalanceSheet`
- Detach `common` module from knowing about the `hub` by using `IHubGuardianActions` interface.