### PR TITLE
Fix: TransferShares issue

### DIFF
--- a/snapshots/VaultRouter.json
+++ b/snapshots/VaultRouter.json
@@ -3,5 +3,5 @@
   "enable": "60953",
   "lockDepositRequest": "95519",
   "requestDeposit": "571799",
-  "requestRedeem": "2490390"
+  "requestRedeem": "2490368"
 }

--- a/src/common/MessageDispatcher.sol
+++ b/src/common/MessageDispatcher.sol
@@ -477,29 +477,33 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
 
     /// @inheritdoc IVaultMessageSender
     function sendInitiateTransferShares(
+        uint16 targetCentrifugeId,
         PoolId poolId,
         ShareClassId scId,
-        uint16 centrifugeId,
         bytes32 receiver,
         uint128 amount
     ) external auth {
-        gateway.send(
-            poolId.centrifugeId(),
-            MessageLib.InitiateTransferShares({
-                poolId: poolId.raw(),
-                scId: scId.raw(),
-                centrifugeId: centrifugeId,
-                receiver: receiver,
-                amount: amount
-            }).serialize()
-        );
+        if (poolId.centrifugeId() == localCentrifugeId) {
+            hub.initiateTransferShares(targetCentrifugeId, poolId, scId, receiver, amount);
+        } else {
+            gateway.send(
+                poolId.centrifugeId(),
+                MessageLib.InitiateTransferShares({
+                    centrifugeId: targetCentrifugeId,
+                    poolId: poolId.raw(),
+                    scId: scId.raw(),
+                    receiver: receiver,
+                    amount: amount
+                }).serialize()
+            );
+        }
     }
 
     /// @inheritdoc IPoolMessageSender
     function sendExecuteTransferShares(
+        uint16 centrifugeId,
         PoolId poolId,
         ShareClassId scId,
-        uint16 centrifugeId,
         bytes32 receiver,
         uint128 amount
     ) external auth {

--- a/src/common/interfaces/IGatewaySenders.sol
+++ b/src/common/interfaces/IGatewaySenders.sol
@@ -148,9 +148,9 @@ interface IPoolMessageSender is ILocalCentrifugeId {
 
     /// @notice Creates and send the message
     function sendExecuteTransferShares(
+        uint16 centrifugeId,
         PoolId poolId,
         ShareClassId scId,
-        uint16 centrifugeId,
         bytes32 receiver,
         uint128 amount
     ) external;
@@ -160,9 +160,9 @@ interface IPoolMessageSender is ILocalCentrifugeId {
 interface IVaultMessageSender is ILocalCentrifugeId {
     /// @notice Creates and send the message
     function sendInitiateTransferShares(
+        uint16 centrifugeId,
         PoolId poolId,
         ShareClassId scId,
-        uint16 centrifugeId,
         bytes32 receiver,
         uint128 amount
     ) external;

--- a/src/hub/Hub.sol
+++ b/src/hub/Hub.sol
@@ -607,7 +607,7 @@ contract Hub is Multicall, Auth, Recoverable, IHub, IHubGatewayHandler, IHubGuar
         _auth();
 
         emit ForwardTransferShares(centrifugeId, poolId, scId, receiver, amount);
-        sender.sendExecuteTransferShares(poolId, scId, centrifugeId, receiver, amount);
+        sender.sendExecuteTransferShares(centrifugeId, poolId, scId, receiver, amount);
     }
 
     /// @inheritdoc IHubGatewayHandler

--- a/src/spoke/Spoke.sol
+++ b/src/spoke/Spoke.sol
@@ -63,6 +63,12 @@ contract Spoke is Auth, Recoverable, ReentrancyProtection, ISpoke, IUpdateContra
         tokenFactory = tokenFactory_;
     }
 
+    modifier payTransaction() {
+        gateway.startTransactionPayment{value: msg.value}(msg.sender);
+        _;
+        gateway.endTransactionPayment();
+    }
+
     //----------------------------------------------------------------------------------------------
     // Administration
     //----------------------------------------------------------------------------------------------
@@ -92,6 +98,7 @@ contract Spoke is Auth, Recoverable, ReentrancyProtection, ISpoke, IUpdateContra
     function transferShares(uint16 centrifugeId, PoolId poolId, ShareClassId scId, bytes32 receiver, uint128 amount)
         external
         payable
+        payTransaction
         protected
     {
         IShareToken share = IShareToken(shareToken(poolId, scId));
@@ -101,21 +108,18 @@ contract Spoke is Auth, Recoverable, ReentrancyProtection, ISpoke, IUpdateContra
             CrossChainTransferNotAllowed()
         );
 
-        gateway.startTransactionPayment{value: msg.value}(msg.sender);
-
         share.authTransferFrom(msg.sender, msg.sender, address(this), amount);
         share.burn(address(this), amount);
 
         emit TransferShares(centrifugeId, poolId, scId, msg.sender, receiver, amount);
-        sender.sendInitiateTransferShares(poolId, scId, centrifugeId, receiver, amount);
-
-        gateway.endTransactionPayment();
+        sender.sendInitiateTransferShares(centrifugeId, poolId, scId, receiver, amount);
     }
 
     // @inheritdoc ISpoke
     function registerAsset(uint16 centrifugeId, address asset, uint256 tokenId)
         external
         payable
+        payTransaction
         protected
         returns (AssetId assetId)
     {
@@ -126,8 +130,6 @@ contract Spoke is Auth, Recoverable, ReentrancyProtection, ISpoke, IUpdateContra
         decimals = _safeGetAssetDecimals(asset, tokenId);
         require(decimals >= MIN_DECIMALS, TooFewDecimals());
         require(decimals <= MAX_DECIMALS, TooManyDecimals());
-
-        gateway.startTransactionPayment{value: msg.value}(msg.sender);
 
         if (tokenId == 0) {
             IERC20Metadata meta = IERC20Metadata(asset);
@@ -151,8 +153,6 @@ contract Spoke is Auth, Recoverable, ReentrancyProtection, ISpoke, IUpdateContra
         }
 
         sender.sendRegisterAsset(centrifugeId, assetId, decimals);
-
-        gateway.endTransactionPayment();
     }
 
     //----------------------------------------------------------------------------------------------


### PR DESCRIPTION
If `CV1` is in `chainA`, `CV2` is in `ChainB`, but `Hub` is also in `ChainA`, the `InitiateTrasferShares` message will be sent through the Gateway when it must be bypassed. The gateway will never be configured to itself, making it fail.

Other minor changes:
- `centrifugeId` as first element in the methods.
- Using a modifier to avoid any future bugs in the transaction payment, forgetting to end the payment.