### PR TITLE
test: cross-chain shares transfer

### DIFF
--- a/script/CommonDeployer.s.sol
+++ b/script/CommonDeployer.s.sol
@@ -26,8 +26,6 @@ abstract contract CommonDeployer is Script, JsonRegistry {
     uint128 constant FALLBACK_MSG_COST = uint128(0.02 ether); // in Weight
     uint128 constant FALLBACK_MAX_BATCH_SIZE = uint128(10_000_000 ether); // 10M in Weight
 
-    IAdapter[] adapters;
-
     ISafe public adminSafe;
     Root public root;
     TokenRecoverer public tokenRecoverer;
@@ -113,18 +111,11 @@ abstract contract CommonDeployer is Script, JsonRegistry {
     }
 
     function wire(uint16 centrifugeId, IAdapter adapter, address deployer) public {
-        bool isDuplicate = false;
-        for (uint256 i = 0; i < adapters.length; i++) {
-            if (address(adapters[i]) == address(adapter)) {
-                isDuplicate = true;
-                break;
-            }
-        }
-        if (!isDuplicate) {
-            adapters.push(adapter);
-            IAuth(address(adapter)).rely(address(root));
-            IAuth(address(adapter)).deny(deployer);
-        }
+        IAuth(address(adapter)).rely(address(root));
+        IAuth(address(adapter)).deny(deployer);
+
+        IAdapter[] memory adapters = new IAdapter[](1);
+        adapters[0] = adapter;
 
         multiAdapter.file("adapters", centrifugeId, adapters);
     }

--- a/script/CommonDeployer.s.sol
+++ b/script/CommonDeployer.s.sol
@@ -113,10 +113,20 @@ abstract contract CommonDeployer is Script, JsonRegistry {
     }
 
     function wire(uint16 centrifugeId, IAdapter adapter, address deployer) public {
-        adapters.push(adapter);
+        bool isDuplicate = false;
+        for (uint256 i = 0; i < adapters.length; i++) {
+            if (address(adapters[i]) == address(adapter)) {
+                isDuplicate = true;
+                break;
+            }
+        }
+        if (!isDuplicate) {
+            adapters.push(adapter);
+            IAuth(address(adapter)).rely(address(root));
+            IAuth(address(adapter)).deny(deployer);
+        }
+
         multiAdapter.file("adapters", centrifugeId, adapters);
-        IAuth(address(adapter)).rely(address(root));
-        IAuth(address(adapter)).deny(deployer);
     }
 
     function removeCommonDeployerAccess(address deployer) public {

--- a/snapshots/AsyncVault.json
+++ b/snapshots/AsyncVault.json
@@ -1,4 +1,4 @@
 {
-  "fulfillDepositRequest": "960950",
-  "requestDeposit": "532911"
+  "fulfillDepositRequest": "968374",
+  "requestDeposit": "532914"
 }

--- a/snapshots/SyncDepositVault.json
+++ b/snapshots/SyncDepositVault.json
@@ -1,4 +1,4 @@
 {
-  "deposit_withQueue": "266887",
-  "deposit_withoutQueue": "325921"
+  "deposit_withQueue": "266890",
+  "deposit_withoutQueue": "325924"
 }

--- a/snapshots/VaultRouter.json
+++ b/snapshots/VaultRouter.json
@@ -1,7 +1,7 @@
 {
-  "claimDeposit": "1163239",
+  "claimDeposit": "1170666",
   "enable": "60953",
-  "lockDepositRequest": "95663",
-  "requestDeposit": "571804",
-  "requestRedeem": "2093434"
+  "lockDepositRequest": "95666",
+  "requestDeposit": "571807",
+  "requestRedeem": "2100864"
 }

--- a/src/spoke/Spoke.sol
+++ b/src/spoke/Spoke.sol
@@ -166,7 +166,7 @@ contract Spoke is Auth, Recoverable, ReentrancyProtection, ISpoke, ISpokeGateway
         pool.createdAt = block.timestamp;
 
         IPoolEscrow escrow = poolEscrowFactory.newEscrow(poolId);
-        gateway.setRefundAddress(PoolId.wrap(poolId.raw()), escrow);
+        gateway.setRefundAddress(poolId, escrow);
 
         emit AddPool(poolId);
     }

--- a/test/integration/EndToEnd.t.sol
+++ b/test/integration/EndToEnd.t.sol
@@ -267,31 +267,29 @@ contract EndToEndUtils is EndToEndDeployment {
         vm.stopPrank();
     }
 
-    function _configurePool(CSpoke memory spoke) internal {
-        _configureAsset(spoke);
+    function _configurePool(CSpoke memory s_) internal {
+        _configureAsset(s_);
 
         if (!h.hubRegistry.exists(POOL_A)) {
             _createPool();
         }
 
         vm.startPrank(FM);
-        h.hub.notifyPool{value: GAS}(POOL_A, spoke.centrifugeId);
-        h.hub.notifyShareClass{value: GAS}(
-            POOL_A, SC_1, spoke.centrifugeId, spoke.redemptionRestrictionsHook.toBytes32()
-        );
+        h.hub.notifyPool{value: GAS}(POOL_A, s_.centrifugeId);
+        h.hub.notifyShareClass{value: GAS}(POOL_A, SC_1, s_.centrifugeId, s_.redemptionRestrictionsHook.toBytes32());
 
         h.hub.initializeHolding(
-            POOL_A, SC_1, spoke.usdcId, h.identityValuation, ASSET_ACCOUNT, EQUITY_ACCOUNT, GAIN_ACCOUNT, LOSS_ACCOUNT
+            POOL_A, SC_1, s_.usdcId, h.identityValuation, ASSET_ACCOUNT, EQUITY_ACCOUNT, GAIN_ACCOUNT, LOSS_ACCOUNT
         );
-        h.hub.updateBalanceSheetManager{value: GAS}(spoke.centrifugeId, POOL_A, BSM.toBytes32(), true);
+        h.hub.updateBalanceSheetManager{value: GAS}(s_.centrifugeId, POOL_A, BSM.toBytes32(), true);
 
         h.hub.updateSharePrice(POOL_A, SC_1, IDENTITY_PRICE);
-        h.hub.notifySharePrice{value: GAS}(POOL_A, SC_1, spoke.centrifugeId);
-        h.hub.notifyAssetPrice{value: GAS}(POOL_A, SC_1, spoke.usdcId);
+        h.hub.notifySharePrice{value: GAS}(POOL_A, SC_1, s_.centrifugeId);
+        h.hub.notifyAssetPrice{value: GAS}(POOL_A, SC_1, s_.usdcId);
         vm.stopPrank();
 
         vm.startPrank(BSM);
-        spoke.gateway.subsidizePool{value: DEFAULT_SUBSIDY}(POOL_A);
+        s_.gateway.subsidizePool{value: DEFAULT_SUBSIDY}(POOL_A);
         vm.stopPrank();
     }
 }

--- a/test/integration/EndToEnd.t.sol
+++ b/test/integration/EndToEnd.t.sol
@@ -253,7 +253,6 @@ contract EndToEndUtils is EndToEndDeployment {
     function _createPool() internal {
         vm.startPrank(address(h.guardian.safe()));
         h.guardian.createPool(POOL_A, FM, USD_ID);
-        vm.stopPrank();
 
         vm.startPrank(FM);
         h.hub.setPoolMetadata(POOL_A, bytes("Testing pool"));
@@ -286,7 +285,6 @@ contract EndToEndUtils is EndToEndDeployment {
         h.hub.updateSharePrice(POOL_A, SC_1, IDENTITY_PRICE);
         h.hub.notifySharePrice{value: GAS}(POOL_A, SC_1, s_.centrifugeId);
         h.hub.notifyAssetPrice{value: GAS}(POOL_A, SC_1, s_.usdcId);
-        vm.stopPrank();
 
         vm.startPrank(BSM);
         s_.gateway.subsidizePool{value: DEFAULT_SUBSIDY}(POOL_A);

--- a/test/integration/EndToEnd.t.sol
+++ b/test/integration/EndToEnd.t.sol
@@ -58,9 +58,9 @@ import {LocalAdapter} from "test/integration/adapters/LocalAdapter.sol";
 /// chosen from a deployment. If not, it has two side effects:
 ///   1.
 ///   vm.prank(FM)
-///   deployA.hub().notifyPool() // Will fail, given prank is used to retriver the hub.
+///   deployA.hub().notifyPool() // Will fail, given prank is used to retrieve the hub.
 ///
-///   2. It increases significatily the amount of calls shown by the debugger.
+///   2. It significantly increases the amount of calls shown by the debugger.
 ///
 /// By using these structs we avoid both "issues".
 contract EndToEndDeployment is Test {
@@ -131,17 +131,20 @@ contract EndToEndDeployment is Test {
     FullDeployer deployA = new FullDeployer();
     FullDeployer deployB = new FullDeployer();
 
+    LocalAdapter adapterA;
+    LocalAdapter adapterB;
+
     CHub h;
     CSpoke s;
 
     D18 immutable IDENTITY_PRICE = d18(1, 1);
     D18 immutable TEN_PERCENT = d18(1, 10);
 
-    function setUp() public {
+    function setUp() public virtual {
         vm.setEnv(MESSAGE_COST_ENV, vm.toString(GAS));
 
-        LocalAdapter adapterA = _deployChain(deployA, CENTRIFUGE_ID_A, CENTRIFUGE_ID_B, safeAdminA);
-        LocalAdapter adapterB = _deployChain(deployB, CENTRIFUGE_ID_B, CENTRIFUGE_ID_A, safeAdminB);
+        adapterA = _deployChain(deployA, CENTRIFUGE_ID_A, CENTRIFUGE_ID_B, safeAdminA);
+        adapterB = _deployChain(deployB, CENTRIFUGE_ID_B, CENTRIFUGE_ID_A, safeAdminB);
 
         // We connect both deploys through the adapters
         adapterA.setEndpoint(adapterB);
@@ -173,6 +176,10 @@ contract EndToEndDeployment is Test {
         USD_ID = deployA.USD_ID();
         POOL_A = h.hubRegistry.poolId(CENTRIFUGE_ID_A, 1);
         SC_1 = h.shareClassManager.previewNextShareClassId(POOL_A);
+
+        vm.label(address(adapterA), "AdapterA");
+        vm.label(address(adapterB), "AdapterB");
+        vm.label(address(h.hub), "Hub");
     }
 
     function _deployChain(FullDeployer deploy, uint16 localCentrifugeId, uint16 remoteCentrifugeId, ISafe safeAdmin)
@@ -184,7 +191,8 @@ contract EndToEndDeployment is Test {
         adapter = new LocalAdapter(localCentrifugeId, deploy.multiAdapter(), address(deploy));
         deploy.wire(remoteCentrifugeId, adapter, address(deploy));
 
-        deploy.removeFullDeployerAccess(address(deploy));
+        // TODO(wischli): Revert when 3-chain-setup works
+        // deploy.removeFullDeployerAccess(address(deploy));
     }
 
     function _setSpoke(bool sameChain) internal {

--- a/test/integration/EndToEnd.t.sol
+++ b/test/integration/EndToEnd.t.sol
@@ -19,6 +19,7 @@ import {Guardian} from "src/common/Guardian.sol";
 import {Root} from "src/common/Root.sol";
 import {Gateway} from "src/common/Gateway.sol";
 import {MessageLib, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
+
 import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
 import {Hub} from "src/hub/Hub.sol";
@@ -31,10 +32,11 @@ import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
 import {VaultRouter} from "src/vaults/VaultRouter.sol";
 import {Spoke} from "src/spoke/Spoke.sol";
 import {BalanceSheet} from "src/spoke/BalanceSheet.sol";
+import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+
 import {AsyncRequestManager} from "src/vaults/AsyncRequestManager.sol";
 import {SyncRequestManager} from "src/vaults/SyncRequestManager.sol";
 import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
 import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
 import {SyncDepositVault} from "src/vaults/SyncDepositVault.sol";
 import {AsyncVaultFactory} from "src/vaults/factories/AsyncVaultFactory.sol";
@@ -115,6 +117,7 @@ contract EndToEndDeployment is Test {
     address immutable BSM = makeAddr("BSM");
     address immutable INVESTOR_A = makeAddr("INVESTOR_A");
     address immutable ANY = makeAddr("ANY");
+    address immutable REFUND = makeAddr("REFUND");
 
     uint128 constant INVESTOR_A_USDC_AMOUNT = 1_000_000e6; // Measured in USDC: 1M of USDC
 

--- a/test/integration/ThreeChainEndToEnd.t.sol
+++ b/test/integration/ThreeChainEndToEnd.t.sol
@@ -30,15 +30,12 @@ contract ThreeChainEndToEndDeployment is EndToEndDeployment {
         adapterC = _deployChain(deployC, CENTRIFUGE_ID_C, CENTRIFUGE_ID_A, safeAdminC);
         vm.label(address(adapterC), "AdapterC");
 
-        // Connect Chain C to Chain A (hub)
-        adapterC.setEndpoint(adapterA);
-
         // Connect Chain A to Chain C (spoke 2)
         vm.startPrank(address(deployA.root()));
-        // FIXME: Breaks with NoDuplicatesAllowed even though A doesn't yet know about C?!
         deployA.wire(CENTRIFUGE_ID_C, adapterA, address(deployA));
         vm.stopPrank();
 
+        adapterC.setEndpoint(adapterA);
         adapterA.setEndpoint(adapterC);
     }
 

--- a/test/integration/ThreeChainEndToEnd.t.sol
+++ b/test/integration/ThreeChainEndToEnd.t.sol
@@ -118,7 +118,6 @@ contract ThreeChainEndToEndUseCases is ThreeChainEndToEndDeployment {
         vm.expectEmit(true, false, false, false);
         emit IMultiAdapter.HandlePayload(h.centrifugeId, bytes32(""), bytes(""), adapterCToA);
         vm.expectEmit();
-        emit IERC20.Transfer(address(0), INVESTOR_A, amount);
         emit ISpoke.ExecuteTransferShares(POOL_A, SC_1, INVESTOR_A, amount);
         h.gateway.repay{value: DEFAULT_SUBSIDY}(sC.centrifugeId, message);
 

--- a/test/integration/ThreeChainEndToEnd.t.sol
+++ b/test/integration/ThreeChainEndToEnd.t.sol
@@ -153,7 +153,7 @@ contract ThreeChainEndToEndUseCases is ThreeChainEndToEndDeployment {
 
     /// @notice Test transferring shares between Chain B and Chain C via Hub A
     /// forge-config: default.isolate = true
-    function testTransferSharesBetweenChains() public {
+    function testTransferSharesWithHop() public {
         uint128 amount = 1000 * 1e18;
 
         testConfigurePoolWithThreeChains();
@@ -203,6 +203,7 @@ contract ThreeChainEndToEndUseCases is ThreeChainEndToEndDeployment {
         emit IMultiAdapter.HandlePayload(h.centrifugeId, bytes32(""), bytes(""), adapterC);
         vm.expectEmit();
         emit IERC20.Transfer(address(0), INVESTOR_A, amount);
+        emit ISpoke.ExecuteTransferShares(POOL_A, SC_1, INVESTOR_A, amount);
         h.gateway.repay{value: DEFAULT_SUBSIDY}(sC.centrifugeId, message);
 
         // C: Verify shares were minted

--- a/test/integration/ThreeChainEndToEnd.t.sol
+++ b/test/integration/ThreeChainEndToEnd.t.sol
@@ -3,14 +3,23 @@ pragma solidity ^0.8.28;
 
 import "forge-std/Test.sol";
 
-import "test/integration/EndToEnd.t.sol";
+import {IRecoverable} from "src/misc/interfaces/IRecoverable.sol";
+import {IERC20} from "src/misc/interfaces/IERC20.sol";
 
 import {IAdapter} from "src/common/interfaces/IAdapter.sol";
+import {IGateway} from "src/common/interfaces/IGateway.sol";
+import {IMultiAdapter} from "src/common/interfaces/adapters/IMultiAdapter.sol";
+
+import {ISpoke} from "src/spoke/interfaces/ISpoke.sol";
+
+import {IHub} from "src/hub/interfaces/IHub.sol";
+
+import "test/integration/EndToEnd.t.sol";
 
 /// @title  Three Chain End-to-End Test
 /// @notice Extends the dual-chain setup to include a third chain (C) which acts as an additional spoke
 ///         Hub is on Chain A, with spokes on Chains B and C
-contract ThreeChainEndToEndDeployment is EndToEndDeployment {
+contract ThreeChainEndToEndDeployment is EndToEndUtils {
     using CastLib for *;
 
     uint16 constant CENTRIFUGE_ID_C = 7;
@@ -20,13 +29,14 @@ contract ThreeChainEndToEndDeployment is EndToEndDeployment {
     LocalAdapter adapterC;
     LocalAdapter adapterAToC;
 
-    // This represents the third Chain's spoke
     CSpoke sC;
+    CSpoke sB;
 
     function setUp() public override {
         // Call the original setUp to set up chains A and B
         super.setUp();
         _setSpoke(false);
+        sB = s;
 
         // Deploy the third chain (C)
         adapterC = _deployChain(deployC, CENTRIFUGE_ID_C, CENTRIFUGE_ID_A, safeAdminC);
@@ -36,7 +46,7 @@ contract ThreeChainEndToEndDeployment is EndToEndDeployment {
         vm.label(address(adapterAToC), "AdapterAToC");
 
         // Connect Chain A to Chain C (spoke 2)
-        vm.startPrank(address(deployA.root()));
+        vm.startPrank(address(sB.root));
         deployA.wire(CENTRIFUGE_ID_C, adapterAToC, address(adapterAToC));
         vm.stopPrank();
 
@@ -76,6 +86,7 @@ contract ThreeChainEndToEndDeployment is EndToEndDeployment {
 /// @notice Test cases for the three-chain setup
 contract ThreeChainEndToEndUseCases is ThreeChainEndToEndDeployment {
     using CastLib for *;
+    using MessageLib for *;
 
     /// @notice Configure the third chain (C) with assets
     /// forge-config: default.isolate = true
@@ -90,8 +101,8 @@ contract ThreeChainEndToEndUseCases is ThreeChainEndToEndDeployment {
     /// forge-config: default.isolate = true
     function testConfigurePoolWithThreeChains() public {
         // Configure spokes
-        s.usdc.mint(INVESTOR_A, INVESTOR_A_USDC_AMOUNT);
-        s.spoke.registerAsset{value: GAS}(h.centrifugeId, address(s.usdc), 0);
+        sB.usdc.mint(INVESTOR_A, INVESTOR_A_USDC_AMOUNT);
+        sB.spoke.registerAsset{value: GAS}(h.centrifugeId, address(sB.usdc), 0);
         sC.usdc.mint(INVESTOR_A, INVESTOR_A_USDC_AMOUNT);
         sC.spoke.registerAsset{value: GAS}(h.centrifugeId, address(sC.usdc), 0);
 
@@ -103,10 +114,10 @@ contract ThreeChainEndToEndUseCases is ThreeChainEndToEndDeployment {
         h.hub.setPoolMetadata(POOL_A, bytes("Testing pool with three chains"));
         h.hub.addShareClass(POOL_A, "Tokenized MMF", "MMF", bytes32("salt"));
 
-        h.hub.notifyPool{value: GAS}(POOL_A, s.centrifugeId);
+        h.hub.notifyPool{value: GAS}(POOL_A, sB.centrifugeId);
         h.hub.notifyPool{value: GAS}(POOL_A, sC.centrifugeId);
 
-        h.hub.notifyShareClass{value: GAS}(POOL_A, SC_1, s.centrifugeId, s.redemptionRestrictionsHook.toBytes32());
+        h.hub.notifyShareClass{value: GAS}(POOL_A, SC_1, sB.centrifugeId, sB.redemptionRestrictionsHook.toBytes32());
         h.hub.notifyShareClass{value: GAS}(POOL_A, SC_1, sC.centrifugeId, sC.redemptionRestrictionsHook.toBytes32());
 
         h.hub.createAccount(POOL_A, ASSET_ACCOUNT, true);
@@ -114,7 +125,7 @@ contract ThreeChainEndToEndUseCases is ThreeChainEndToEndDeployment {
         h.hub.createAccount(POOL_A, LOSS_ACCOUNT, false);
         h.hub.createAccount(POOL_A, GAIN_ACCOUNT, false);
 
-        AssetId USDC_ID_B = newAssetId(s.centrifugeId, 1);
+        AssetId USDC_ID_B = newAssetId(sB.centrifugeId, 1);
         AssetId USDC_ID_C = newAssetId(sC.centrifugeId, 1);
 
         h.hub.initializeHolding(
@@ -124,11 +135,11 @@ contract ThreeChainEndToEndUseCases is ThreeChainEndToEndDeployment {
             POOL_A, SC_1, USDC_ID_C, h.identityValuation, ASSET_ACCOUNT, EQUITY_ACCOUNT, GAIN_ACCOUNT, LOSS_ACCOUNT
         );
 
-        h.hub.updateBalanceSheetManager{value: GAS}(s.centrifugeId, POOL_A, BSM.toBytes32(), true);
+        h.hub.updateBalanceSheetManager{value: GAS}(sB.centrifugeId, POOL_A, BSM.toBytes32(), true);
         h.hub.updateBalanceSheetManager{value: GAS}(sC.centrifugeId, POOL_A, BSM.toBytes32(), true);
 
         h.hub.updateSharePrice(POOL_A, SC_1, IDENTITY_PRICE);
-        h.hub.notifySharePrice{value: GAS}(POOL_A, SC_1, s.centrifugeId);
+        h.hub.notifySharePrice{value: GAS}(POOL_A, SC_1, sB.centrifugeId);
         h.hub.notifySharePrice{value: GAS}(POOL_A, SC_1, sC.centrifugeId);
 
         h.hub.notifyAssetPrice{value: GAS}(POOL_A, SC_1, USDC_ID_B);
@@ -136,7 +147,66 @@ contract ThreeChainEndToEndUseCases is ThreeChainEndToEndDeployment {
         vm.stopPrank();
 
         vm.startPrank(BSM);
-        s.gateway.subsidizePool{value: DEFAULT_SUBSIDY}(POOL_A);
+        sB.gateway.subsidizePool{value: DEFAULT_SUBSIDY}(POOL_A);
         sC.gateway.subsidizePool{value: DEFAULT_SUBSIDY}(POOL_A);
+    }
+
+    /// @notice Test transferring shares between Chain B and Chain C via Hub A
+    /// forge-config: default.isolate = true
+    function testTransferSharesBetweenChains() public {
+        uint128 amount = 1000 * 1e18;
+
+        testConfigurePoolWithThreeChains();
+
+        // B + C: Deploy vaults on both chains
+        vm.startPrank(FM);
+        AssetId USDC_ID_B = newAssetId(sB.centrifugeId, 1);
+        h.hub.updateVault{value: GAS}(POOL_A, SC_1, USDC_ID_B, sB.asyncVaultFactory, VaultUpdateKind.DeployAndLink);
+        AssetId USDC_ID_C = newAssetId(sC.centrifugeId, 1);
+        h.hub.updateVault{value: GAS}(POOL_A, SC_1, USDC_ID_C, sC.asyncVaultFactory, VaultUpdateKind.DeployAndLink);
+        vm.stopPrank();
+
+        // B: Mint shares
+        vm.startPrank(address(sB.root));
+        IShareToken shareTokenB = IShareToken(sB.spoke.shareToken(POOL_A, SC_1));
+        shareTokenB.mint(INVESTOR_A, amount);
+        vm.stopPrank();
+        assertEq(shareTokenB.balanceOf(INVESTOR_A), amount, "Investor should have minted shares on chain B");
+
+        // B: Initiate transfer of shares
+        vm.expectEmit();
+        emit ISpoke.TransferShares(sC.centrifugeId, POOL_A, SC_1, INVESTOR_A, INVESTOR_A.toBytes32(), amount);
+        emit IHub.ForwardTransferShares(sC.centrifugeId, POOL_A, SC_1, INVESTOR_A.toBytes32(), amount);
+        vm.expectEmit(true, false, false, false);
+        emit IGateway.UnderpaidBatch(sC.centrifugeId, bytes(""));
+        vm.prank(INVESTOR_A);
+        sB.spoke.transferShares{value: GAS}(sC.centrifugeId, POOL_A, SC_1, INVESTOR_A.toBytes32(), amount);
+
+        assertEq(shareTokenB.balanceOf(INVESTOR_A), 0, "Shares should be burned on chain B");
+
+        // C: Transfer expected to be pending on A due to message being unpaid
+        IShareToken shareTokenC = IShareToken(sC.spoke.shareToken(POOL_A, SC_1));
+        assertEq(shareTokenC.balanceOf(INVESTOR_A), 0, "Share transfer not executed due to unpaid message");
+
+        // A: Before calling repay, set a refund address for the pool
+        vm.prank(address(h.root));
+        h.gateway.setRefundAddress(POOL_A, IRecoverable(h.gateway));
+
+        // A: Repay for unpaid ExecuteTransferShares message on A to trigger sending it to C
+        bytes memory message = MessageLib.ExecuteTransferShares({
+            poolId: PoolId.unwrap(POOL_A),
+            scId: ShareClassId.unwrap(SC_1),
+            receiver: INVESTOR_A.toBytes32(),
+            amount: amount
+        }).serialize();
+        vm.expectEmit(true, false, false, false);
+        emit IMultiAdapter.HandlePayload(h.centrifugeId, bytes32(""), bytes(""), adapterC);
+        vm.expectEmit();
+        emit IERC20.Transfer(address(0), INVESTOR_A, amount);
+        h.gateway.repay{value: DEFAULT_SUBSIDY}(sC.centrifugeId, message);
+
+        // C: Verify shares were minted
+        assertEq(shareTokenC.balanceOf(INVESTOR_A), amount, "Shares should be minted on chain C");
+        assertEq(shareTokenB.balanceOf(INVESTOR_A), 0, "Shares should still be burned on chain B");
     }
 }

--- a/test/integration/ThreeChainEndToEnd.t.sol
+++ b/test/integration/ThreeChainEndToEnd.t.sol
@@ -53,12 +53,12 @@ contract ThreeChainEndToEndDeployment is EndToEndUtils {
         vm.label(address(adapterCToA), "AdapterCToA");
     }
 
-    /// @param sameChain Whether the chain A equals chain B, such that sB points to Centrifuge ID A == 5
+    /// @param sameChain Whether the chain B equals chain C, such that sB points to Centrifuge ID C == 7
     function _setSpokeB(bool sameChain) internal {
         if (sameChain) {
-            _setSpoke(deployB, CENTRIFUGE_ID_B, sB);
+            _setSpoke(deployC, CENTRIFUGE_ID_C, sB);
         } else {
-            _setSpoke(deployA, CENTRIFUGE_ID_A, sB);
+            _setSpoke(deployB, CENTRIFUGE_ID_B, sB);
         }
     }
 }
@@ -70,13 +70,16 @@ contract ThreeChainEndToEndUseCases is ThreeChainEndToEndDeployment {
     using MessageLib for *;
 
     /// @notice Configure the third chain (C) with assets
-    /// @param sameChain Whether the chain A equals chain B, such that sB points to Centrifuge ID A == 5
+    /// @param sameChain Whether the chain B equals chain C, such that sB points to Centrifuge ID C == 7
     /// forge-config: default.isolate = true
     function testConfigureAssets(bool sameChain) public {
         _setSpokeB(sameChain);
 
         _configureAsset(sB);
-        _configureAsset(sC);
+
+        if (!sameChain) {
+            _configureAsset(sC);
+        }
     }
 
     /// @notice Configure a pool with support for all three chains
@@ -85,12 +88,26 @@ contract ThreeChainEndToEndUseCases is ThreeChainEndToEndDeployment {
         _setSpokeB(sameChain);
 
         _configurePool(sB);
-        _configurePool(sC);
+
+        if (!sameChain) {
+            _configurePool(sC);
+        }
     }
 
     /// @notice Test transferring shares between Chain B and Chain C via Hub A
     /// forge-config: default.isolate = true
-    function testCrossChainTransferShares(bool sameChain) public {
+    function testCrossChainTransferShares() public {
+        _testCrossChainTransferShares(false);
+    }
+
+    /// @notice Test transferring shares between Chain B and Chain C via Hub A
+    /// forge-config: default.isolate = true
+    function testCrossChainTransferSharesSameChain() public {
+        _testCrossChainTransferShares(true);
+    }
+
+    /// @notice Test transferring shares between Chain B and Chain C via Hub A
+    function _testCrossChainTransferShares(bool sameChain) internal {
         uint128 amount = 1e18;
 
         testConfigurePool(sameChain);

--- a/test/integration/ThreeChainEndToEnd.t.sol
+++ b/test/integration/ThreeChainEndToEnd.t.sol
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+
+import "test/integration/EndToEnd.t.sol";
+
+import {IAdapter} from "src/common/interfaces/IAdapter.sol";
+
+/// @title  Three Chain End-to-End Test
+/// @notice Extends the dual-chain setup to include a third chain (C) which acts as an additional spoke
+///         Hub is on Chain A, with spokes on Chains B and C
+contract ThreeChainEndToEndDeployment is EndToEndDeployment {
+    using CastLib for *;
+
+    uint16 constant CENTRIFUGE_ID_C = 7;
+    ISafe immutable safeAdminC = ISafe(makeAddr("SafeAdminC"));
+
+    FullDeployer deployC = new FullDeployer();
+    LocalAdapter adapterC;
+
+    // This represents the third Chain's spoke
+    CSpoke sC;
+
+    function setUp() public override {
+        // Call the original setUp to set up chains A and B
+        super.setUp();
+
+        // Deploy the third chain (C)
+        adapterC = _deployChain(deployC, CENTRIFUGE_ID_C, CENTRIFUGE_ID_A, safeAdminC);
+        vm.label(address(adapterC), "AdapterC");
+
+        // Connect Chain C to Chain A (hub)
+        adapterC.setEndpoint(adapterA);
+
+        // Connect Chain A to Chain C (spoke 2)
+        vm.startPrank(address(deployA.root()));
+        // FIXME: Breaks with NoDuplicatesAllowed even though A doesn't yet know about C?!
+        deployA.wire(CENTRIFUGE_ID_C, adapterA, address(deployA));
+        vm.stopPrank();
+
+        adapterA.setEndpoint(adapterC);
+    }
+
+    function _setThirdSpoke() internal {
+        if (sC.centrifugeId != 0) return; // Already set
+
+        sC = CSpoke({
+            centrifugeId: CENTRIFUGE_ID_C,
+            root: deployC.root(),
+            guardian: deployC.guardian(),
+            gateway: deployC.gateway(),
+            balanceSheet: deployC.balanceSheet(),
+            spoke: deployC.spoke(),
+            router: deployC.vaultRouter(),
+            fullRestrictionsHook: deployC.fullRestrictionsHook(),
+            redemptionRestrictionsHook: deployC.redemptionRestrictionsHook(),
+            asyncVaultFactory: address(deployC.asyncVaultFactory()).toBytes32(),
+            syncDepositVaultFactory: address(deployC.syncDepositVaultFactory()).toBytes32(),
+            asyncRequestManager: deployC.asyncRequestManager(),
+            syncRequestManager: deployC.syncRequestManager(),
+            usdc: new ERC20(6)
+        });
+
+        // Initialize USDC on chain C
+        sC.usdc.file("name", "USD Coin");
+        sC.usdc.file("symbol", "USDC");
+    }
+}
+
+/// @title  Three Chain End-to-End Use Cases
+/// @notice Test cases for the three-chain setup
+contract ThreeChainEndToEndUseCases is ThreeChainEndToEndDeployment {
+    using CastLib for *;
+
+    /// @notice Configure the third chain (C) with assets
+    /// forge-config: default.isolate = true
+    function testConfigureThirdChainAsset() public {
+        _setThirdSpoke();
+
+        // Initialize USDC on chain C
+        sC.usdc.mint(INVESTOR_A, INVESTOR_A_USDC_AMOUNT);
+        sC.spoke.registerAsset{value: GAS}(h.centrifugeId, address(sC.usdc), 0);
+
+        assertEq(h.hubRegistry.decimals(newAssetId(CENTRIFUGE_ID_C, 1)), 6, "expected decimals");
+    }
+}

--- a/test/integration/ThreeChainEndToEnd.t.sol
+++ b/test/integration/ThreeChainEndToEnd.t.sol
@@ -32,11 +32,8 @@ contract ThreeChainEndToEndDeployment is EndToEndDeployment {
         adapterC = _deployChain(deployC, CENTRIFUGE_ID_C, CENTRIFUGE_ID_A, safeAdminC);
         vm.label(address(adapterC), "AdapterC");
 
-        adapterAToC = new LocalAdapter(
-            CENTRIFUGE_ID_A,
-            deployA.multiAdapter(),
-            address(deployA)
-        );
+        adapterAToC = new LocalAdapter(CENTRIFUGE_ID_A, deployA.multiAdapter(), address(deployA));
+        vm.label(address(adapterAToC), "AdapterAToC");
 
         // Connect Chain A to Chain C (spoke 2)
         vm.startPrank(address(deployA.root()));
@@ -87,5 +84,59 @@ contract ThreeChainEndToEndUseCases is ThreeChainEndToEndDeployment {
         sC.spoke.registerAsset{value: GAS}(h.centrifugeId, address(sC.usdc), 0);
 
         assertEq(h.hubRegistry.decimals(newAssetId(CENTRIFUGE_ID_C, 1)), 6, "expected decimals");
+    }
+
+    /// @notice Configure a pool with support for all three chains
+    /// forge-config: default.isolate = true
+    function testConfigurePoolWithThreeChains() public {
+        // Configure spokes
+        s.usdc.mint(INVESTOR_A, INVESTOR_A_USDC_AMOUNT);
+        s.spoke.registerAsset{value: GAS}(h.centrifugeId, address(s.usdc), 0);
+        sC.usdc.mint(INVESTOR_A, INVESTOR_A_USDC_AMOUNT);
+        sC.spoke.registerAsset{value: GAS}(h.centrifugeId, address(sC.usdc), 0);
+
+        // Create and configure the pool on hub (chain A)
+        vm.prank(address(h.guardian.safe()));
+        h.guardian.createPool(POOL_A, FM, USD_ID);
+
+        vm.startPrank(FM);
+        h.hub.setPoolMetadata(POOL_A, bytes("Testing pool with three chains"));
+        h.hub.addShareClass(POOL_A, "Tokenized MMF", "MMF", bytes32("salt"));
+
+        h.hub.notifyPool{value: GAS}(POOL_A, s.centrifugeId);
+        h.hub.notifyPool{value: GAS}(POOL_A, sC.centrifugeId);
+
+        h.hub.notifyShareClass{value: GAS}(POOL_A, SC_1, s.centrifugeId, s.redemptionRestrictionsHook.toBytes32());
+        h.hub.notifyShareClass{value: GAS}(POOL_A, SC_1, sC.centrifugeId, sC.redemptionRestrictionsHook.toBytes32());
+
+        h.hub.createAccount(POOL_A, ASSET_ACCOUNT, true);
+        h.hub.createAccount(POOL_A, EQUITY_ACCOUNT, false);
+        h.hub.createAccount(POOL_A, LOSS_ACCOUNT, false);
+        h.hub.createAccount(POOL_A, GAIN_ACCOUNT, false);
+
+        AssetId USDC_ID_B = newAssetId(s.centrifugeId, 1);
+        AssetId USDC_ID_C = newAssetId(sC.centrifugeId, 1);
+
+        h.hub.initializeHolding(
+            POOL_A, SC_1, USDC_ID_B, h.identityValuation, ASSET_ACCOUNT, EQUITY_ACCOUNT, GAIN_ACCOUNT, LOSS_ACCOUNT
+        );
+        h.hub.initializeHolding(
+            POOL_A, SC_1, USDC_ID_C, h.identityValuation, ASSET_ACCOUNT, EQUITY_ACCOUNT, GAIN_ACCOUNT, LOSS_ACCOUNT
+        );
+
+        h.hub.updateBalanceSheetManager{value: GAS}(s.centrifugeId, POOL_A, BSM.toBytes32(), true);
+        h.hub.updateBalanceSheetManager{value: GAS}(sC.centrifugeId, POOL_A, BSM.toBytes32(), true);
+
+        h.hub.updateSharePrice(POOL_A, SC_1, IDENTITY_PRICE);
+        h.hub.notifySharePrice{value: GAS}(POOL_A, SC_1, s.centrifugeId);
+        h.hub.notifySharePrice{value: GAS}(POOL_A, SC_1, sC.centrifugeId);
+
+        h.hub.notifyAssetPrice{value: GAS}(POOL_A, SC_1, USDC_ID_B);
+        h.hub.notifyAssetPrice{value: GAS}(POOL_A, SC_1, USDC_ID_C);
+        vm.stopPrank();
+
+        vm.startPrank(BSM);
+        s.gateway.subsidizePool{value: DEFAULT_SUBSIDY}(POOL_A);
+        sC.gateway.subsidizePool{value: DEFAULT_SUBSIDY}(POOL_A);
     }
 }

--- a/test/integration/adapters/LocalAdapter.sol
+++ b/test/integration/adapters/LocalAdapter.sol
@@ -8,7 +8,7 @@ import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
 import {IAdapter} from "src/common/interfaces/IAdapter.sol";
 
-/// An adapter that sends the message to the another MessageHandler and acts as MessageHandler too.
+/// An adapter that sends the message to another MessageHandler and acts as MessageHandler too.
 contract LocalAdapter is Test, Auth, IAdapter, IMessageHandler {
     uint16 localCentrifugeId;
     IMessageHandler public entrypoint;
@@ -40,7 +40,7 @@ contract LocalAdapter is Test, Auth, IAdapter, IMessageHandler {
         // Local messages must be bypassed
         assertNotEq(remoteCentrifugeId, localCentrifugeId, "Local messages must be bypassed");
 
-        // The other handler will receive the message as comming from this
+        // The other handler will receive the message as coming from this
         endpoint.handle(localCentrifugeId, payload);
 
         adapterData = bytes32("");


### PR DESCRIPTION
* Adds E2e setup for three chains `B <> A <> C` (currently only A <> B supported)
* Adds test to register asset `C -> A`
* Adds test to configure pools on `{B, C} -> A`
* Adds test to transfer shares `B -> A -> C` as B and C are not linked directly, only indirectly via hub on A

