### PR TITLE
Feat: BalanceSheet multicall

### DIFF
--- a/script/SpokeDeployer.s.sol
+++ b/script/SpokeDeployer.s.sol
@@ -120,6 +120,7 @@ contract SpokeDeployer is CommonDeployer {
 
         // Rely BalanceSheet
         messageDispatcher.rely(address(balanceSheet));
+        gateway.rely(address(balanceSheet));
 
         // Rely Root
         vaultRouter.rely(address(root));
@@ -182,6 +183,7 @@ contract SpokeDeployer is CommonDeployer {
 
         balanceSheet.file("spoke", address(spoke));
         balanceSheet.file("sender", address(messageDispatcher));
+        balanceSheet.file("gateway", address(gateway));
         balanceSheet.file("poolEscrowProvider", address(poolEscrowFactory));
 
         poolEscrowFactory.file("gateway", address(gateway));

--- a/snapshots/AsyncVault.json
+++ b/snapshots/AsyncVault.json
@@ -1,4 +1,4 @@
 {
-  "fulfillDepositRequest": "959668",
+  "fulfillDepositRequest": "959827",
   "requestDeposit": "533004"
 }

--- a/snapshots/SyncDepositVault.json
+++ b/snapshots/SyncDepositVault.json
@@ -1,4 +1,4 @@
 {
-  "deposit_withQueue": "269402",
-  "deposit_withoutQueue": "326574"
+  "deposit_withQueue": "269578",
+  "deposit_withoutQueue": "326728"
 }

--- a/snapshots/VaultRouter.json
+++ b/snapshots/VaultRouter.json
@@ -1,7 +1,7 @@
 {
-  "claimDeposit": "1161610",
+  "claimDeposit": "1161769",
   "enable": "60953",
   "lockDepositRequest": "95607",
   "requestDeposit": "571897",
-  "requestRedeem": "2109514"
+  "requestRedeem": "2109695"
 }


### PR DESCRIPTION
- I think we do not need to add all methods with `protected` because all of them are `authOrManager()` (should we also remove protected from pool admin methods in Hub 🤔)