### PR TITLE
Fix: start/end transactional payment

### DIFF
--- a/snapshots/AsyncVault.json
+++ b/snapshots/AsyncVault.json
@@ -1,9 +1,4 @@
 {
-<<<<<<< HEAD
-  "fulfillDepositRequest": "1302110",
-  "requestDeposit": "513710"
-=======
-  "fulfillDepositRequest": "1304465",
-  "requestDeposit": "515865"
->>>>>>> 8a167b43 (fix)
+  "fulfillDepositRequest": "1301859",
+  "requestDeposit": "513553"
 }

--- a/snapshots/AsyncVault.json
+++ b/snapshots/AsyncVault.json
@@ -1,4 +1,4 @@
 {
-  "fulfillDepositRequest": "1301917",
-  "requestDeposit": "513688"
+  "fulfillDepositRequest": "1302110",
+  "requestDeposit": "513710"
 }

--- a/snapshots/AsyncVault.json
+++ b/snapshots/AsyncVault.json
@@ -1,4 +1,9 @@
 {
+<<<<<<< HEAD
   "fulfillDepositRequest": "1302110",
   "requestDeposit": "513710"
+=======
+  "fulfillDepositRequest": "1304465",
+  "requestDeposit": "515865"
+>>>>>>> 8a167b43 (fix)
 }

--- a/snapshots/VaultRouter.json
+++ b/snapshots/VaultRouter.json
@@ -1,7 +1,7 @@
 {
-  "claimDeposit": "1504206",
+  "claimDeposit": "1504399",
   "enable": "60953",
-  "lockDepositRequest": "95775",
-  "requestDeposit": "550854",
-  "requestRedeem": "2401523"
+  "lockDepositRequest": "95776",
+  "requestDeposit": "552939",
+  "requestRedeem": "2418767"
 }

--- a/snapshots/VaultRouter.json
+++ b/snapshots/VaultRouter.json
@@ -1,7 +1,15 @@
 {
+<<<<<<< HEAD
   "claimDeposit": "1504399",
   "enable": "60953",
   "lockDepositRequest": "95776",
   "requestDeposit": "552939",
   "requestRedeem": "2418767"
+=======
+  "claimDeposit": "1545090",
+  "enable": "60953",
+  "lockDepositRequest": "95798",
+  "requestDeposit": "554983",
+  "requestRedeem": "2495569"
+>>>>>>> 8a167b43 (fix)
 }

--- a/snapshots/VaultRouter.json
+++ b/snapshots/VaultRouter.json
@@ -1,15 +1,7 @@
 {
-<<<<<<< HEAD
-  "claimDeposit": "1504399",
+  "claimDeposit": "1504148",
   "enable": "60953",
   "lockDepositRequest": "95776",
-  "requestDeposit": "552939",
-  "requestRedeem": "2418767"
-=======
-  "claimDeposit": "1545090",
-  "enable": "60953",
-  "lockDepositRequest": "95798",
-  "requestDeposit": "554983",
-  "requestRedeem": "2495569"
->>>>>>> 8a167b43 (fix)
+  "requestDeposit": "552649",
+  "requestRedeem": "2418756"
 }

--- a/src/common/Gateway.sol
+++ b/src/common/Gateway.sol
@@ -278,7 +278,6 @@ contract Gateway is Auth, Recoverable, IGateway {
             TransientBytesLib.append(batchSlot, message);
         } else {
             _send(centrifugeId, poolId, message, gasService.gasLimit(centrifugeId, message));
-            _refundTransaction();
         }
     }
 
@@ -376,19 +375,6 @@ contract Gateway is Auth, Recoverable, IGateway {
         emit RepayBatch(centrifugeId, batch);
     }
 
-    function _refundTransaction() internal {
-        if (transactionRefund == address(0)) return;
-
-        if (fuel > 0) {
-            (bool success,) = payable(transactionRefund).call{value: fuel}(new bytes(0));
-
-            if (!success) {
-                // If refund fails, move remaining fuel to global pot
-                _subsidizePool(GLOBAL_POT, transactionRefund, fuel);
-            }
-        }
-    }
-
     function _requestPoolFunding(PoolId poolId) internal {
         IRecoverable refund = subsidy[poolId].refund;
         if (!poolId.isNull() && address(refund) != address(0)) {
@@ -429,8 +415,22 @@ contract Gateway is Auth, Recoverable, IGateway {
 
     /// @inheritdoc IGateway
     function endTransactionPayment() external auth {
-        transactionRefund = address(0);
+        if (transactionRefund == address(0)) return;
+
+        // Reset before external call
+        uint256 fuel_ = fuel;
+        address transactionRefund_ = transactionRefund;
         fuel = 0;
+        transactionRefund = address(0);
+
+        if (fuel_ > 0) {
+            (bool success,) = payable(transactionRefund_).call{value: fuel_}(new bytes(0));
+
+            if (!success) {
+                // If refund fails, move remaining fuel to global pot
+                _subsidizePool(GLOBAL_POT, transactionRefund_, fuel_);
+            }
+        }
     }
 
     /// @inheritdoc IGateway
@@ -456,8 +456,6 @@ contract Gateway is Auth, Recoverable, IGateway {
             TransientBytesLib.clear(outboundBatchSlot);
             _gasLimitSlot(centrifugeId, poolId).tstore(uint256(0));
         }
-
-        _refundTransaction();
     }
 
     function _encodeLocator(uint16 centrifugeId, PoolId poolId) internal pure returns (bytes32) {

--- a/src/common/interfaces/IGateway.sol
+++ b/src/common/interfaces/IGateway.sol
@@ -170,10 +170,13 @@ interface IGateway is IMessageHandler, IMessageSender {
     function subsidizePool(PoolId poolId) external payable;
 
     /// @notice Prepays for the TX cost for sending the messages through the adapters
-    ///         Currently being called from Vault Router only.
+    ///         Currently being called from Vault Router and Hub.
     ///         In order to prepay, the method MUST be called with `msg.value`.
     ///         Called is assumed to have called IGateway.estimate before calling this.
-    function payTransaction(address payer) external payable;
+    function startTransactionPayment(address payer) external payable;
+
+    /// @notice Finalize the transaction payment mode, next payments will be subsidized (as default).
+    function endTransactionPayment() external;
 
     /// @notice Initialize batching message
     function startBatching() external;

--- a/src/hub/interfaces/IHubHelpers.sol
+++ b/src/hub/interfaces/IHubHelpers.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity >=0.5.0;
+
+import {D18} from "src/misc/types/D18.sol";
+
+import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
+import {AccountId} from "src/common/types/AccountId.sol";
+
+import {HoldingAccount} from "src/hub/interfaces/IHoldings.sol";
+
+interface IHubHelpers {
+    /// @notice Emitted when a call to `file()` was performed.
+    event File(bytes32 what, address addr);
+
+    /// @notice Dispatched when the `what` parameter of `file()` is not supported by the implementation.
+    error FileUnrecognizedParam();
+
+    /// @notice Updates a contract parameter.
+    /// @param what Name of the parameter to update.
+    /// Accepts a `bytes32` representation of 'hub'
+    function file(bytes32 what, address data) external;
+
+    /// @notice Notify a deposit for an investor address located in the chain where the asset belongs
+    function notifyDeposit(PoolId poolId, ShareClassId scId, AssetId assetId, bytes32 investor, uint32 maxClaims)
+        external
+        returns (uint128 totalPayoutShareAmount, uint128 totalPaymentAssetAmount, uint128 cancelledAssetAmount);
+
+    /// @notice Notify a redemption for an investor address located in the chain where the asset belongs
+    function notifyRedeem(PoolId poolId, ShareClassId scId, AssetId assetId, bytes32 investor, uint32 maxClaims)
+        external
+        returns (uint128 totalPayoutAssetAmount, uint128 totalPaymentShareAmount, uint128 cancelledShareAmount);
+
+    function updateAccountingAmount(PoolId poolId, ShareClassId scId, AssetId assetId, bool isPositive, uint128 diff)
+        external;
+
+    function updateAccountingValue(PoolId poolId, ShareClassId scId, AssetId assetId, bool isPositive, uint128 diff)
+        external;
+
+    function holdingAccounts(
+        AccountId assetAccount,
+        AccountId equityAccount,
+        AccountId gainAccount,
+        AccountId lossAccount
+    ) external pure returns (HoldingAccount[] memory accounts);
+
+    function liabilityAccounts(AccountId expenseAccount, AccountId liabilityAccount)
+        external
+        pure
+        returns (HoldingAccount[] memory accounts);
+
+    function pricePoolPerAsset(PoolId poolId, ShareClassId scId, AssetId assetId) external view returns (D18);
+}

--- a/src/vaults/PoolManager.sol
+++ b/src/vaults/PoolManager.sol
@@ -126,13 +126,15 @@ contract PoolManager is
             CrossChainTransferNotAllowed()
         );
 
-        gateway.payTransaction{value: msg.value}(msg.sender);
+        gateway.startTransactionPayment{value: msg.value}(msg.sender);
 
         share.authTransferFrom(msg.sender, msg.sender, address(this), amount);
         share.burn(address(this), amount);
 
         emit TransferShares(centrifugeId, poolId, scId, msg.sender, receiver, amount);
         sender.sendTransferShares(centrifugeId, poolId, scId, receiver, amount);
+
+        gateway.endTransactionPayment();
     }
 
     // @inheritdoc IPoolManager
@@ -150,7 +152,7 @@ contract PoolManager is
         require(decimals >= MIN_DECIMALS, TooFewDecimals());
         require(decimals <= MAX_DECIMALS, TooManyDecimals());
 
-        gateway.payTransaction{value: msg.value}(msg.sender);
+        gateway.startTransactionPayment{value: msg.value}(msg.sender);
 
         if (tokenId == 0) {
             IERC20Metadata meta = IERC20Metadata(asset);
@@ -174,6 +176,8 @@ contract PoolManager is
         }
 
         sender.sendRegisterAsset(centrifugeId, assetId, decimals);
+
+        gateway.endTransactionPayment();
     }
 
     //----------------------------------------------------------------------------------------------

--- a/src/vaults/VaultRouter.sol
+++ b/src/vaults/VaultRouter.sol
@@ -56,6 +56,16 @@ contract VaultRouter is Auth, Multicall, Recoverable, IVaultRouter {
         messageDispatcher = messageDispatcher_;
     }
 
+    modifier payTransaction() {
+        if (!gateway.isBatching()) {
+            gateway.startTransactionPayment{value: msg.value}(msg.sender);
+        }
+        _;
+        if (!gateway.isBatching()) {
+            gateway.endTransactionPayment();
+        }
+    }
+
     //----------------------------------------------------------------------------------------------
     // Administration
     //----------------------------------------------------------------------------------------------
@@ -66,13 +76,14 @@ contract VaultRouter is Auth, Multicall, Recoverable, IVaultRouter {
         bool wasBatching = gateway.isBatching();
         if (!wasBatching) {
             gateway.startBatching();
-            gateway.payTransaction{value: msg.value}(msg.sender);
+            gateway.startTransactionPayment{value: msg.value}(msg.sender);
         }
 
         super.multicall(data);
 
         if (!wasBatching) {
             gateway.endBatching();
+            gateway.endTransactionPayment();
         }
     }
 
@@ -96,6 +107,7 @@ contract VaultRouter is Auth, Multicall, Recoverable, IVaultRouter {
     function requestDeposit(IAsyncVault vault, uint256 amount, address controller, address owner)
         external
         payable
+        payTransaction
         protected
     {
         require(owner == msg.sender || owner == address(this), InvalidOwner());
@@ -105,7 +117,6 @@ contract VaultRouter is Auth, Multicall, Recoverable, IVaultRouter {
             _approveMax(vaultDetails.asset, address(vault));
         }
 
-        _pay();
         vault.requestDeposit(amount, controller, owner);
     }
 
@@ -113,6 +124,7 @@ contract VaultRouter is Auth, Multicall, Recoverable, IVaultRouter {
     function deposit(BaseSyncDepositVault vault, uint256 assets, address receiver, address owner)
         external
         payable
+        payTransaction
         protected
     {
         require(owner == msg.sender || owner == address(this), InvalidOwner());
@@ -122,7 +134,6 @@ contract VaultRouter is Auth, Multicall, Recoverable, IVaultRouter {
         SafeTransferLib.safeTransferFrom(vaultDetails.asset, owner, address(this), assets);
         _approveMax(vaultDetails.asset, address(vault));
 
-        _pay();
         vault.deposit(assets, receiver);
     }
 
@@ -173,7 +184,12 @@ contract VaultRouter is Auth, Multicall, Recoverable, IVaultRouter {
     }
 
     /// @inheritdoc IVaultRouter
-    function executeLockedDepositRequest(IAsyncVault vault, address controller) external payable protected {
+    function executeLockedDepositRequest(IAsyncVault vault, address controller)
+        external
+        payable
+        payTransaction
+        protected
+    {
         uint256 lockedRequest = lockedRequests[controller][vault];
         require(lockedRequest != 0, NoLockedRequest());
         lockedRequests[controller][vault] = 0;
@@ -181,7 +197,6 @@ contract VaultRouter is Auth, Multicall, Recoverable, IVaultRouter {
         VaultDetails memory vaultDetails = poolManager.vaultDetails(vault);
         escrow.authTransferTo(vaultDetails.asset, address(this), lockedRequest);
 
-        _pay();
         _approveMax(vaultDetails.asset, address(vault));
         vault.requestDeposit(lockedRequest, controller, address(this));
         emit ExecuteLockedDepositRequest(vault, controller, msg.sender);
@@ -195,8 +210,7 @@ contract VaultRouter is Auth, Multicall, Recoverable, IVaultRouter {
     }
 
     /// @inheritdoc IVaultRouter
-    function cancelDepositRequest(IAsyncVault vault) external payable protected {
-        _pay();
+    function cancelDepositRequest(IAsyncVault vault) external payable payTransaction protected {
         vault.cancelDepositRequest(REQUEST_ID, msg.sender);
     }
 
@@ -218,10 +232,10 @@ contract VaultRouter is Auth, Multicall, Recoverable, IVaultRouter {
     function requestRedeem(IAsyncVault vault, uint256 amount, address controller, address owner)
         external
         payable
+        payTransaction
         protected
     {
         require(owner == msg.sender || owner == address(this), InvalidOwner());
-        _pay();
         vault.requestRedeem(amount, controller, owner);
     }
 
@@ -241,8 +255,7 @@ contract VaultRouter is Auth, Multicall, Recoverable, IVaultRouter {
     }
 
     /// @inheritdoc IVaultRouter
-    function cancelRedeemRequest(IAsyncVault vault) external payable protected {
-        _pay();
+    function cancelRedeemRequest(IAsyncVault vault) external payable payTransaction protected {
         vault.cancelRedeemRequest(REQUEST_ID, msg.sender);
     }
 
@@ -312,13 +325,6 @@ contract VaultRouter is Auth, Multicall, Recoverable, IVaultRouter {
     function _approveMax(address asset, address spender) internal {
         if (IERC20(asset).allowance(address(this), spender) == 0) {
             SafeTransferLib.safeApprove(asset, spender, type(uint256).max);
-        }
-    }
-
-    /// @notice Send native tokens to the gateway for transaction payment if it's not in a multicall.
-    function _pay() internal {
-        if (!gateway.isBatching()) {
-            gateway.payTransaction{value: msg.value}(msg.sender);
         }
     }
 

--- a/test/common/unit/Gateway.t.sol
+++ b/test/common/unit/Gateway.t.sol
@@ -815,11 +815,11 @@ contract GatewayTestPayTransaction is GatewayTest {
         vm.deal(ANY, 100);
         vm.prank(ANY);
         vm.expectRevert(IAuth.NotAuthorized.selector);
-        gateway.payTransaction{value: 100}(TRANSIENT_REFUND);
+        gateway.startTransactionPayment{value: 100}(TRANSIENT_REFUND);
     }
 
     function testPayTransaction() public {
-        gateway.payTransaction{value: 100}(TRANSIENT_REFUND);
+        gateway.startTransactionPayment{value: 100}(TRANSIENT_REFUND);
 
         assertEq(gateway.transactionRefund(), TRANSIENT_REFUND);
         assertEq(gateway.fuel(), 100);
@@ -827,7 +827,7 @@ contract GatewayTestPayTransaction is GatewayTest {
 
     /// forge-config: default.isolate = true
     function testPayTransactionIsTransactional() public {
-        gateway.payTransaction{value: 100}(TRANSIENT_REFUND);
+        gateway.startTransactionPayment{value: 100}(TRANSIENT_REFUND);
 
         assertEq(gateway.transactionRefund(), address(0));
         assertEq(gateway.fuel(), 0);
@@ -890,7 +890,7 @@ contract GatewayTestSend is GatewayTest {
         bytes memory message = MessageKind.WithPoolA1.asBytes();
 
         uint256 payment = MESSAGE_GAS_LIMIT * 3 + ADAPTER_ESTIMATE_1 + ADAPTER_ESTIMATE_2 + ADAPTER_ESTIMATE_3 - 1;
-        gateway.payTransaction{value: payment}(TRANSIENT_REFUND);
+        gateway.startTransactionPayment{value: payment}(TRANSIENT_REFUND);
 
         _mockAdapters(REMOTE_CENT_ID, message, MESSAGE_GAS_LIMIT, TRANSIENT_REFUND);
 
@@ -1052,7 +1052,7 @@ contract GatewayTestSend is GatewayTest {
         bytes32 batchId = keccak256(abi.encodePacked(LOCAL_CENT_ID, REMOTE_CENT_ID, batchHash));
 
         uint256 payment = MESSAGE_GAS_LIMIT * 3 + ADAPTER_ESTIMATE_1 + ADAPTER_ESTIMATE_2 + ADAPTER_ESTIMATE_3 + 1234;
-        gateway.payTransaction{value: payment}(TRANSIENT_REFUND);
+        gateway.startTransactionPayment{value: payment}(TRANSIENT_REFUND);
 
         _mockAdapters(REMOTE_CENT_ID, message, MESSAGE_GAS_LIMIT, TRANSIENT_REFUND);
 
@@ -1068,7 +1068,6 @@ contract GatewayTestSend is GatewayTest {
 
         assertEq(TRANSIENT_REFUND.balance, 1234);
         assertEq(gateway.fuel(), 0);
-        assertEq(gateway.transactionRefund(), address(0));
     }
 }
 
@@ -1224,7 +1223,7 @@ contract GatewayTestEndBatching is GatewayTest {
 
         uint256 payment =
             MESSAGE_GAS_LIMIT * 2 * 3 + ADAPTER_ESTIMATE_1 + ADAPTER_ESTIMATE_2 + ADAPTER_ESTIMATE_3 + 1234;
-        gateway.payTransaction{value: payment}(TRANSIENT_REFUND);
+        gateway.startTransactionPayment{value: payment}(TRANSIENT_REFUND);
 
         _mockAdapters(REMOTE_CENT_ID, batch, MESSAGE_GAS_LIMIT * 2, TRANSIENT_REFUND);
 
@@ -1232,7 +1231,6 @@ contract GatewayTestEndBatching is GatewayTest {
 
         assertEq(TRANSIENT_REFUND.balance, 1234);
         assertEq(gateway.fuel(), 0);
-        assertEq(gateway.transactionRefund(), address(0));
     }
 
     function testSendMessageUnderpaid() public {

--- a/test/common/unit/Gateway.t.sol
+++ b/test/common/unit/Gateway.t.sol
@@ -1065,9 +1065,6 @@ contract GatewayTestSend is GatewayTest {
         vm.expectEmit();
         emit IGateway.SendProof(REMOTE_CENT_ID, batchId, batchHash, proofAdapter2, ADAPTER_DATA_3);
         gateway.send(REMOTE_CENT_ID, message);
-
-        assertEq(TRANSIENT_REFUND.balance, 1234);
-        assertEq(gateway.fuel(), 0);
     }
 }
 
@@ -1228,9 +1225,6 @@ contract GatewayTestEndBatching is GatewayTest {
         _mockAdapters(REMOTE_CENT_ID, batch, MESSAGE_GAS_LIMIT * 2, TRANSIENT_REFUND);
 
         gateway.endBatching();
-
-        assertEq(TRANSIENT_REFUND.balance, 1234);
-        assertEq(gateway.fuel(), 0);
     }
 
     function testSendMessageUnderpaid() public {

--- a/test/hub/unit/Hub.t.sol
+++ b/test/hub/unit/Hub.t.sol
@@ -8,7 +8,6 @@ import {IERC7726} from "src/misc/interfaces/IERC7726.sol";
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
 
 import {IGateway} from "src/common/interfaces/IGateway.sol";
-import {VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
 
 import {PoolId} from "src/common/types/PoolId.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
@@ -19,6 +18,7 @@ import {IHoldings} from "src/hub/interfaces/IHoldings.sol";
 import {IAccounting, JournalEntry} from "src/hub/interfaces/IAccounting.sol";
 import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
 import {IHub} from "src/hub/interfaces/IHub.sol";
+import {IHubHelpers} from "src/hub/interfaces/IHubHelpers.sol";
 import {Hub} from "src/hub/Hub.sol";
 
 contract TestCommon is Test {
@@ -30,12 +30,13 @@ contract TestCommon is Test {
     JournalEntry[] EMPTY;
 
     IHubRegistry immutable hubRegistry = IHubRegistry(makeAddr("HubRegistry"));
+    IHubHelpers immutable hubHelpers = IHubHelpers(makeAddr("HubHelpers"));
     IHoldings immutable holdings = IHoldings(makeAddr("Holdings"));
     IAccounting immutable accounting = IAccounting(makeAddr("Accounting"));
     IShareClassManager immutable scm = IShareClassManager(makeAddr("ShareClassManager"));
     IGateway immutable gateway = IGateway(makeAddr("Gateway"));
 
-    Hub hub = new Hub(scm, hubRegistry, accounting, holdings, gateway, address(this));
+    Hub hub = new Hub(gateway, holdings, hubHelpers, accounting, hubRegistry, scm, address(this));
 
     function setUp() public {
         vm.mockCall(

--- a/test/hub/unit/HubHelpers.t.sol
+++ b/test/hub/unit/HubHelpers.t.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+
+import {IAuth} from "src/misc/interfaces/IAuth.sol";
+
+import {PoolId} from "src/common/types/PoolId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
+import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
+import {IHoldings} from "src/hub/interfaces/IHoldings.sol";
+import {IAccounting} from "src/hub/interfaces/IAccounting.sol";
+import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
+import {Hub} from "src/hub/Hub.sol";
+import {HubHelpers} from "src/hub/HubHelpers.sol";
+
+contract TestCommon is Test {
+    IHoldings immutable holdings = IHoldings(makeAddr("Holdings"));
+    IAccounting immutable accounting = IAccounting(makeAddr("Accounting"));
+    IHubRegistry immutable hubRegistry = IHubRegistry(makeAddr("HubRegistry"));
+    IShareClassManager immutable scm = IShareClassManager(makeAddr("ShareClassManager"));
+
+    HubHelpers hubHelpers = new HubHelpers(holdings, accounting, hubRegistry, scm, address(this));
+}
+
+contract TestMainMethodsChecks is TestCommon {
+    function testErrNotAuthotized() public {
+        vm.startPrank(makeAddr("noWard"));
+
+        vm.expectRevert(IAuth.NotAuthorized.selector);
+        hubHelpers.notifyDeposit(PoolId.wrap(0), ShareClassId.wrap(0), AssetId.wrap(0), bytes32(0), 0);
+
+        vm.expectRevert(IAuth.NotAuthorized.selector);
+        hubHelpers.notifyRedeem(PoolId.wrap(0), ShareClassId.wrap(0), AssetId.wrap(0), bytes32(0), 0);
+
+        vm.expectRevert(IAuth.NotAuthorized.selector);
+        hubHelpers.updateAccountingAmount(PoolId.wrap(0), ShareClassId.wrap(0), AssetId.wrap(0), true, 0);
+
+        vm.expectRevert(IAuth.NotAuthorized.selector);
+        hubHelpers.updateAccountingValue(PoolId.wrap(0), ShareClassId.wrap(0), AssetId.wrap(0), true, 0);
+
+        vm.stopPrank();
+    }
+}

--- a/test/vaults/unit/VaultRouter.t.sol
+++ b/test/vaults/unit/VaultRouter.t.sol
@@ -99,7 +99,7 @@ contract VaultRouterTest is BaseTest {
         uint256 amount = 100 * 10 ** 18;
         erc20.mint(self, amount);
         centrifugeChain.updateMember(vault.poolId().raw(), vault.scId().raw(), self, type(uint64).max);
-        uint256 gas = DEFAULT_GAS;
+        uint256 gas = DEFAULT_GAS * 2; // two messages under the hood
 
         erc20.approve(address(vault_), amount);
         vm.expectRevert(SafeTransferLib.SafeTransferFromFailed.selector);


### PR DESCRIPTION
Currently, only one message can be sent inside a transactional payment, because the fuel is reset after sending the first message. This PR modifies this behavior to allow multiple messages