### PR TITLE
ref: normalize PricingLib return types to `uint128`

### DIFF
--- a/snapshots/AsyncVault.json
+++ b/snapshots/AsyncVault.json
@@ -1,4 +1,4 @@
 {
-  "fulfillDepositRequest": "960969",
-  "requestDeposit": "532911"
+  "fulfillDepositRequest": "961039",
+  "requestDeposit": "533001"
 }

--- a/snapshots/SyncDepositVault.json
+++ b/snapshots/SyncDepositVault.json
@@ -1,4 +1,4 @@
 {
-  "deposit_withQueue": "268847",
-  "deposit_withoutQueue": "326041"
+  "deposit_withQueue": "268937",
+  "deposit_withoutQueue": "326131"
 }

--- a/snapshots/VaultRouter.json
+++ b/snapshots/VaultRouter.json
@@ -1,7 +1,7 @@
 {
-  "claimDeposit": "1163258",
+  "claimDeposit": "1163328",
   "enable": "60953",
   "lockDepositRequest": "95663",
-  "requestDeposit": "571804",
-  "requestRedeem": "2093453"
+  "requestDeposit": "571894",
+  "requestRedeem": "2093613"
 }

--- a/src/hub/Holdings.sol
+++ b/src/hub/Holdings.sol
@@ -130,7 +130,7 @@ contract Holdings is Auth, IHoldings {
 
         amountValue = PricingLib.convertWithPrice(
             amount_, hubRegistry.decimals(assetId), hubRegistry.decimals(poolId), pricePoolPerAsset
-        ).toUint128();
+        );
 
         holding_.assetAmount += amount_;
         holding_.assetAmountValue += amountValue;
@@ -148,7 +148,7 @@ contract Holdings is Auth, IHoldings {
 
         amountValue = PricingLib.convertWithPrice(
             amount_, hubRegistry.decimals(assetId), hubRegistry.decimals(poolId), pricePoolPerAsset
-        ).toUint128();
+        );
 
         holding_.assetAmount -= amount_;
         holding_.assetAmountValue -= amountValue;

--- a/src/hub/ShareClassManager.sol
+++ b/src/hub/ShareClassManager.sol
@@ -174,7 +174,7 @@ contract ShareClassManager is Auth, IShareClassManager {
 
         approvedPoolAmount = PricingLib.convertWithPrice(
             approvedAssetAmount, hubRegistry.decimals(depositAssetId), hubRegistry.decimals(poolId), pricePoolPerAsset
-        ).toUint128();
+        );
 
         // Update epoch data
         EpochInvestAmounts storage epochAmounts = epochInvestAmounts[scId_][depositAssetId][nowDepositEpochId];
@@ -297,13 +297,14 @@ contract ShareClassManager is Auth, IShareClassManager {
         // NOTE: shares and pool currency have the same decimals - no conversion needed!
         payoutPoolAmount = navPoolPerShare.mulUint128(epochAmounts.approvedShareAmount, MathLib.Rounding.Down);
 
-        payoutAssetAmount = PricingLib.poolToAssetAmount(
-            payoutPoolAmount,
+        payoutAssetAmount = PricingLib.shareToAssetAmount(
+            epochAmounts.approvedShareAmount,
             hubRegistry.decimals(poolId),
             hubRegistry.decimals(payoutAssetId),
             epochAmounts.pricePoolPerAsset,
+            epochAmounts.navPoolPerShare,
             MathLib.Rounding.Down
-        ).toUint128();
+        );
         revokedShareAmount = epochAmounts.approvedShareAmount;
 
         epochAmounts.payoutAssetAmount = payoutAssetAmount;
@@ -423,14 +424,14 @@ contract ShareClassManager is Auth, IShareClassManager {
         // tokens corresponding to the approved share amount (instead of equality). I.e., it is possible for an epoch to
         // have an excess of a share class tokens which cannot be claimed by anyone.
         if (paymentAssetAmount > 0) {
-            uint256 paymentPoolAmount = PricingLib.convertWithPrice(
+            payoutShareAmount = PricingLib.assetToShareAmount(
                 paymentAssetAmount,
                 hubRegistry.decimals(depositAssetId),
                 hubRegistry.decimals(poolId),
-                epochAmounts.pricePoolPerAsset
+                epochAmounts.pricePoolPerAsset,
+                epochAmounts.navPoolPerShare,
+                MathLib.Rounding.Down
             );
-            payoutShareAmount =
-                epochAmounts.navPoolPerShare.reciprocalMulUint256(paymentPoolAmount, MathLib.Rounding.Down).toUint128();
 
             userOrder.pending -= paymentAssetAmount;
         }

--- a/src/misc/IdentityValuation.sol
+++ b/src/misc/IdentityValuation.sol
@@ -18,6 +18,6 @@ contract IdentityValuation is BaseValuation, IIdentityValuation {
 
     /// @inheritdoc IValuation
     function getQuote(uint128 baseAmount, AssetId base, AssetId quote) external view returns (uint128 quoteAmount) {
-        return PricingLib.convertWithPrice(baseAmount, _getDecimals(base), _getDecimals(quote), d18(1e18)).toUint128();
+        return PricingLib.convertWithPrice(baseAmount, _getDecimals(base), _getDecimals(quote), d18(1e18));
     }
 }

--- a/test/hub/integration/Cases.t.sol
+++ b/test/hub/integration/Cases.t.sol
@@ -116,7 +116,7 @@ contract TestCases is BaseTest {
                 hubRegistry.decimals(USDC_C2),
                 hubRegistry.decimals(poolId),
                 NAV_PER_SHARE.reciprocal()
-            ).toUint128()
+            )
         );
         assertEq(m2.cancelledAssetAmount, INVESTOR_AMOUNT - APPROVED_INVESTOR_AMOUNT);
     }
@@ -129,7 +129,7 @@ contract TestCases is BaseTest {
 
         uint128 revokedAssetAmount = PricingLib.convertWithPrice(
             APPROVED_SHARE_AMOUNT, hubRegistry.decimals(poolId), hubRegistry.decimals(USDC_C2), NAV_PER_SHARE
-        ).toUint128();
+        );
 
         vm.startPrank(FM);
         hub.approveRedeems(

--- a/test/hub/unit/ShareClassManager.t.sol
+++ b/test/hub/unit/ShareClassManager.t.sol
@@ -106,7 +106,7 @@ abstract contract ShareClassManagerBaseTest is Test {
             IHubRegistry(hubRegistryMock).decimals(assetId),
             IHubRegistry(hubRegistryMock).decimals(poolId),
             _pricePoolPerAsset(assetId)
-        ).toUint128();
+        );
     }
 
     function _intoAssetAmount(AssetId assetId, uint128 amount) internal view returns (uint128) {
@@ -115,7 +115,7 @@ abstract contract ShareClassManagerBaseTest is Test {
             IHubRegistry(hubRegistryMock).decimals(poolId),
             IHubRegistry(hubRegistryMock).decimals(assetId),
             _pricePoolPerAsset(assetId).reciprocal()
-        ).toUint128();
+        );
     }
 
     function _calcSharesIssued(AssetId assetId, uint128 depositAmountAsset, D18 pricePoolPerShare)

--- a/test/misc/mocks/MockValuation.sol
+++ b/test/misc/mocks/MockValuation.sol
@@ -30,6 +30,6 @@ contract MockValuation is BaseValuation, ReentrancyProtection {
         D18 price_ = price[base][quote];
         require(D18.unwrap(price_) != 0, "Price not set");
 
-        return PricingLib.convertWithPrice(baseAmount, _getDecimals(base), _getDecimals(quote), price_).toUint128();
+        return PricingLib.convertWithPrice(baseAmount, _getDecimals(base), _getDecimals(quote), price_);
     }
 }

--- a/test/misc/unit/libraries/PricingLib.t.sol
+++ b/test/misc/unit/libraries/PricingLib.t.sol
@@ -18,9 +18,9 @@ contract PricingLibBaseTest is Test {
     uint8 constant POOL_DECIMALS = 18;
     uint8 constant SHARE_DECIMALS = POOL_DECIMALS;
     uint128 constant MIN_PRICE = 1; // NOTE: 0 prices are handled separately
-    uint128 constant MAX_PRICE_POOL_PER_ASSET = 1e38;
-    uint128 constant MAX_PRICE_POOL_PER_SHARE = 1e38;
-    uint128 constant MAX_AMOUNT = 1e38; //type(uint128).max / MAX_PRICE_POOL_PER_SHARE;
+    uint128 constant MAX_PRICE_POOL_PER_ASSET = 1e30;
+    uint128 constant MAX_PRICE_POOL_PER_SHARE = 1e30;
+    uint128 constant MAX_AMOUNT = 1e24;
 }
 
 contract ConvertWithPriceTest is PricingLibBaseTest {
@@ -59,9 +59,9 @@ contract ConvertWithPriceTest is PricingLibBaseTest {
         uint8 quoteDecimals,
         uint128 priceRaw
     ) public pure {
-        baseAmount = uint128(bound(baseAmount, 0, MAX_AMOUNT));
         baseDecimals = uint8(bound(baseDecimals, MIN_ASSET_DECIMALS, MAX_ASSET_DECIMALS));
         quoteDecimals = uint8(bound(quoteDecimals, MIN_ASSET_DECIMALS, MAX_ASSET_DECIMALS));
+        baseAmount = uint128(bound(baseAmount, 1, MAX_AMOUNT / (10 ** quoteDecimals)));
         D18 price = d18(uint128(bound(priceRaw, MIN_PRICE, MAX_PRICE_POOL_PER_ASSET)));
 
         uint256 scaledBase;
@@ -113,7 +113,7 @@ contract ConvertWithPriceEdgeCasesTest is PricingLibBaseTest {
     }
 
     function testEdgeCaseWithPriceMaxAmounts() public view {
-        uint256 maxBaseAmount = type(uint128).max;
+        uint128 maxBaseAmount = type(uint64).max;
         D18 price = d18(type(uint64).max);
         uint256 result = PricingLib.convertWithPrice(maxBaseAmount, baseDecimals, quoteDecimals, price);
         uint256 expected =
@@ -149,8 +149,8 @@ contract ConvertWithReciprocalPriceTest is PricingLibBaseTest {
     }
 
     function testConvertWithReciprocalPriceSameDecimals(uint128 baseAmount, uint128 priceRaw) public pure {
-        baseAmount = uint128(bound(baseAmount, 0, MAX_AMOUNT));
-        D18 price = d18(uint128(bound(priceRaw, MIN_PRICE, MAX_PRICE_POOL_PER_ASSET)));
+        baseAmount = uint128(bound(baseAmount, 0, type(uint128).max / (10 ** 18)));
+        D18 price = d18(uint128(bound(priceRaw, MIN_PRICE, type(uint128).max / (10 ** 18))));
 
         uint256 expected = price.reciprocalMulUint256(baseAmount, MathLib.Rounding.Down);
         uint256 result = PricingLib.convertWithReciprocalPrice(baseAmount, 18, 18, price, MathLib.Rounding.Down);
@@ -163,10 +163,12 @@ contract ConvertWithReciprocalPriceTest is PricingLibBaseTest {
         uint8 quoteDecimals,
         uint128 priceRaw
     ) public pure {
-        baseAmount = uint128(bound(baseAmount, 0, MAX_AMOUNT));
         baseDecimals = uint8(bound(baseDecimals, MIN_ASSET_DECIMALS, MAX_ASSET_DECIMALS));
         quoteDecimals = uint8(bound(quoteDecimals, MIN_ASSET_DECIMALS, MAX_ASSET_DECIMALS));
-        D18 price = d18(uint128(bound(priceRaw, MIN_PRICE, MAX_PRICE_POOL_PER_ASSET)));
+        baseAmount = uint128(bound(baseAmount, 0, type(uint128).max / (10 ** quoteDecimals)));
+        D18 price = d18(uint128(bound(priceRaw, MIN_PRICE, type(uint128).max / (10 ** baseDecimals))));
+
+        vm.assume(10 ** (18 + quoteDecimals) * baseAmount < type(uint128).max * 10 ** baseDecimals * price.raw());
 
         uint256 scaledBase;
         if (baseDecimals > quoteDecimals) {
@@ -174,7 +176,6 @@ contract ConvertWithReciprocalPriceTest is PricingLibBaseTest {
         } else {
             scaledBase = baseAmount * (10 ** (quoteDecimals - baseDecimals));
         }
-
         uint256 underestimate = price.reciprocalMulUint256(scaledBase, MathLib.Rounding.Down);
         uint256 expectedDown = MathLib.mulDiv(
             baseAmount * 10 ** quoteDecimals, 1e18, 10 ** baseDecimals * price.raw(), MathLib.Rounding.Down
@@ -184,7 +185,6 @@ contract ConvertWithReciprocalPriceTest is PricingLibBaseTest {
         );
         uint256 result =
             PricingLib.convertWithReciprocalPrice(baseAmount, baseDecimals, quoteDecimals, price, MathLib.Rounding.Down);
-
         assertGe(result, underestimate, "convertWithReciprocalPrice should be at least as large as underestimate");
         assertEq(result, expectedDown, "convertWithReciprocalPrice failed");
         assertApproxEqAbs(expectedDown, expectedUp, 1, "Rounding diff should be at most one");
@@ -228,8 +228,8 @@ contract ConvertWithReciprocalPriceEdgeCasesTest is PricingLibBaseTest {
     }
 
     function testEdgeCaseWithReciprocalPriceMaxAmounts() public view {
-        uint256 maxBaseAmount = type(uint128).max;
-        D18 price = d18(type(uint64).max);
+        uint256 maxBaseAmount = type(uint64).max;
+        D18 price = d18(type(uint128).max);
         uint256 result = PricingLib.convertWithReciprocalPrice(
             maxBaseAmount, baseDecimals, quoteDecimals, price, MathLib.Rounding.Down
         );
@@ -268,14 +268,19 @@ contract ConvertWithPricesTest is PricingLibBaseTest {
         );
     }
 
-    function testConvertWithPricesSameDecimals(
-        uint128 baseAmount,
-        uint128 priceNumeratorRaw,
-        uint128 priceDenominatorRaw
-    ) public pure {
+    function testConvertWithPricesSameDecimals(uint128 baseAmount, uint128 priceNumerator_, uint128 priceDenominator_)
+        public
+        pure
+    {
         baseAmount = uint128(bound(baseAmount, 0, MAX_AMOUNT));
-        D18 priceNumerator = d18(uint128(bound(priceNumeratorRaw, MIN_PRICE, MAX_PRICE_POOL_PER_ASSET)));
-        D18 priceDenominator = d18(uint128(bound(priceDenominatorRaw, MIN_PRICE, MAX_PRICE_POOL_PER_ASSET)));
+        D18 priceDenominator = d18(uint128(bound(priceDenominator_, MIN_PRICE, MAX_PRICE_POOL_PER_ASSET)));
+        D18 priceNumerator = d18(
+            uint128(
+                bound(
+                    priceNumerator_, MIN_PRICE, uint256(type(uint128).max) / (baseAmount + 1) * priceDenominator.raw()
+                )
+            )
+        );
 
         uint256 expected =
             MathLib.mulDiv(priceNumerator.raw(), baseAmount, priceDenominator.raw(), MathLib.Rounding.Down);
@@ -288,36 +293,43 @@ contract ConvertWithPricesTest is PricingLibBaseTest {
         uint128 baseAmount,
         uint8 baseDecimals,
         uint8 quoteDecimals,
-        uint128 priceNumeratorRaw,
-        uint128 priceDenominatorRaw
+        uint128 priceNumerator_,
+        uint128 priceDenominator_
     ) public pure {
-        baseAmount = uint128(bound(baseAmount, 0, MAX_AMOUNT));
         baseDecimals = uint8(bound(baseDecimals, MIN_ASSET_DECIMALS, MAX_ASSET_DECIMALS));
         quoteDecimals = uint8(bound(quoteDecimals, MIN_ASSET_DECIMALS, MAX_ASSET_DECIMALS));
-        D18 priceNumerator = d18(uint128(bound(priceNumeratorRaw, MIN_PRICE, MAX_PRICE_POOL_PER_ASSET)));
-        D18 priceDenominator = d18(uint128(bound(priceDenominatorRaw, MIN_PRICE, MAX_PRICE_POOL_PER_ASSET)));
-
+        baseAmount = uint128(bound(baseAmount, 1, type(uint128).max / (10 ** quoteDecimals)));
+        D18 priceDenominator = d18(uint128(bound(priceDenominator_, MIN_PRICE, MAX_PRICE_POOL_PER_ASSET)));
+        D18 priceNumerator = d18(
+            uint128(
+                bound(
+                    priceNumerator_,
+                    0,
+                    10 ** baseDecimals * 1e28 / (10 ** quoteDecimals * (baseAmount + 1)) * priceDenominator.raw()
+                )
+            )
+        );
         uint256 scaledBase;
         if (baseDecimals > quoteDecimals) {
             scaledBase = baseAmount / (10 ** (baseDecimals - quoteDecimals));
         } else {
             scaledBase = baseAmount * (10 ** (quoteDecimals - baseDecimals));
         }
-
         uint256 underestimate =
             MathLib.mulDiv(priceNumerator.raw(), scaledBase, priceDenominator.raw(), MathLib.Rounding.Down);
-        uint256 expectedDown = MathLib.mulDiv(
-            priceNumerator.raw(),
-            baseAmount * 10 ** quoteDecimals,
-            10 ** baseDecimals * priceDenominator.raw(),
-            MathLib.Rounding.Down
-        );
         uint256 expectedUp = MathLib.mulDiv(
             priceNumerator.raw(),
-            baseAmount * 10 ** quoteDecimals,
+            10 ** quoteDecimals * baseAmount,
             10 ** baseDecimals * priceDenominator.raw(),
             MathLib.Rounding.Up
         );
+        uint256 expectedDown = MathLib.mulDiv(
+            priceNumerator.raw(),
+            uint256(baseAmount) * 10 ** quoteDecimals,
+            10 ** baseDecimals * uint256(priceDenominator.raw()),
+            MathLib.Rounding.Down
+        );
+
         uint256 result = PricingLib.convertWithPrices(
             baseAmount, baseDecimals, quoteDecimals, priceNumerator, priceDenominator, MathLib.Rounding.Down
         );
@@ -371,7 +383,7 @@ contract ConvertWithPricesEdgeCasesTest is PricingLibBaseTest {
     }
 
     function testEdgeCaseWithPricesMaxAmounts() public view {
-        uint256 maxBaseAmount = type(uint128).max;
+        uint256 maxBaseAmount = type(uint64).max;
 
         D18 priceNumerator = d18(type(uint64).max);
         D18 priceDenominator = d18(type(uint64).max);
@@ -395,21 +407,41 @@ contract AssetToShareAmountTest is PricingLibBaseTest {
     using PricingLib for *;
     using MathLib for uint256;
 
+    function _setUpBounds(
+        uint128 assetAmount_,
+        uint8 assetDecimals_,
+        uint128 pricePoolPerAsset_,
+        uint128 pricePoolPerShare_
+    )
+        internal
+        pure
+        returns (
+            uint128 assetAmount,
+            uint8 assetDecimals,
+            D18 pricePoolPerAsset,
+            D18 pricePoolPerShare,
+            uint256 poolAmount
+        )
+    {
+        assetDecimals = uint8(bound(assetDecimals, MIN_ASSET_DECIMALS, MAX_ASSET_DECIMALS));
+        assetAmount = uint128(bound(assetAmount, 0, type(uint128).max / (10 ** assetDecimals)));
+        pricePoolPerAsset = d18(uint128(bound(pricePoolPerAsset_, MIN_PRICE, MAX_PRICE_POOL_PER_ASSET)));
+        pricePoolPerShare = d18(uint128(bound(pricePoolPerShare_, MIN_PRICE, MAX_PRICE_POOL_PER_SHARE)));
+
+        poolAmount = pricePoolPerAsset.mulUint256(
+            uint256(assetAmount).mulDiv(10 ** SHARE_DECIMALS, 10 ** assetDecimals), MathLib.Rounding.Down
+        );
+        vm.assume(poolAmount < type(uint128).max / 1e18);
+    }
+
     function testAssetToShareAmount(
-        uint128 assetAmount,
-        uint8 assetDecimals,
+        uint128 assetAmount_,
+        uint8 assetDecimals_,
         uint128 pricePoolPerAsset_,
         uint128 pricePoolPerShare_
     ) public pure {
-        assetDecimals = uint8(bound(assetDecimals, MIN_ASSET_DECIMALS, MAX_ASSET_DECIMALS));
-        assetAmount = uint128(bound(assetAmount, 10 ** assetDecimals, MAX_AMOUNT));
-        D18 pricePoolPerAsset = d18(uint128(bound(pricePoolPerAsset_, MIN_PRICE, MAX_PRICE_POOL_PER_ASSET)));
-        D18 pricePoolPerShare = d18(uint128(bound(pricePoolPerShare_, MIN_PRICE, MAX_PRICE_POOL_PER_SHARE)));
-
-        uint256 poolAmount = pricePoolPerAsset.mulUint256(
-            uint256(assetAmount).mulDiv(10 ** SHARE_DECIMALS, 10 ** assetDecimals), MathLib.Rounding.Down
-        );
-        vm.assume(poolAmount < type(uint256).max / 1e18);
+        (uint128 assetAmount, uint8 assetDecimals, D18 pricePoolPerAsset, D18 pricePoolPerShare, uint256 poolAmount) =
+            _setUpBounds(assetAmount_, assetDecimals_, pricePoolPerAsset_, pricePoolPerShare_);
 
         uint256 underestimate = pricePoolPerShare.reciprocalMulUint256(poolAmount, MathLib.Rounding.Down);
         uint256 expectedDown = MathLib.mulDiv(
@@ -426,7 +458,7 @@ contract AssetToShareAmountTest is PricingLibBaseTest {
         );
 
         uint256 result = PricingLib.assetToShareAmount(
-            assetAmount, assetDecimals, SHARE_DECIMALS, pricePoolPerAsset, pricePoolPerShare, MathLib.Rounding.Down
+            assetAmount, assetDecimals, POOL_DECIMALS, pricePoolPerAsset, pricePoolPerShare, MathLib.Rounding.Down
         );
 
         assertGe(result, underestimate, "assetToShareAmount should be at least as large as underestimate");
@@ -436,15 +468,13 @@ contract AssetToShareAmountTest is PricingLibBaseTest {
 
     /// NOTE: Precision is horrible with fuzzed inputs but still reflects a worst case which is better than nothing
     function testAssetToShareToAssetRoundTrip(
-        uint128 assetAmount,
-        uint8 assetDecimals,
+        uint128 assetAmount_,
+        uint8 assetDecimals_,
         uint64 pricePoolPerAsset_,
         uint64 pricePoolPerShare_
     ) public pure {
-        assetDecimals = uint8(bound(assetDecimals, MIN_ASSET_DECIMALS, MAX_ASSET_DECIMALS));
-        assetAmount = uint128(bound(assetAmount, 10 ** assetDecimals, MAX_AMOUNT));
-        D18 pricePoolPerAsset = d18(uint128(bound(pricePoolPerAsset_, MIN_PRICE, MAX_PRICE_POOL_PER_ASSET)));
-        D18 pricePoolPerShare = d18(uint128(bound(pricePoolPerShare_, MIN_PRICE, MAX_PRICE_POOL_PER_SHARE)));
+        (uint128 assetAmount, uint8 assetDecimals, D18 pricePoolPerAsset, D18 pricePoolPerShare,) =
+            _setUpBounds(assetAmount_, assetDecimals_, pricePoolPerAsset_, pricePoolPerShare_);
 
         uint256 shareAmount = PricingLib.assetToShareAmount(
             assetAmount, assetDecimals, POOL_DECIMALS, pricePoolPerAsset, pricePoolPerShare, MathLib.Rounding.Down
@@ -469,9 +499,18 @@ contract ShareToAssetToShareTest is PricingLibBaseTest {
         uint64 pricePoolPerShare_
     ) public pure {
         assetDecimals = uint8(bound(assetDecimals, MIN_ASSET_DECIMALS, MAX_ASSET_DECIMALS));
+        shareAmount = uint128(bound(shareAmount, 0, (type(uint128).max / 10 ** assetDecimals)));
         D18 pricePoolPerAsset = d18(uint128(bound(pricePoolPerAsset_, MIN_PRICE, MAX_PRICE_POOL_PER_ASSET)));
-        D18 pricePoolPerShare = d18(uint128(bound(pricePoolPerShare_, MIN_PRICE, MAX_PRICE_POOL_PER_SHARE)));
-        shareAmount = uint128(bound(shareAmount, 10 ** assetDecimals, MAX_AMOUNT));
+        D18 pricePoolPerShare = d18(
+            uint128(
+                bound(
+                    pricePoolPerShare_,
+                    MIN_PRICE,
+                    (10 ** 18 * pricePoolPerAsset.raw() * uint256(type(uint128).max))
+                        / (10 ** assetDecimals * (shareAmount + 1))
+                )
+            )
+        );
 
         uint256 assetAmount = PricingLib.shareToAssetAmount(
             shareAmount, POOL_DECIMALS, assetDecimals, pricePoolPerAsset, pricePoolPerShare, MathLib.Rounding.Down
@@ -489,10 +528,18 @@ contract ShareToAssetToShareTest is PricingLibBaseTest {
         uint64 pricePoolPerAsset_
     ) public pure {
         assetDecimals = uint8(bound(assetDecimals, MIN_ASSET_DECIMALS, MAX_ASSET_DECIMALS));
-        shareAmount = uint128(bound(shareAmount, 1e18, MAX_AMOUNT));
+        shareAmount = uint128(bound(shareAmount, 0, (type(uint128).max / 10 ** assetDecimals)));
         D18 pricePoolPerAsset = d18(uint128(bound(pricePoolPerAsset_, MIN_PRICE, MAX_PRICE_POOL_PER_ASSET)));
-        D18 pricePoolPerShare = d18(uint128(bound(pricePoolPerShare_, MIN_PRICE, MAX_PRICE_POOL_PER_SHARE)));
-
+        D18 pricePoolPerShare = d18(
+            uint128(
+                bound(
+                    pricePoolPerShare_,
+                    MIN_PRICE,
+                    (10 ** 18 * pricePoolPerAsset.raw() * uint256(type(uint128).max))
+                        / (10 ** assetDecimals * (shareAmount + 1))
+                )
+            )
+        );
         uint256 underestimate = pricePoolPerAsset.reciprocalMulUint256(
             pricePoolPerShare.mulUint256(
                 uint256(shareAmount).mulDiv(10 ** assetDecimals, 10 ** SHARE_DECIMALS), MathLib.Rounding.Down
@@ -550,8 +597,9 @@ contract PoolToAssetAmountTest is PricingLibBaseTest {
 
     function testPoolToAssetAmount(uint128 poolAmount, uint8 assetDecimals, uint64 pricePoolPerAsset_) public pure {
         assetDecimals = uint8(bound(assetDecimals, MIN_ASSET_DECIMALS, MAX_ASSET_DECIMALS));
-        poolAmount = uint128(bound(poolAmount, 10 ** POOL_DECIMALS, MAX_AMOUNT));
         D18 pricePoolPerAsset = d18(uint128(bound(pricePoolPerAsset_, MIN_PRICE, MAX_PRICE_POOL_PER_ASSET)));
+        poolAmount =
+            uint128(bound(poolAmount, 0, type(uint128).max / (10 ** (assetDecimals + 18) * pricePoolPerAsset.raw())));
 
         uint256 underestimate = pricePoolPerAsset.reciprocalMulUint256(
             uint256(poolAmount).mulDiv(10 ** assetDecimals, 10 ** POOL_DECIMALS, MathLib.Rounding.Down),
@@ -589,8 +637,8 @@ contract CalcPriceAssetPerShareTest is Test {
         vm.mockCall(shareToken, abi.encodeWithSelector(IERC20Metadata.decimals.selector), abi.encode(SHARE_DECIMALS));
     }
 
-    function _assertPrice(uint256 shares, uint256 assets, uint256 expected, MathLib.Rounding rounding) internal view {
-        uint256 calculated = PricingLib.calculatePriceAssetPerShare(
+    function _assertPrice(uint256 shares, uint256 assets, uint128 expected, MathLib.Rounding rounding) internal view {
+        uint128 calculated = PricingLib.calculatePriceAssetPerShare(
             shareToken, shares.toUint128(), asset, 0, assets.toUint128(), rounding
         );
         assertEq(calculated, expected);
@@ -599,7 +647,7 @@ contract CalcPriceAssetPerShareTest is Test {
     function testIdentityPrice() public view {
         uint256 shares = 10 ** SHARE_DECIMALS;
         uint256 assets = 10 ** ASSET_DECIMALS;
-        uint256 expected = 1e18;
+        uint128 expected = 1e18;
 
         _assertPrice(shares, assets, expected, MathLib.Rounding.Down);
     }
@@ -607,7 +655,7 @@ contract CalcPriceAssetPerShareTest is Test {
     function testManual() public view {
         uint256 shares = 2e18;
         uint256 assets = 51;
-        uint256 expected = 25.5e10; // 1e18 * 51 * 1e12 / 2e18 * 1e2
+        uint128 expected = 25.5e10; // 1e18 * 51 * 1e12 / 2e18 * 1e2
 
         _assertPrice(shares, assets, expected, MathLib.Rounding.Down);
     }
@@ -628,13 +676,13 @@ contract CalcPriceAssetPerShareTest is Test {
         _assertPrice(1e18, 1, 1e10, MathLib.Rounding.Down);
 
         // Large assets, small shares
-        _assertPrice(1, 1e18, 1e46, MathLib.Rounding.Down);
+        _assertPrice(1, 1e10, 1e38, MathLib.Rounding.Down);
     }
 
     function testRoundingModes() public view {
         uint256 shares = 3;
         uint256 assets = 10;
-        uint256 expected = 10 ** 29;
+        uint128 expected = 10 ** 29;
 
         // Rounding.Down
         _assertPrice(shares, assets, expected / 3, MathLib.Rounding.Down);

--- a/test/misc/unit/libraries/PricingLib.t.sol
+++ b/test/misc/unit/libraries/PricingLib.t.sol
@@ -423,8 +423,8 @@ contract AssetToShareAmountTest is PricingLibBaseTest {
             uint256 poolAmount
         )
     {
-        assetDecimals = uint8(bound(assetDecimals, MIN_ASSET_DECIMALS, MAX_ASSET_DECIMALS));
-        assetAmount = uint128(bound(assetAmount, 0, type(uint128).max / (10 ** assetDecimals)));
+        assetDecimals = uint8(bound(assetDecimals_, MIN_ASSET_DECIMALS, MAX_ASSET_DECIMALS));
+        assetAmount = uint128(bound(assetAmount_, 0, type(uint128).max / (10 ** assetDecimals)));
         pricePoolPerAsset = d18(uint128(bound(pricePoolPerAsset_, MIN_PRICE, MAX_PRICE_POOL_PER_ASSET)));
         pricePoolPerShare = d18(uint128(bound(pricePoolPerShare_, MIN_PRICE, MAX_PRICE_POOL_PER_SHARE)));
 


### PR DESCRIPTION
* Normalizes return types of PricingLib functions to `uint128` as we are using solely that throughout our codebase
* Apart from a larger amount of required changes in the corresponding test function, there were no other changes necessary
   * Proves this change effectively does nothing apart from moving to uint128 conversion check layer from consumers of the lib to itself
   * Improves PricingLib fuzzed bounds (unfortunately more complex than with `uint256` return types)
* Ref creep 1: Minor precision improvement in SCM by merging two split calculations into one each 