### PR TITLE
Fix: Correct check before disputeRecovery

### DIFF
--- a/src/common/adapters/MultiAdapter.sol
+++ b/src/common/adapters/MultiAdapter.sol
@@ -156,6 +156,7 @@ contract MultiAdapter is Auth, IMultiAdapter {
 
     /// @inheritdoc IMultiAdapter
     function disputeRecovery(uint16 centrifugeId, IAdapter adapter, bytes32 payloadHash) external auth {
+        require(recoveries[centrifugeId][adapter][payloadHash] != 0, RecoveryNotInitiated());
         delete recoveries[centrifugeId][adapter][payloadHash];
         emit DisputeRecovery(centrifugeId, payloadHash, adapter);
     }

--- a/test/common/unit/MultiAdapter.t.sol
+++ b/test/common/unit/MultiAdapter.t.sol
@@ -419,56 +419,56 @@ contract MultiAdapterTestHandle is MultiAdapterTest {
 }
 
 contract MultiAdapterTestInitiateRecovery is MultiAdapterTest {
-    bytes32 constant BATCH_HASH = bytes32("1");
+    bytes32 constant PAYLOAD_HASH = bytes32("1");
 
     function testErrInvalidAdapter() public {
         vm.expectRevert(IMultiAdapter.InvalidAdapter.selector);
-        multiAdapter.initiateRecovery(REMOTE_CENT_ID, payloadAdapter, BATCH_HASH);
+        multiAdapter.initiateRecovery(REMOTE_CENT_ID, payloadAdapter, PAYLOAD_HASH);
     }
 
     function testErrNotAuthorized() public {
         vm.prank(ANY);
         vm.expectRevert(IAuth.NotAuthorized.selector);
-        multiAdapter.initiateRecovery(REMOTE_CENT_ID, payloadAdapter, BATCH_HASH);
+        multiAdapter.initiateRecovery(REMOTE_CENT_ID, payloadAdapter, PAYLOAD_HASH);
     }
 
     function testInitiateRecovery() public {
         multiAdapter.file("adapters", REMOTE_CENT_ID, oneAdapter);
 
         vm.expectEmit();
-        emit IMultiAdapter.InitiateRecovery(REMOTE_CENT_ID, BATCH_HASH, payloadAdapter);
-        multiAdapter.initiateRecovery(REMOTE_CENT_ID, payloadAdapter, BATCH_HASH);
+        emit IMultiAdapter.InitiateRecovery(REMOTE_CENT_ID, PAYLOAD_HASH, payloadAdapter);
+        multiAdapter.initiateRecovery(REMOTE_CENT_ID, payloadAdapter, PAYLOAD_HASH);
 
         assertEq(
-            multiAdapter.recoveries(REMOTE_CENT_ID, payloadAdapter, BATCH_HASH),
+            multiAdapter.recoveries(REMOTE_CENT_ID, payloadAdapter, PAYLOAD_HASH),
             block.timestamp + multiAdapter.RECOVERY_CHALLENGE_PERIOD()
         );
     }
 }
 
 contract MultiAdapterTestDisputeRecovery is MultiAdapterTest {
-    bytes32 constant BATCH_HASH = bytes32("1");
+    bytes32 constant PAYLOAD_HASH = bytes32("1");
 
     function testErrNotAuthorized() public {
         vm.prank(ANY);
         vm.expectRevert(IAuth.NotAuthorized.selector);
-        multiAdapter.initiateRecovery(REMOTE_CENT_ID, payloadAdapter, BATCH_HASH);
+        multiAdapter.initiateRecovery(REMOTE_CENT_ID, payloadAdapter, PAYLOAD_HASH);
     }
 
     function testErrRecoveryNotInitiated() public {
         vm.expectRevert(IMultiAdapter.RecoveryNotInitiated.selector);
-        multiAdapter.disputeRecovery(REMOTE_CENT_ID, payloadAdapter, BATCH_HASH);
+        multiAdapter.disputeRecovery(REMOTE_CENT_ID, payloadAdapter, PAYLOAD_HASH);
     }
 
     function testDisputeRecovery() public {
         multiAdapter.file("adapters", REMOTE_CENT_ID, oneAdapter);
-        multiAdapter.initiateRecovery(REMOTE_CENT_ID, payloadAdapter, BATCH_HASH);
+        multiAdapter.initiateRecovery(REMOTE_CENT_ID, payloadAdapter, PAYLOAD_HASH);
 
         vm.expectEmit();
-        emit IMultiAdapter.DisputeRecovery(REMOTE_CENT_ID, BATCH_HASH, payloadAdapter);
-        multiAdapter.disputeRecovery(REMOTE_CENT_ID, payloadAdapter, BATCH_HASH);
+        emit IMultiAdapter.DisputeRecovery(REMOTE_CENT_ID, PAYLOAD_HASH, payloadAdapter);
+        multiAdapter.disputeRecovery(REMOTE_CENT_ID, payloadAdapter, PAYLOAD_HASH);
 
-        assertEq(multiAdapter.recoveries(REMOTE_CENT_ID, payloadAdapter, BATCH_HASH), 0);
+        assertEq(multiAdapter.recoveries(REMOTE_CENT_ID, payloadAdapter, PAYLOAD_HASH), 0);
     }
 }
 

--- a/test/common/unit/MultiAdapter.t.sol
+++ b/test/common/unit/MultiAdapter.t.sol
@@ -455,8 +455,14 @@ contract MultiAdapterTestDisputeRecovery is MultiAdapterTest {
         multiAdapter.initiateRecovery(REMOTE_CENT_ID, payloadAdapter, BATCH_HASH);
     }
 
+    function testErrRecoveryNotInitiated() public {
+        vm.expectRevert(IMultiAdapter.RecoveryNotInitiated.selector);
+        multiAdapter.disputeRecovery(REMOTE_CENT_ID, payloadAdapter, BATCH_HASH);
+    }
+
     function testDisputeRecovery() public {
         multiAdapter.file("adapters", REMOTE_CENT_ID, oneAdapter);
+        multiAdapter.initiateRecovery(REMOTE_CENT_ID, payloadAdapter, BATCH_HASH);
 
         vm.expectEmit();
         emit IMultiAdapter.DisputeRecovery(REMOTE_CENT_ID, BATCH_HASH, payloadAdapter);


### PR DESCRIPTION
Problem: The caller can call `disputeRecovery()` at any moment over any payload hash, and the method will "work" and will emit an event that should not be emitted.