### PR TITLE
Pass tokenWards directly to the factory once.

### DIFF
--- a/docs/architecture/vaults/overview.puml
+++ b/docs/architecture/vaults/overview.puml
@@ -46,7 +46,7 @@ SyncDepositVaultFactory --|> IVaultFactory
 Spoke --up-> TokenFactory
 Spoke --up-> PoolEscrowFactory
 Spoke --up->"n" IVaultFactory
-Spoke <-left-> BalanceSheet
+Spoke <-left- BalanceSheet
 Spoke --down->"n" ShareToken
 Spoke ---down->"n" BaseVault
 Spoke --> Gateway

--- a/script/VaultsDeployer.s.sol
+++ b/script/VaultsDeployer.s.sol
@@ -172,7 +172,6 @@ contract VaultsDeployer is CommonDeployer {
         messageProcessor.file("balanceSheet", address(balanceSheet));
 
         spoke.file("gateway", address(gateway));
-        spoke.file("balanceSheet", address(balanceSheet));
         spoke.file("sender", address(messageDispatcher));
         spoke.file("poolEscrowFactory", address(poolEscrowFactory));
         spoke.file("vaultFactory", address(asyncVaultFactory), true);
@@ -195,6 +194,12 @@ contract VaultsDeployer is CommonDeployer {
         poolEscrowFactory.file("gateway", address(gateway));
         poolEscrowFactory.file("balanceSheet", address(balanceSheet));
         poolEscrowFactory.file("asyncRequestManager", address(asyncRequestManager));
+
+        address[] memory tokenWards = new address[](2);
+        tokenWards[0] = address(spoke);
+        tokenWards[1] = address(balanceSheet);
+
+        tokenFactory.file("wards", tokenWards);
     }
 
     function removeVaultsDeployerAccess(address deployer) public {

--- a/snapshots/AsyncVault.json
+++ b/snapshots/AsyncVault.json
@@ -1,4 +1,4 @@
 {
-  "fulfillDepositRequest": "1334720",
-  "requestDeposit": "532592"
+  "fulfillDepositRequest": "1334610",
+  "requestDeposit": "532526"
 }

--- a/snapshots/VaultRouter.json
+++ b/snapshots/VaultRouter.json
@@ -1,7 +1,7 @@
 {
-  "claimDeposit": "1536751",
+  "claimDeposit": "1536619",
   "enable": "60953",
-  "lockDepositRequest": "95541",
-  "requestDeposit": "571485",
-  "requestRedeem": "2489666"
+  "lockDepositRequest": "95519",
+  "requestDeposit": "571397",
+  "requestRedeem": "2489424"
 }

--- a/src/spokes/Spoke.sol
+++ b/src/spokes/Spoke.sol
@@ -46,7 +46,6 @@ contract Spoke is Auth, Recoverable, ReentrancyProtection, ISpoke, IUpdateContra
     uint8 internal constant MAX_DECIMALS = 18;
 
     IGateway public gateway;
-    address public balanceSheet;
     ITokenFactory public tokenFactory;
     IVaultMessageSender public sender;
     IPoolEscrowFactory public poolEscrowFactory;
@@ -73,7 +72,6 @@ contract Spoke is Auth, Recoverable, ReentrancyProtection, ISpoke, IUpdateContra
         if (what == "sender") sender = IVaultMessageSender(data);
         else if (what == "tokenFactory") tokenFactory = ITokenFactory(data);
         else if (what == "gateway") gateway = IGateway(data);
-        else if (what == "balanceSheet") balanceSheet = data;
         else if (what == "poolEscrowFactory") poolEscrowFactory = IPoolEscrowFactory(data);
         else revert FileUnrecognizedParam();
         emit File(what, data);
@@ -193,12 +191,7 @@ contract Spoke is Auth, Recoverable, ReentrancyProtection, ISpoke, IUpdateContra
         // Hook can be address zero if the share token is fully permissionless and has no custom logic
         require(hook == address(0) || _isValidHook(hook), InvalidHook());
 
-        address[] memory tokenWards = new address[](2);
-        tokenWards[0] = address(this);
-        // BalanceSheet needs this in order to mint shares
-        tokenWards[1] = balanceSheet;
-
-        IShareToken shareToken_ = tokenFactory.newToken(name, symbol, decimals, salt, tokenWards);
+        IShareToken shareToken_ = tokenFactory.newToken(name, symbol, decimals, salt);
 
         if (hook != address(0)) {
             shareToken_.file("hook", hook);

--- a/src/spokes/factories/TokenFactory.sol
+++ b/src/spokes/factories/TokenFactory.sol
@@ -13,19 +13,25 @@ import {IShareToken} from "src/spokes/interfaces/IShareToken.sol";
 ///         based on the pool id and share class id.
 contract TokenFactory is Auth, ITokenFactory {
     address public immutable root;
+    address[] public tokenWards;
 
     constructor(address _root, address deployer) Auth(deployer) {
         root = _root;
     }
 
+    function file(bytes32 what, address[] memory data) external auth {
+        if (what == "wards") tokenWards = data;
+        else revert FileUnrecognizedParam();
+
+        emit File(what, data);
+    }
+
     /// @inheritdoc ITokenFactory
-    function newToken(
-        string memory name,
-        string memory symbol,
-        uint8 decimals,
-        bytes32 salt,
-        address[] calldata tokenWards
-    ) public auth returns (IShareToken) {
+    function newToken(string memory name, string memory symbol, uint8 decimals, bytes32 salt)
+        public
+        auth
+        returns (IShareToken)
+    {
         ShareToken token = new ShareToken{salt: salt}(decimals);
 
         token.file("name", name);

--- a/src/spokes/interfaces/factories/ITokenFactory.sol
+++ b/src/spokes/interfaces/factories/ITokenFactory.sol
@@ -4,6 +4,14 @@ pragma solidity 0.8.28;
 import {IShareToken} from "src/spokes/interfaces/IShareToken.sol";
 
 interface ITokenFactory {
+    event File(bytes32 what, address[] addr);
+
+    error FileUnrecognizedParam();
+
+    /// @notice Updates a contract parameter.
+    /// @param what Name of the parameter to update.
+    function file(bytes32 what, address[] memory data) external;
+
     /// @notice Used to deploy new share class tokens.
     /// @dev    In order to have the same address on different EVMs `salt` should be used
     ///         during creationg process.
@@ -11,14 +19,9 @@ interface ITokenFactory {
     /// @param symbol Symbol of the new token.
     /// @param decimals Decimals of the new token.
     /// @param salt Salt used for deterministic deployments.
-    /// @param tokenWards Address which can call methods behind authorized only.
-    function newToken(
-        string memory name,
-        string memory symbol,
-        uint8 decimals,
-        bytes32 salt,
-        address[] calldata tokenWards
-    ) external returns (IShareToken);
+    function newToken(string memory name, string memory symbol, uint8 decimals, bytes32 salt)
+        external
+        returns (IShareToken);
 
     /// @notice Returns the predicted address (using CREATE2)
     function getAddress(uint8 decimals, bytes32 salt) external view returns (address);

--- a/test/spokes/integration/Spoke.t.sol
+++ b/test/spokes/integration/Spoke.t.sol
@@ -95,13 +95,11 @@ contract SpokeTest is BaseTest, SpokeTestHelper {
 
         // values set correctly
         assertEq(address(messageDispatcher.spoke()), address(spoke));
-        assertEq(address(balanceSheet.spoke()), address(spoke));
         assertEq(address(asyncRequestManager.spoke()), address(spoke));
         assertEq(address(syncRequestManager.spoke()), address(spoke));
 
         assertEq(address(spoke.poolEscrowFactory()), address(poolEscrowFactory));
         assertEq(address(spoke.tokenFactory()), address(tokenFactory));
-        assertEq(address(spoke.balanceSheet()), address(balanceSheet));
         assertEq(address(spoke.sender()), address(messageDispatcher));
 
         // permissions set correctly
@@ -117,12 +115,6 @@ contract SpokeTest is BaseTest, SpokeTestHelper {
         emit ISpoke.File("sender", newSender);
         spoke.file("sender", newSender);
         assertEq(address(spoke.sender()), newSender);
-
-        address newBalanceSheet = makeAddr("newBalanceSheet");
-        vm.expectEmit();
-        emit ISpoke.File("balanceSheet", newBalanceSheet);
-        spoke.file("balanceSheet", newBalanceSheet);
-        assertEq(spoke.balanceSheet(), newBalanceSheet);
 
         address newTokenFactory = makeAddr("newTokenFactory");
         vm.expectEmit();
@@ -812,7 +804,7 @@ contract SpokeRegisterAssetTest is BaseTest {
     using CastLib for *;
     using BytesLib for *;
 
-    uint32 constant STORAGE_INDEX_ASSET_COUNTER = 5;
+    uint32 constant STORAGE_INDEX_ASSET_COUNTER = 4;
     uint256 constant STORAGE_OFFSET_ASSET_COUNTER = 20;
 
     function _assertAssetCounterEq(uint32 expected) internal view {

--- a/test/spokes/unit/factories/TokenFactory.t.sol
+++ b/test/spokes/unit/factories/TokenFactory.t.sol
@@ -92,7 +92,7 @@ contract FactoryTest is Test {
     }
 
     function testShareShouldBeDeterministic(
-        address asyncRequestManager,
+        address balanceSheet,
         address spoke,
         string memory name,
         string memory symbol,
@@ -119,7 +119,7 @@ contract FactoryTest is Test {
         );
 
         address[] memory tokenWards = new address[](2);
-        tokenWards[0] = address(asyncRequestManager);
+        tokenWards[0] = address(balanceSheet);
         tokenWards[1] = address(spoke);
 
         IShareToken token = tokenFactory.newToken(name, symbol, decimals, tokenSalt, tokenWards);
@@ -130,7 +130,7 @@ contract FactoryTest is Test {
 
     function testDeployingDeterministicAddressTwiceReverts(
         bytes32 salt,
-        address asyncRequestManager,
+        address balanceSheet,
         address spoke,
         string memory name,
         string memory symbol,
@@ -157,7 +157,7 @@ contract FactoryTest is Test {
         );
 
         address[] memory tokenWards = new address[](2);
-        tokenWards[0] = address(asyncRequestManager);
+        tokenWards[0] = address(balanceSheet);
         tokenWards[1] = address(spoke);
 
         TokenFactory tokenFactory = new TokenFactory{salt: salt}(root, address(this));


### PR DESCRIPTION
Minor simplification to avoid `Spoke` to know about the `BalanceSheet` existence.

Also, from a configuration PoV, I think it makes sense to pass the wards just once in the deployment phase instead of in every token creation