### PR TITLE
Tests: add more end-to-end tests

### DIFF
--- a/src/common/libraries/PricingLib.sol
+++ b/src/common/libraries/PricingLib.sol
@@ -251,6 +251,17 @@ library PricingLib {
         return convertWithReciprocalPrice(poolAmount, poolDecimals, assetDecimals, pricePoolPerAsset, rounding);
     }
 
+    /// @dev Converts asset amount to pool amount.
+    function assetToPoolAmount(
+        uint256 assetAmount,
+        uint8 assetDecimals,
+        uint8 poolDecimals,
+        D18 pricePoolPerAsset,
+        MathLib.Rounding rounding
+    ) internal pure returns (uint256 poolAmount) {
+        return convertWithPrice(assetAmount, assetDecimals, poolDecimals, pricePoolPerAsset, rounding);
+    }
+
     /// @dev Returns the asset price per share denominated in ASSET_UNIT/SHARE_UNIT
     ///
     ///      NOTE: Should never be used for calculating amounts due to precision loss. Instead, please refer to

--- a/src/common/libraries/PricingLib.sol
+++ b/src/common/libraries/PricingLib.sol
@@ -253,12 +253,12 @@ library PricingLib {
 
     /// @dev Converts asset amount to pool amount.
     function assetToPoolAmount(
-        uint256 assetAmount,
+        uint128 assetAmount,
         uint8 assetDecimals,
         uint8 poolDecimals,
         D18 pricePoolPerAsset,
         MathLib.Rounding rounding
-    ) internal pure returns (uint256 poolAmount) {
+    ) internal pure returns (uint128 poolAmount) {
         return convertWithPrice(assetAmount, assetDecimals, poolDecimals, pricePoolPerAsset, rounding);
     }
 

--- a/src/spoke/BalanceSheet.sol
+++ b/src/spoke/BalanceSheet.sol
@@ -204,7 +204,7 @@ contract BalanceSheet is Auth, Recoverable, IBalanceSheet, IBalanceSheetGatewayH
         ShareQueueAmount storage shareQueue = queuedShares[poolId][scId];
         D18 pricePoolPerAsset = _pricePoolPerAsset(poolId, scId, assetId);
 
-        bool isSnapshot = shareQueue.delta == 0 && shareQueue.queuedAssetCounter == 0;
+        bool isSnapshot = shareQueue.delta == 0 && shareQueue.queuedAssetCounter == 1;
         emit SubmitQueuedAssets(
             poolId,
             scId,
@@ -215,29 +215,18 @@ contract BalanceSheet is Auth, Recoverable, IBalanceSheet, IBalanceSheetGatewayH
             isSnapshot,
             shareQueue.nonce
         );
-        if (assetQueue.deposits > assetQueue.withdrawals) {
-            sender.sendUpdateHoldingAmount(
-                poolId,
-                scId,
-                assetId,
-                assetQueue.deposits - assetQueue.withdrawals,
-                pricePoolPerAsset,
-                true,
-                isSnapshot,
-                shareQueue.nonce
-            );
-        } else if (assetQueue.withdrawals > assetQueue.deposits) {
-            sender.sendUpdateHoldingAmount(
-                poolId,
-                scId,
-                assetId,
-                assetQueue.withdrawals - assetQueue.deposits,
-                pricePoolPerAsset,
-                false,
-                isSnapshot,
-                shareQueue.nonce
-            );
-        }
+        sender.sendUpdateHoldingAmount(
+            poolId,
+            scId,
+            assetId,
+            (assetQueue.deposits >= assetQueue.withdrawals)
+                ? assetQueue.deposits - assetQueue.withdrawals
+                : assetQueue.withdrawals - assetQueue.deposits,
+            pricePoolPerAsset,
+            assetQueue.deposits >= assetQueue.withdrawals,
+            isSnapshot,
+            shareQueue.nonce
+        );
 
         assetQueue.deposits = 0;
         assetQueue.withdrawals = 0;

--- a/test/common/mocks/MockValuation.sol
+++ b/test/common/mocks/MockValuation.sol
@@ -4,8 +4,6 @@ pragma solidity 0.8.28;
 import {D18, d18} from "src/misc/types/D18.sol";
 import {MathLib} from "src/misc/libraries/MathLib.sol";
 
-import {TransientStorageLib} from "src/misc/libraries/TransientStorageLib.sol";
-import {ReentrancyProtection} from "src/misc/ReentrancyProtection.sol";
 import {IERC6909Decimals} from "src/misc/interfaces/IERC6909.sol";
 
 import {IValuation} from "src/common/interfaces/IValuation.sol";
@@ -13,14 +11,14 @@ import {BaseValuation} from "src/common/BaseValuation.sol";
 import {PricingLib} from "src/common/libraries/PricingLib.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
 
-contract MockValuation is BaseValuation, ReentrancyProtection {
+contract MockValuation is BaseValuation {
     using MathLib for *;
 
     constructor(IERC6909Decimals erc6909) BaseValuation(erc6909, msg.sender) {}
 
     mapping(AssetId base => mapping(AssetId quote => D18)) public price;
 
-    function setPrice(AssetId base, AssetId quote, D18 price_) external protected {
+    function setPrice(AssetId base, AssetId quote, D18 price_) external {
         price[base][quote] = price_;
         price[quote][base] = price_.reciprocal();
     }

--- a/test/hooks/mocks/MockSnapshotHook.sol
+++ b/test/hooks/mocks/MockSnapshotHook.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {ISnapshotHook} from "src/common/interfaces/ISnapshotHook.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
+import {ShareClassId} from "src/common/types/ShareClassId.sol";
+
+contract MockSnapshotHook is ISnapshotHook {
+    mapping(PoolId => mapping(ShareClassId => mapping(uint16 centrifugeId => uint256 counter))) public synced;
+
+    function onSync(PoolId poolId, ShareClassId scId, uint16 centrifugeId) external {
+        synced[poolId][scId][centrifugeId]++;
+    }
+}

--- a/test/hub/integration/BaseTest.sol
+++ b/test/hub/integration/BaseTest.sol
@@ -24,7 +24,7 @@ import {AccountType} from "src/hub/interfaces/IHub.sol";
 import {JournalEntry} from "src/hub/interfaces/IAccounting.sol";
 
 import {MockVaults} from "test/hub/mocks/MockVaults.sol";
-import {MockValuation} from "test/misc/mocks/MockValuation.sol";
+import {MockValuation} from "test/common/mocks/MockValuation.sol";
 
 contract BaseTest is HubDeployer, Test {
     uint16 constant CHAIN_CP = 5;

--- a/test/integration/EndToEnd.t.sol
+++ b/test/integration/EndToEnd.t.sol
@@ -49,7 +49,7 @@ import {FullDeployer, HubDeployer, SpokeDeployer} from "script/FullDeployer.s.so
 import {CommonDeployer, MESSAGE_COST_ENV} from "script/CommonDeployer.s.sol";
 
 import {LocalAdapter} from "test/integration/adapters/LocalAdapter.sol";
-import {MockValuation} from "test/misc/mocks/MockValuation.sol";
+import {MockValuation} from "test/common/mocks/MockValuation.sol";
 import {MockSnapshotHook} from "test/hooks/mocks/MockSnapshotHook.sol";
 
 /// End to end testing assuming two full deployments in two different chains

--- a/test/integration/EndToEnd.t.sol
+++ b/test/integration/EndToEnd.t.sol
@@ -262,7 +262,7 @@ contract EndToEndUtils is EndToEndDeployment {
 
     function shareToAsset(uint128 shareAmount) public view returns (uint128 assetAmount) {
         return PricingLib.shareToAssetAmount(
-            shareAmount, SHARE_DECIMALS, USDC_DECIMALS, ASSET_PRICE, SHARE_PRICE, MathLib.Rounding.Down
+            shareAmount, SHARE_DECIMALS, USDC_DECIMALS, SHARE_PRICE, ASSET_PRICE, MathLib.Rounding.Down
         );
     }
 

--- a/test/integration/EndToEnd.t.sol
+++ b/test/integration/EndToEnd.t.sol
@@ -257,25 +257,23 @@ contract EndToEndUtils is EndToEndDeployment {
     function assetToShare(uint128 assetAmount) public view returns (uint128 shareAmount) {
         return PricingLib.assetToShareAmount(
             assetAmount, USDC_DECIMALS, SHARE_DECIMALS, ASSET_PRICE, SHARE_PRICE, MathLib.Rounding.Down
-        ).toUint128();
+        );
     }
 
     function shareToAsset(uint128 shareAmount) public view returns (uint128 assetAmount) {
         return PricingLib.shareToAssetAmount(
             shareAmount, SHARE_DECIMALS, USDC_DECIMALS, ASSET_PRICE, SHARE_PRICE, MathLib.Rounding.Down
-        ).toUint128();
+        );
     }
 
     function assetToPool(uint128 assetAmount) public view returns (uint128 poolAmount) {
-        return PricingLib.assetToPoolAmount(
-            assetAmount, USDC_DECIMALS, POOL_DECIMALS, ASSET_PRICE, MathLib.Rounding.Down
-        ).toUint128();
+        return
+            PricingLib.assetToPoolAmount(assetAmount, USDC_DECIMALS, POOL_DECIMALS, ASSET_PRICE, MathLib.Rounding.Down);
     }
 
     function poolToAsset(uint128 poolAmount) public view returns (uint128 assetAmount) {
-        return PricingLib.poolToAssetAmount(
-            poolAmount, POOL_DECIMALS, USDC_DECIMALS, ASSET_PRICE, MathLib.Rounding.Down
-        ).toUint128();
+        return
+            PricingLib.poolToAssetAmount(poolAmount, POOL_DECIMALS, USDC_DECIMALS, ASSET_PRICE, MathLib.Rounding.Down);
     }
 
     function checkAccountValue(AccountId accountId, uint128 value, bool isPositive) public view {

--- a/test/integration/EndToEnd.t.sol
+++ b/test/integration/EndToEnd.t.sol
@@ -157,7 +157,7 @@ contract EndToEndDeployment is Test {
     uint8 constant POOL_DECIMALS = 18;
     uint8 constant SHARE_DECIMALS = POOL_DECIMALS;
 
-    uint256 constant NO_USED = 0;
+    uint256 constant PLACEHOLDER = 0;
 
     function setUp() public virtual {
         vm.setEnv(MESSAGE_COST_ENV, vm.toString(GAS));
@@ -480,8 +480,8 @@ contract EndToEndUseCases is EndToEndFlows {
         vm.startPrank(INVESTOR_A);
         s.usdc.approve(address(vault), USDC_AMOUNT_1);
         vault.requestDeposit(USDC_AMOUNT_1, INVESTOR_A, INVESTOR_A);
-        vault.cancelDepositRequest(NO_USED, INVESTOR_A);
-        vault.claimCancelDepositRequest(NO_USED, INVESTOR_A, INVESTOR_A);
+        vault.cancelDepositRequest(PLACEHOLDER, INVESTOR_A);
+        vault.claimCancelDepositRequest(PLACEHOLDER, INVESTOR_A, INVESTOR_A);
 
         // CHECKS
         assertEq(s.usdc.balanceOf(INVESTOR_A), USDC_AMOUNT_1, "expected assets");
@@ -533,8 +533,8 @@ contract EndToEndUseCases is EndToEndFlows {
         vm.startPrank(INVESTOR_A);
         uint128 shares = uint128(s.spoke.shareToken(POOL_A, SC_1).balanceOf(INVESTOR_A));
         vault.requestRedeem(shares, INVESTOR_A, INVESTOR_A);
-        vault.cancelRedeemRequest(NO_USED, INVESTOR_A);
-        vault.claimCancelRedeemRequest(NO_USED, INVESTOR_A, INVESTOR_A);
+        vault.cancelRedeemRequest(PLACEHOLDER, INVESTOR_A);
+        vault.claimCancelRedeemRequest(PLACEHOLDER, INVESTOR_A, INVESTOR_A);
 
         // CHECKS
         assertEq(s.spoke.shareToken(POOL_A, SC_1).balanceOf(INVESTOR_A), assetToShare(USDC_AMOUNT_1), "expected shares");

--- a/test/integration/ThreeChainEndToEnd.t.sol
+++ b/test/integration/ThreeChainEndToEnd.t.sol
@@ -28,7 +28,7 @@ enum CrossChainDirection {
 ///         Hub is on Chain A, with spokes on Chains B and C
 ///         C is considered the source chain, B the destination chain
 ///         Depending on the cross chain direction, the hub is either on A or B or C
-contract ThreeChainEndToEndDeployment is EndToEndUtils {
+contract ThreeChainEndToEndDeployment is EndToEndFlows {
     using CastLib for *;
     using MessageLib for *;
 


### PR DESCRIPTION
### Current state of End to End testing

I think we already have the most common flows:

- pool configuration flow
- basic fund management flow
- async deposit flow 
- sync deposit flow
- async deposit flow + fund management
- sync deposit flow + fund management
- async deposit flow + async redeem flow
- sync deposit flow + async redeem flow
- async deposit flow + async redeem flow + fund management
- sync deposit flow + async redeem flow + fund management
- async deposit cancellation flow
- sync deposit + async redeem cancelation flow
- async deposit + async redeem cancelation flow

All of them tested with local and remote (emulated) chains through the gateway and different prices for assets and shares.

### Next steps. 

Same flows but mixing more stuff:

- Play with different investors
- Play with different approval amounts
- Play with different prices for deposit vs redeem

Add more checks to the end of existing tests

### Production changes
- Added `PricingLib.assetToPool`, useful for integrators.
- Fixed 3 issues from BSM: 
  - Manuel issue regarding snapshots: https://kflabs.slack.com/archives/C04HF8SHRRC/p1748945986778699
  - nonce incremented in all messages: https://kflabs.slack.com/archives/C07PG2EUR9C/p1749055334179079
  - uUsent when deposits == withdrawals: https://kflabs.slack.com/archives/C07PG2EUR9C/p1749110746190999