### PR TITLE
Fix Tests from deployment arch branch

### DIFF
--- a/snapshots/AsyncVault.json
+++ b/snapshots/AsyncVault.json
@@ -1,4 +1,4 @@
 {
-  "fulfillDepositRequest": "960950",
-  "requestDeposit": "532911"
+  "fulfillDepositRequest": "926705",
+  "requestDeposit": "370371"
 }

--- a/snapshots/ShareToken.json
+++ b/snapshots/ShareToken.json
@@ -1,3 +1,3 @@
 {
-  "transferFrom": "84427"
+  "transferFrom": "30187"
 }

--- a/snapshots/SyncDepositVault.json
+++ b/snapshots/SyncDepositVault.json
@@ -1,4 +1,4 @@
 {
-  "deposit_withQueue": "266887",
-  "deposit_withoutQueue": "325921"
+  "deposit_withQueue": "109570",
+  "deposit_withoutQueue": "221949"
 }

--- a/snapshots/VaultRouter.json
+++ b/snapshots/VaultRouter.json
@@ -1,7 +1,7 @@
 {
-  "claimDeposit": "1163239",
-  "enable": "60953",
-  "lockDepositRequest": "95663",
-  "requestDeposit": "571804",
-  "requestRedeem": "2093434"
+  "claimDeposit": "1007472",
+  "enable": "34521",
+  "lockDepositRequest": "57855",
+  "requestDeposit": "411196",
+  "requestRedeem": "1693671"
 }

--- a/test/spoke/BaseTest.sol
+++ b/test/spoke/BaseTest.sol
@@ -66,11 +66,11 @@ contract BaseTest is SpokeDeployer, Test {
     uint16 public constant THIS_CHAIN_ID = OTHER_CHAIN_ID + 100;
     uint32 public constant BLOCK_CHAIN_ID = 23;
     PoolId public immutable POOL_A = newPoolId(OTHER_CHAIN_ID, 1);
-    uint256 public constant ESTIMATE_ADAPTER_1 = 1 gwei;
-    uint256 public constant ESTIMATE_ADAPTER_2 = 1.25 gwei;
-    uint256 public constant ESTIMATE_ADAPTER_3 = 1.75 gwei;
+    uint256 public constant ESTIMATE_ADAPTER_1 = 1_000_000;  // 1M gas
+    uint256 public constant ESTIMATE_ADAPTER_2 = 1_250_000;  // 1.25M gas
+    uint256 public constant ESTIMATE_ADAPTER_3 = 1_750_000;  // 1.75M gas
     uint256 public constant ESTIMATE_ADAPTERS = ESTIMATE_ADAPTER_1 + ESTIMATE_ADAPTER_2 + ESTIMATE_ADAPTER_3;
-    uint256 public constant GAS_COST_LIMIT = 0.5 gwei;
+    uint256 public constant GAS_COST_LIMIT = 500_000;  // 500K gas
     uint256 public constant DEFAULT_GAS = ESTIMATE_ADAPTERS + GAS_COST_LIMIT * 3;
     uint256 public constant DEFAULT_SUBSIDY = DEFAULT_GAS * 100;
 

--- a/test/spoke/BaseTest.sol
+++ b/test/spoke/BaseTest.sol
@@ -66,11 +66,11 @@ contract BaseTest is SpokeDeployer, Test {
     uint16 public constant THIS_CHAIN_ID = OTHER_CHAIN_ID + 100;
     uint32 public constant BLOCK_CHAIN_ID = 23;
     PoolId public immutable POOL_A = newPoolId(OTHER_CHAIN_ID, 1);
-    uint256 public constant ESTIMATE_ADAPTER_1 = 1_000_000;  // 1M gas
-    uint256 public constant ESTIMATE_ADAPTER_2 = 1_250_000;  // 1.25M gas
-    uint256 public constant ESTIMATE_ADAPTER_3 = 1_750_000;  // 1.75M gas
+    uint256 public constant ESTIMATE_ADAPTER_1 = 1_000_000; // 1M gas
+    uint256 public constant ESTIMATE_ADAPTER_2 = 1_250_000; // 1.25M gas
+    uint256 public constant ESTIMATE_ADAPTER_3 = 1_750_000; // 1.75M gas
     uint256 public constant ESTIMATE_ADAPTERS = ESTIMATE_ADAPTER_1 + ESTIMATE_ADAPTER_2 + ESTIMATE_ADAPTER_3;
-    uint256 public constant GAS_COST_LIMIT = 500_000;  // 500K gas
+    uint256 public constant GAS_COST_LIMIT = 500_000; // 500K gas
     uint256 public constant DEFAULT_GAS = ESTIMATE_ADAPTERS + GAS_COST_LIMIT * 3;
     uint256 public constant DEFAULT_SUBSIDY = DEFAULT_GAS * 100;
 

--- a/test/spoke/integration/VaultRouter.t.sol
+++ b/test/spoke/integration/VaultRouter.t.sol
@@ -23,7 +23,7 @@ contract VaultRouterTest is BaseTest {
     using MessageLib for *;
     using MathLib for uint256;
 
-    uint256 constant GAS_BUFFER = 10_000_000;  // 10M gas
+    uint256 constant GAS_BUFFER = 10_000_000; // 10M gas
     bytes PAYLOAD_FOR_GAS_ESTIMATION = MessageLib.NotifyPool(1).serialize();
 
     /// forge-config: default.isolate = true

--- a/test/spoke/integration/VaultRouter.t.sol
+++ b/test/spoke/integration/VaultRouter.t.sol
@@ -23,7 +23,7 @@ contract VaultRouterTest is BaseTest {
     using MessageLib for *;
     using MathLib for uint256;
 
-    uint256 constant GAS_BUFFER = 10 gwei;
+    uint256 constant GAS_BUFFER = 10_000_000;  // 10M gas
     bytes PAYLOAD_FOR_GAS_ESTIMATION = MessageLib.NotifyPool(1).serialize();
 
     /// forge-config: default.isolate = true

--- a/test/spoke/unit/VaultRouter.t.sol
+++ b/test/spoke/unit/VaultRouter.t.sol
@@ -52,7 +52,7 @@ contract VaultRouterTest is BaseTest {
     using MathLib for uint256;
 
     uint16 constant CHAIN_ID = 1;
-    uint256 constant GAS_BUFFER = 10_000_000;  // 10M gas
+    uint256 constant GAS_BUFFER = 10_000_000; // 10M gas
     bytes PAYLOAD_FOR_GAS_ESTIMATION = MessageLib.NotifyPool(1).serialize();
 
     function testInitialization() public {

--- a/test/spoke/unit/VaultRouter.t.sol
+++ b/test/spoke/unit/VaultRouter.t.sol
@@ -20,6 +20,8 @@ import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
 import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
 import {SyncDepositVault} from "src/vaults/SyncDepositVault.sol";
 
+import {MathLib} from "src/misc/libraries/MathLib.sol";
+
 interface Authlike {
     function rely(address) external;
 }
@@ -47,9 +49,10 @@ contract NonAsyncVault {
 contract VaultRouterTest is BaseTest {
     using CastLib for *;
     using MessageLib for *;
+    using MathLib for uint256;
 
     uint16 constant CHAIN_ID = 1;
-    uint256 constant GAS_BUFFER = 10 gwei;
+    uint256 constant GAS_BUFFER = 10_000_000;  // 10M gas
     bytes PAYLOAD_FOR_GAS_ESTIMATION = MessageLib.NotifyPool(1).serialize();
 
     function testInitialization() public {


### PR DESCRIPTION
Tests are not passing on the branch for the new deployment architecture #419. This PR tries to fix that 

Here's the logs from running
`FOUNDRY_PROFILE=ci FORK_TEST=false forge test --no-match-path "test/spoke/fuzzing/**/*.sol" --deny-warnings`

Failing tests:
Encountered 1 failing test in test/common/unit/Gateway.t.sol:GatewayTestPayTransaction
[FAIL: assertion failed: 0xae7De9cB0cCcbe05118baE7c532a62FA10690A22 != 0x0000000000000000000000000000000000000000] testPayTransactionIsTransactional() (gas: 18818)

Encountered 1 failing test in test/common/unit/Gateway.t.sol:GatewayTestStartBatching
[FAIL: assertion failed: true != false] testStartBatchingIsTransactional() (gas: 12318)

Encountered 6 failing tests in test/spoke/integration/VaultRouter.t.sol:VaultRouterTest
[FAIL: ExceedsMaxBatchSize(); counterexample: calldata=0xb9551f12000000000000000000000000000000000000000000000000050d7bae2533ad52 args=[364083132765547858 [3.64e17]]] testLockAndExecuteDepositRequest(uint256) (runs: 0, μ: 0, ~: 0)
[FAIL: ExceedsMaxBatchSize()] testMulticallingApproveVaultAndExecuteLockedDepositRequest() (gas: 8125494)
[FAIL: ExceedsMaxBatchSize(); counterexample: calldata=0x86f0caa9000000000000000000000000000000000000000000000000050d7bae2533ad52 args=[364083132765547858 [3.64e17]]] testMulticallingApproveVaultAndExecuteLockedDepositRequestFuzz(uint256) (runs: 0, μ: 0, ~: 0)
[FAIL: ExceedsMaxBatchSize(); counterexample: calldata=0x07cc970c000000000000000000000000000000000000000000000000050d7bae2533ad52 args=[364083132765547858 [3.64e17]]] testMulticallingDepositClaimAndRequestRedeem(uint256) (runs: 0, μ: 0, ~: 0)
[FAIL: ExceedsMaxBatchSize(); counterexample: calldata=0x4f3e6d71000000000000000000000000000000000000000000000000050d7bae2533ad52000000000023b0a2463e12b274f99caea9cd710b18e239ff2b7bf054277bab02 args=[364083132765547858 [3.64e17], 14682004585171689204931677383812162902968522465928953195531053826 [1.468e64]]] testMulticallingDepositIntoMultipleVaults(uint256,uint256) (runs: 0, μ: 0, ~: 0)
[FAIL: Error != expected error: ExceedsMaxBatchSize() != NotEnoughTransactionGas(); counterexample: calldata=0xba0b734c000000000000000000000000000000000000000000000000050d7bae2533ad52 args=[364083132765547858 [3.64e17]]] testMultipleTopUpScenarios(uint256) (runs: 0, μ: 0, ~: 0)

Encountered a total of 8 failing tests, 689 tests succeeded
