### PR TITLE
ref: import order

### DIFF
--- a/script/CommonDeployer.s.sol
+++ b/script/CommonDeployer.s.sol
@@ -3,16 +3,16 @@ pragma solidity 0.8.28;
 
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
 
-import {GasService} from "src/common/GasService.sol";
+import {Root} from "src/common/Root.sol";
 import {Gateway} from "src/common/Gateway.sol";
+import {GasService} from "src/common/GasService.sol";
 import {Guardian, ISafe} from "src/common/Guardian.sol";
 import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {MessageDispatcher} from "src/common/MessageDispatcher.sol";
+import {TokenRecoverer} from "src/common/TokenRecoverer.sol";
 import {MessageProcessor} from "src/common/MessageProcessor.sol";
 import {MultiAdapter} from "src/common/adapters/MultiAdapter.sol";
+import {MessageDispatcher} from "src/common/MessageDispatcher.sol";
 import {PoolEscrowFactory} from "src/common/factories/PoolEscrowFactory.sol";
-import {Root} from "src/common/Root.sol";
-import {TokenRecoverer} from "src/common/TokenRecoverer.sol";
 
 import {JsonRegistry} from "script/utils/JsonRegistry.s.sol";
 

--- a/script/CommonDeployer.s.sol
+++ b/script/CommonDeployer.s.sol
@@ -3,16 +3,16 @@ pragma solidity 0.8.28;
 
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
 
-import {Root} from "src/common/Root.sol";
 import {GasService} from "src/common/GasService.sol";
 import {Gateway} from "src/common/Gateway.sol";
-import {MultiAdapter} from "src/common/adapters/MultiAdapter.sol";
 import {Guardian, ISafe} from "src/common/Guardian.sol";
 import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {MessageProcessor} from "src/common/MessageProcessor.sol";
 import {MessageDispatcher} from "src/common/MessageDispatcher.sol";
-import {TokenRecoverer} from "src/common/TokenRecoverer.sol";
+import {MessageProcessor} from "src/common/MessageProcessor.sol";
+import {MultiAdapter} from "src/common/adapters/MultiAdapter.sol";
 import {PoolEscrowFactory} from "src/common/factories/PoolEscrowFactory.sol";
+import {Root} from "src/common/Root.sol";
+import {TokenRecoverer} from "src/common/TokenRecoverer.sol";
 
 import {JsonRegistry} from "script/utils/JsonRegistry.s.sol";
 

--- a/script/FullDeployer.s.sol
+++ b/script/FullDeployer.s.sol
@@ -3,9 +3,10 @@ pragma solidity 0.8.28;
 
 import {ISafe} from "src/common/Guardian.sol";
 
-import "forge-std/Script.sol";
 import {HubDeployer} from "script/HubDeployer.s.sol";
 import {SpokeDeployer} from "script/SpokeDeployer.s.sol";
+
+import "forge-std/Script.sol";
 
 contract FullDeployer is HubDeployer, SpokeDeployer {
     function deployFull(uint16 centrifugeId, ISafe adminSafe_, address deployer, bool isTests) public {

--- a/script/HubDeployer.s.sol
+++ b/script/HubDeployer.s.sol
@@ -3,20 +3,21 @@ pragma solidity 0.8.28;
 
 import {IdentityValuation} from "src/misc/IdentityValuation.sol";
 
-import {ISafe} from "src/common/Guardian.sol";
+import {AssetId, newAssetId} from "src/common/types/AssetId.sol";
 import {Gateway} from "src/common/Gateway.sol";
+import {ISafe} from "src/common/Guardian.sol";
 import {Root} from "src/common/Root.sol";
 
-import {AssetId, newAssetId} from "src/common/types/AssetId.sol";
-import {HubRegistry} from "src/hub/HubRegistry.sol";
-import {ShareClassManager} from "src/hub/ShareClassManager.sol";
-import {Holdings} from "src/hub/Holdings.sol";
 import {Accounting} from "src/hub/Accounting.sol";
-import {Hub} from "src/hub/Hub.sol";
+import {Holdings} from "src/hub/Holdings.sol";
 import {HubHelpers} from "src/hub/HubHelpers.sol";
+import {HubRegistry} from "src/hub/HubRegistry.sol";
+import {Hub} from "src/hub/Hub.sol";
+import {ShareClassManager} from "src/hub/ShareClassManager.sol";
+
+import {CommonDeployer} from "script/CommonDeployer.s.sol";
 
 import "forge-std/Script.sol";
-import {CommonDeployer} from "script/CommonDeployer.s.sol";
 
 contract HubDeployer is CommonDeployer {
     // Main contracts

--- a/script/HubDeployer.s.sol
+++ b/script/HubDeployer.s.sol
@@ -3,16 +3,14 @@ pragma solidity 0.8.28;
 
 import {IdentityValuation} from "src/misc/IdentityValuation.sol";
 
-import {AssetId, newAssetId} from "src/common/types/AssetId.sol";
-import {Gateway} from "src/common/Gateway.sol";
 import {ISafe} from "src/common/Guardian.sol";
-import {Root} from "src/common/Root.sol";
+import {AssetId, newAssetId} from "src/common/types/AssetId.sol";
 
-import {Accounting} from "src/hub/Accounting.sol";
+import {Hub} from "src/hub/Hub.sol";
 import {Holdings} from "src/hub/Holdings.sol";
+import {Accounting} from "src/hub/Accounting.sol";
 import {HubHelpers} from "src/hub/HubHelpers.sol";
 import {HubRegistry} from "src/hub/HubRegistry.sol";
-import {Hub} from "src/hub/Hub.sol";
 import {ShareClassManager} from "src/hub/ShareClassManager.sol";
 
 import {CommonDeployer} from "script/CommonDeployer.s.sol";

--- a/script/SpokeDeployer.s.sol
+++ b/script/SpokeDeployer.s.sol
@@ -1,27 +1,30 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
 import {Escrow} from "src/misc/Escrow.sol";
+import {IAuth} from "src/misc/interfaces/IAuth.sol";
 import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
 
-import {ISafe} from "src/common/Guardian.sol";
 import {Gateway} from "src/common/Gateway.sol";
+import {ISafe} from "src/common/Guardian.sol";
 
 import {AsyncRequestManager} from "src/vaults/AsyncRequestManager.sol";
-import {BalanceSheet} from "src/spoke/BalanceSheet.sol";
-import {TokenFactory} from "src/spoke/factories/TokenFactory.sol";
 import {AsyncVaultFactory} from "src/vaults/factories/AsyncVaultFactory.sol";
 import {SyncDepositVaultFactory} from "src/vaults/factories/SyncDepositVaultFactory.sol";
-import {FreezeOnly} from "src/hooks/FreezeOnly.sol";
-import {RedemptionRestrictions} from "src/hooks/RedemptionRestrictions.sol";
-import {FullRestrictions} from "src/hooks/FullRestrictions.sol";
 import {SyncManager} from "src/vaults/SyncManager.sol";
-import {Spoke} from "src/spoke/Spoke.sol";
 import {VaultRouter} from "src/vaults/VaultRouter.sol";
 
-import "forge-std/Script.sol";
+import {BalanceSheet} from "src/spoke/BalanceSheet.sol";
+import {Spoke} from "src/spoke/Spoke.sol";
+import {TokenFactory} from "src/spoke/factories/TokenFactory.sol";
+
+import {FreezeOnly} from "src/hooks/FreezeOnly.sol";
+import {FullRestrictions} from "src/hooks/FullRestrictions.sol";
+import {RedemptionRestrictions} from "src/hooks/RedemptionRestrictions.sol";
+
 import {CommonDeployer} from "script/CommonDeployer.s.sol";
+
+import "forge-std/Script.sol";
 
 contract SpokeDeployer is CommonDeployer {
     Spoke public spoke;

--- a/script/SpokeDeployer.s.sol
+++ b/script/SpokeDeployer.s.sol
@@ -5,17 +5,16 @@ import {Escrow} from "src/misc/Escrow.sol";
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
 import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
 
-import {Gateway} from "src/common/Gateway.sol";
 import {ISafe} from "src/common/Guardian.sol";
 
+import {SyncManager} from "src/vaults/SyncManager.sol";
+import {VaultRouter} from "src/vaults/VaultRouter.sol";
 import {AsyncRequestManager} from "src/vaults/AsyncRequestManager.sol";
 import {AsyncVaultFactory} from "src/vaults/factories/AsyncVaultFactory.sol";
 import {SyncDepositVaultFactory} from "src/vaults/factories/SyncDepositVaultFactory.sol";
-import {SyncManager} from "src/vaults/SyncManager.sol";
-import {VaultRouter} from "src/vaults/VaultRouter.sol";
 
-import {BalanceSheet} from "src/spoke/BalanceSheet.sol";
 import {Spoke} from "src/spoke/Spoke.sol";
+import {BalanceSheet} from "src/spoke/BalanceSheet.sol";
 import {TokenFactory} from "src/spoke/factories/TokenFactory.sol";
 
 import {FreezeOnly} from "src/hooks/FreezeOnly.sol";

--- a/script/adapters/Axelar.s.sol
+++ b/script/adapters/Axelar.s.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {AxelarAdapter} from "src/common/adapters/AxelarAdapter.sol";
 import {ISafe} from "src/common/interfaces/IGuardian.sol";
+import {AxelarAdapter} from "src/common/adapters/AxelarAdapter.sol";
 
 import {FullDeployer} from "script/FullDeployer.s.sol";
 

--- a/script/adapters/Localhost.s.sol
+++ b/script/adapters/Localhost.s.sol
@@ -1,22 +1,23 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {ERC20} from "src/misc/ERC20.sol";
-import {D18, d18} from "src/misc/types/D18.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {D18, d18} from "src/misc/types/D18.sol";
+import {ERC20} from "src/misc/ERC20.sol";
 
-import {ISafe} from "src/common/interfaces/IGuardian.sol";
-import {VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {AssetId, newAssetId} from "src/common/types/AssetId.sol";
 import {AccountId} from "src/common/types/AccountId.sol";
+import {AssetId, newAssetId} from "src/common/types/AssetId.sol";
+import {ISafe} from "src/common/interfaces/IGuardian.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
-import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+import {ShareClassId} from "src/common/types/ShareClassId.sol";
 import {VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
+
+import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
+import {SyncDepositVault} from "src/vaults/SyncDepositVault.sol";
 
 import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
-import {SyncDepositVault} from "src/vaults/SyncDepositVault.sol";
-import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
+
+import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
 import {FullDeployer} from "script/FullDeployer.s.sol";
 

--- a/script/adapters/Localhost.s.sol
+++ b/script/adapters/Localhost.s.sol
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {D18, d18} from "src/misc/types/D18.sol";
 import {ERC20} from "src/misc/ERC20.sol";
+import {D18, d18} from "src/misc/types/D18.sol";
+import {CastLib} from "src/misc/libraries/CastLib.sol";
 
-import {AccountId} from "src/common/types/AccountId.sol";
-import {AssetId, newAssetId} from "src/common/types/AssetId.sol";
-import {ISafe} from "src/common/interfaces/IGuardian.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {AccountId} from "src/common/types/AccountId.sol";
+import {ISafe} from "src/common/interfaces/IGuardian.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {AssetId, newAssetId} from "src/common/types/AssetId.sol";
 import {VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
 
-import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
 import {SyncDepositVault} from "src/vaults/SyncDepositVault.sol";
+import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
 
 import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
 

--- a/script/adapters/Wormhole.s.sol
+++ b/script/adapters/Wormhole.s.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {WormholeAdapter} from "src/common/adapters/WormholeAdapter.sol";
 import {ISafe} from "src/common/interfaces/IGuardian.sol";
+import {WormholeAdapter} from "src/common/adapters/WormholeAdapter.sol";
 
 import {FullDeployer} from "script/FullDeployer.s.sol";
 

--- a/script/utils/fix_imports.py
+++ b/script/utils/fix_imports.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+
+import os
+import re
+import subprocess
+from typing import List, Dict, Set
+
+# Priority order for imports
+IMPORT_PRIORITY = [
+    "src/misc",
+    "src/common", 
+    "src/vaults",
+    "src/hub",
+    "src/spoke",
+    "src/managers",
+    "src/hooks",
+    "script",
+    "test"
+]
+
+def get_all_solidity_files() -> List[str]:
+    """Get all Solidity files excluding lib directory"""
+    result = subprocess.run(
+        ["find", ".", "-name", "*.sol", "-not", "-path", "./lib/*"],
+        capture_output=True,
+        text=True
+    )
+    return result.stdout.strip().split('\n') if result.stdout.strip() else []
+
+def extract_imports(content: str) -> List[str]:
+    """Extract all import statements from file content"""
+    import_pattern = r'^import\s+.*?;$'
+    imports = re.findall(import_pattern, content, re.MULTILINE)
+    return imports
+
+def categorize_imports(imports: List[str]) -> Dict[str, List[str]]:
+    """Categorize imports by their path prefix"""
+    categorized = {priority: [] for priority in IMPORT_PRIORITY}
+    other_imports = []
+    
+    for import_stmt in imports:
+        # Extract the path from import statement
+        path_match = re.search(r'from\s+"([^"]+)"', import_stmt)
+        if not path_match:
+            # Handle imports without 'from' keyword
+            path_match = re.search(r'import\s+"([^"]+)"', import_stmt)
+        
+        if path_match:
+            path = path_match.group(1)
+            categorized_flag = False
+            
+            for priority in IMPORT_PRIORITY:
+                if path.startswith(priority):
+                    categorized[priority].append(import_stmt)
+                    categorized_flag = True
+                    break
+            
+            if not categorized_flag:
+                other_imports.append(import_stmt)
+        else:
+            other_imports.append(import_stmt)
+    
+    return categorized, other_imports
+
+def organize_imports(categorized: Dict[str, List[str]], other_imports: List[str]) -> str:
+    """Organize imports according to priority with empty lines between categories"""
+    organized_imports = []
+    
+    for priority in IMPORT_PRIORITY:
+        if categorized[priority]:
+            # Sort imports within each category
+            sorted_imports = sorted(set(categorized[priority]))
+            organized_imports.extend(sorted_imports)
+            organized_imports.append("")
+    
+    # Add other imports at the end
+    if other_imports:
+        sorted_other = sorted(set(other_imports))
+        organized_imports.extend(sorted_other)
+        organized_imports.append("")
+    
+    # Remove trailing empty lines
+    while organized_imports and organized_imports[-1] == "":
+        organized_imports.pop()
+    
+    return '\n'.join(organized_imports)
+
+def fix_file_imports(file_path: str) -> bool:
+    """Fix imports in a single file"""
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+        
+        # Find the pragma and license lines
+        lines = content.split('\n')
+        pragma_end_idx = 0
+        
+        for i, line in enumerate(lines):
+            if line.strip().startswith('pragma ') or line.strip().startswith('// SPDX-License-Identifier'):
+                pragma_end_idx = i + 1
+            elif line.strip() == '' and i <= 5:  # Allow empty lines after pragma
+                pragma_end_idx = i + 1
+            elif line.strip().startswith('import '):
+                break
+            elif line.strip() and not line.strip().startswith('//'):
+                break
+        
+        # Extract imports
+        imports = extract_imports(content)
+        if not imports:
+            return False  # No imports to fix
+        
+        # Remove existing import lines from content
+        content_without_imports = content
+        for import_stmt in imports:
+            content_without_imports = content_without_imports.replace(import_stmt + '\n', '')
+            content_without_imports = content_without_imports.replace(import_stmt, '')
+        
+        # Categorize and organize imports
+        categorized, other_imports = categorize_imports(imports)
+        organized_imports_str = organize_imports(categorized, other_imports)
+        
+        if not organized_imports_str:
+            return False
+        
+        # Reconstruct the file
+        lines = content_without_imports.split('\n')
+        
+        # Handle pragma
+        insert_idx = pragma_end_idx
+        while insert_idx < len(lines) and lines[insert_idx].strip() == '':
+            insert_idx += 1
+        
+        # Insert organized imports
+        new_lines = lines[:pragma_end_idx] + [''] + organized_imports_str.split('\n') + [''] + lines[insert_idx:]
+        
+        # Clean up multiple consecutive empty lines
+        cleaned_lines = []
+        prev_empty = False
+        for line in new_lines:
+            if line.strip() == '':
+                if not prev_empty:
+                    cleaned_lines.append(line)
+                prev_empty = True
+            else:
+                cleaned_lines.append(line)
+                prev_empty = False
+        
+        new_content = '\n'.join(cleaned_lines)
+        
+        # Only write if content changed
+        if new_content != content:
+            with open(file_path, 'w', encoding='utf-8') as f:
+                f.write(new_content)
+            return True
+        
+        return False
+        
+    except Exception as e:
+        print(f"Error processing {file_path}: {e}")
+        return False
+
+def main():
+    """Main function to fix imports in all Solidity files"""
+    files = get_all_solidity_files()
+    print(f"Found {len(files)} Solidity files to process")
+    
+    fixed_count = 0
+    other_import_paths = set()
+    
+    for file_path in files:
+        if file_path.strip():
+            print(f"Processing: {file_path}")
+            
+            # Check for other import paths
+            try:
+                with open(file_path, 'r', encoding='utf-8') as f:
+                    content = f.read()
+                imports = extract_imports(content)
+                for import_stmt in imports:
+                    path_match = re.search(r'from\s+"([^"]+)"', import_stmt)
+                    if not path_match:
+                        path_match = re.search(r'import\s+"([^"]+)"', import_stmt)
+                    if path_match:
+                        path = path_match.group(1)
+                        if path.startswith('src/') and not any(path.startswith(p) for p in IMPORT_PRIORITY):
+                            other_import_paths.add(path.split('/')[1] if '/' in path else path)
+            except:
+                pass
+            
+            if fix_file_imports(file_path):
+                fixed_count += 1
+    
+    print(f"\nFixed imports in {fixed_count} files")
+    
+    if other_import_paths:
+        print(f"\nOther import paths found beyond the specified ones:")
+        for path in sorted(other_import_paths):
+            print(f"  - src/{path}")
+
+if __name__ == "__main__":
+    main() 

--- a/script/utils/fix_imports.py
+++ b/script/utils/fix_imports.py
@@ -3,7 +3,8 @@
 import os
 import re
 import subprocess
-from typing import List, Dict, Set
+from typing import List, Dict, Set, Tuple
+import argparse
 
 # Priority order for imports
 IMPORT_PRIORITY = [
@@ -12,8 +13,8 @@ IMPORT_PRIORITY = [
     "src/vaults",
     "src/hub",
     "src/spoke",
-    "src/managers",
     "src/hooks",
+    "src/managers",
     "script",
     "test"
 ]
@@ -33,7 +34,194 @@ def extract_imports(content: str) -> List[str]:
     imports = re.findall(import_pattern, content, re.MULTILINE)
     return imports
 
-def categorize_imports(imports: List[str]) -> Dict[str, List[str]]:
+def parse_import_statement(import_stmt: str) -> Tuple[List[str], str]:
+    """Parse an import statement to extract imported symbols and path"""
+    # Handle different import formats:
+    # import "path";
+    # import {Symbol} from "path";
+    # import {Symbol1, Symbol2} from "path";
+    
+    path_match = re.search(r'from\s+"([^"]+)"', import_stmt)
+    if not path_match:
+        path_match = re.search(r'import\s+"([^"]+)"', import_stmt)
+        if path_match:
+            return [], path_match.group(1)  # Direct import without symbols
+        return [], ""
+    
+    path = path_match.group(1)
+    
+    # Extract symbols
+    symbols_match = re.search(r'import\s+\{([^}]+)\}', import_stmt)
+    if symbols_match:
+        symbols_str = symbols_match.group(1)
+        # Split by comma and clean up whitespace
+        symbols = [s.strip() for s in symbols_str.split(',')]
+        # Handle aliases (e.g., "Symbol as Alias")
+        clean_symbols = []
+        for symbol in symbols:
+            if ' as ' in symbol:
+                clean_symbols.append(symbol.split(' as ')[1].strip())
+            else:
+                clean_symbols.append(symbol.strip())
+        return clean_symbols, path
+    
+    return [], path
+
+def find_unused_imports(file_path: str, content: str) -> List[str]:
+    """Find unused imports in a Solidity file"""
+    imports = extract_imports(content)
+    unused_imports = []
+    
+    # Remove import statements from content for analysis
+    content_without_imports = content
+    for import_stmt in imports:
+        content_without_imports = content_without_imports.replace(import_stmt, '')
+    
+    for import_stmt in imports:
+        symbols, path = parse_import_statement(import_stmt)
+        
+        if not symbols:
+            # Direct import without symbols - harder to detect usage
+            continue
+            
+        unused_symbols = []
+        for symbol in symbols:
+            # Check if symbol is used in the code
+            # Look for the symbol as a standalone word (not part of another word)
+            pattern = r'\b' + re.escape(symbol) + r'\b'
+            if not re.search(pattern, content_without_imports):
+                unused_symbols.append(symbol)
+        
+        if unused_symbols:
+            if len(unused_symbols) == len(symbols):
+                # Entire import is unused
+                unused_imports.append(import_stmt)
+            else:
+                # Some symbols are unused
+                unused_imports.append(f"Partially unused in '{import_stmt}': {', '.join(unused_symbols)}")
+    
+    return unused_imports
+
+def remove_unused_symbols_from_import(import_stmt: str, unused_symbols: List[str]) -> str:
+    """Remove unused symbols from an import statement"""
+    symbols, path = parse_import_statement(import_stmt)
+    
+    if not symbols:
+        return import_stmt
+    
+    # Remove unused symbols
+    used_symbols = [s for s in symbols if s not in unused_symbols]
+    
+    if not used_symbols:
+        # All symbols are unused, remove entire import
+        return ""
+    
+    # Reconstruct import statement with only used symbols
+    symbols_str = ", ".join(used_symbols)
+    return f'import {{{symbols_str}}} from "{path}";'
+
+def fix_unused_imports_in_file(file_path: str) -> Tuple[bool, int]:
+    """Remove unused imports from a single file"""
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+        
+        imports = extract_imports(content)
+        if not imports:
+            return False, 0
+        
+        # Remove import statements from content for analysis
+        content_without_imports = content
+        for import_stmt in imports:
+            content_without_imports = content_without_imports.replace(import_stmt, '')
+        
+        new_imports = []
+        removed_count = 0
+        
+        for import_stmt in imports:
+            symbols, path = parse_import_statement(import_stmt)
+            
+            if not symbols:
+                # Direct import without symbols - keep as is
+                new_imports.append(import_stmt)
+                continue
+            
+            unused_symbols = []
+            for symbol in symbols:
+                # Check if symbol is used in the code
+                pattern = r'\b' + re.escape(symbol) + r'\b'
+                if not re.search(pattern, content_without_imports):
+                    unused_symbols.append(symbol)
+            
+            if unused_symbols:
+                if len(unused_symbols) == len(symbols):
+                    # Entire import is unused, remove it
+                    removed_count += 1
+                    continue
+                else:
+                    # Some symbols are unused, remove only unused ones
+                    new_import = remove_unused_symbols_from_import(import_stmt, unused_symbols)
+                    if new_import:
+                        new_imports.append(new_import)
+                        removed_count += len(unused_symbols)
+            else:
+                # No unused symbols, keep import as is
+                new_imports.append(import_stmt)
+        
+        # Replace old imports with new ones
+        new_content = content
+        for old_import in imports:
+            new_content = new_content.replace(old_import + '\n', '')
+            new_content = new_content.replace(old_import, '')
+        
+        # Add new imports back
+        if new_imports:
+            # Find where to insert imports (after pragma/license)
+            lines = new_content.split('\n')
+            pragma_end_idx = 0
+            
+            for i, line in enumerate(lines):
+                if line.strip().startswith('pragma ') or line.strip().startswith('// SPDX-License-Identifier'):
+                    pragma_end_idx = i + 1
+                elif line.strip() == '' and i <= 5:
+                    pragma_end_idx = i + 1
+                elif line.strip() and not line.strip().startswith('//'):
+                    break
+            
+            # Organize the cleaned imports
+            categorized, other_imports = categorize_imports(new_imports)
+            organized_imports_str = organize_imports(categorized, other_imports)
+            
+            # Insert organized imports
+            new_lines = lines[:pragma_end_idx] + [''] + organized_imports_str.split('\n') + [''] + lines[pragma_end_idx:]
+            
+            # Clean up multiple consecutive empty lines
+            cleaned_lines = []
+            prev_empty = False
+            for line in new_lines:
+                if line.strip() == '':
+                    if not prev_empty:
+                        cleaned_lines.append(line)
+                    prev_empty = True
+                else:
+                    cleaned_lines.append(line)
+                    prev_empty = False
+            
+            new_content = '\n'.join(cleaned_lines)
+        
+        # Write back if content changed
+        if new_content != content:
+            with open(file_path, 'w', encoding='utf-8') as f:
+                f.write(new_content)
+            return True, removed_count
+        
+        return False, 0
+        
+    except Exception as e:
+        print(f"Error processing {file_path}: {e}")
+        return False, 0
+
+def categorize_imports(imports: List[str]) -> Tuple[Dict[str, List[str]], List[str]]:
     """Categorize imports by their path prefix"""
     categorized = {priority: [] for priority in IMPORT_PRIORITY}
     other_imports = []
@@ -63,19 +251,21 @@ def categorize_imports(imports: List[str]) -> Dict[str, List[str]]:
     return categorized, other_imports
 
 def organize_imports(categorized: Dict[str, List[str]], other_imports: List[str]) -> str:
-    """Organize imports according to priority with empty lines between categories"""
+    """Organize imports according to priority with empty lines between categories, sorted by ascending length within each category"""
     organized_imports = []
     
     for priority in IMPORT_PRIORITY:
         if categorized[priority]:
-            # Sort imports within each category
-            sorted_imports = sorted(set(categorized[priority]))
+            # Remove duplicates and sort by length (ascending), then alphabetically
+            unique_imports = list(set(categorized[priority]))
+            sorted_imports = sorted(unique_imports, key=lambda x: (len(x), x))
             organized_imports.extend(sorted_imports)
-            organized_imports.append("")
+            organized_imports.append("")  # Empty line after each category
     
     # Add other imports at the end
     if other_imports:
-        sorted_other = sorted(set(other_imports))
+        unique_other = list(set(other_imports))
+        sorted_other = sorted(unique_other, key=lambda x: (len(x), x))
         organized_imports.extend(sorted_other)
         organized_imports.append("")
     
@@ -126,8 +316,10 @@ def fix_file_imports(file_path: str) -> bool:
         # Reconstruct the file
         lines = content_without_imports.split('\n')
         
-        # Handle pragma
+        # Find where to insert imports (after pragma/license)
         insert_idx = pragma_end_idx
+        
+        # Remove empty lines after pragma to avoid too many empty lines
         while insert_idx < len(lines) and lines[insert_idx].strip() == '':
             insert_idx += 1
         
@@ -160,8 +352,61 @@ def fix_file_imports(file_path: str) -> bool:
         print(f"Error processing {file_path}: {e}")
         return False
 
-def main():
-    """Main function to fix imports in all Solidity files"""
+def check_unused_imports():
+    """Check for unused imports in all Solidity files"""
+    files = get_all_solidity_files()
+    print(f"Checking {len(files)} Solidity files for unused imports...\n")
+    
+    total_unused = 0
+    files_with_unused = 0
+    
+    for file_path in files:
+        if file_path.strip():
+            try:
+                with open(file_path, 'r', encoding='utf-8') as f:
+                    content = f.read()
+                
+                unused = find_unused_imports(file_path, content)
+                if unused:
+                    files_with_unused += 1
+                    total_unused += len(unused)
+                    print(f"\n📁 {file_path}")
+                    for unused_import in unused:
+                        print(f"  ❌ {unused_import}")
+            except Exception as e:
+                print(f"Error checking {file_path}: {e}")
+    
+    print(f"\n📊 Summary:")
+    print(f"   Files checked: {len(files)}")
+    print(f"   Files with unused imports: {files_with_unused}")
+    print(f"   Total unused imports: {total_unused}")
+
+def fix_all_unused_imports():
+    """Remove unused imports from all Solidity files"""
+    files = get_all_solidity_files()
+    print(f"Fixing unused imports in {len(files)} Solidity files...\n")
+    
+    total_files_fixed = 0
+    total_imports_removed = 0
+    
+    for file_path in files:
+        if file_path.strip():
+            print(f"Processing: {file_path}")
+            fixed, removed_count = fix_unused_imports_in_file(file_path)
+            if fixed:
+                total_files_fixed += 1
+                total_imports_removed += removed_count
+                print(f"  ✅ Removed {removed_count} unused import(s)")
+            else:
+                print(f"  ℹ️  No unused imports found")
+    
+    print(f"\n📊 Summary:")
+    print(f"   Files processed: {len(files)}")
+    print(f"   Files fixed: {total_files_fixed}")
+    print(f"   Total unused imports removed: {total_imports_removed}")
+
+def organize_all_imports():
+    """Organize imports in all Solidity files"""
     files = get_all_solidity_files()
     print(f"Found {len(files)} Solidity files to process")
     
@@ -169,7 +414,7 @@ def main():
     other_import_paths = set()
     
     for file_path in files:
-        if file_path.strip():
+        if file_path.strip():  # Skip empty strings
             print(f"Processing: {file_path}")
             
             # Check for other import paths
@@ -197,6 +442,59 @@ def main():
         print(f"\nOther import paths found beyond the specified ones:")
         for path in sorted(other_import_paths):
             print(f"  - src/{path}")
+
+def main():
+    """Main function"""
+    parser = argparse.ArgumentParser(description='Solidity import organizer and unused import detector')
+    parser.add_argument('--check-unused', action='store_true', help='Check for unused imports')
+    parser.add_argument('--fix-unused', action='store_true', help='Remove unused imports from all files')
+    parser.add_argument('--organize', action='store_true', help='Organize imports according to priority')
+    parser.add_argument('--file', type=str, help='Process a specific file instead of all files')
+    
+    args = parser.parse_args()
+    
+    if not args.check_unused and not args.organize and not args.fix_unused:
+        # Default behavior: check for unused imports
+        args.check_unused = True
+    
+    if args.file:
+        # Process specific file
+        if args.check_unused:
+            try:
+                with open(args.file, 'r', encoding='utf-8') as f:
+                    content = f.read()
+                unused = find_unused_imports(args.file, content)
+                if unused:
+                    print(f"📁 {args.file}")
+                    for unused_import in unused:
+                        print(f"  ❌ {unused_import}")
+                else:
+                    print(f"✅ No unused imports found in {args.file}")
+            except Exception as e:
+                print(f"Error checking {args.file}: {e}")
+        
+        if args.fix_unused:
+            fixed, removed_count = fix_unused_imports_in_file(args.file)
+            if fixed:
+                print(f"✅ Removed {removed_count} unused import(s) from {args.file}")
+            else:
+                print(f"ℹ️  No unused imports found in {args.file}")
+        
+        if args.organize:
+            if fix_file_imports(args.file):
+                print(f"✅ Organized imports in {args.file}")
+            else:
+                print(f"ℹ️  No changes needed in {args.file}")
+    else:
+        # Process all files
+        if args.check_unused:
+            check_unused_imports()
+        
+        if args.fix_unused:
+            fix_all_unused_imports()
+        
+        if args.organize:
+            organize_all_imports()
 
 if __name__ == "__main__":
     main() 

--- a/snapshots/AsyncVault.json
+++ b/snapshots/AsyncVault.json
@@ -1,4 +1,4 @@
 {
-  "fulfillDepositRequest": "982564",
-  "requestDeposit": "539253"
+  "fulfillDepositRequest": "982423",
+  "requestDeposit": "539187"
 }

--- a/snapshots/VaultRouter.json
+++ b/snapshots/VaultRouter.json
@@ -1,7 +1,7 @@
 {
-  "claimDeposit": "1184798",
+  "claimDeposit": "1184591",
   "enable": "60953",
   "lockDepositRequest": "95585",
-  "requestDeposit": "578190",
-  "requestRedeem": "2150977"
+  "requestDeposit": "578124",
+  "requestRedeem": "2150726"
 }

--- a/src/common/BaseValuation.sol
+++ b/src/common/BaseValuation.sol
@@ -2,10 +2,10 @@
 pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
-
-import {IBaseValuation} from "src/common/interfaces/IBaseValuation.sol";
 import {IERC6909Decimals} from "src/misc/interfaces/IERC6909.sol";
+
 import {AssetId} from "src/common/types/AssetId.sol";
+import {IBaseValuation} from "src/common/interfaces/IBaseValuation.sol";
 
 abstract contract BaseValuation is Auth, IBaseValuation {
     /// @notice ERC6909 dependency.

--- a/src/common/Gateway.sol
+++ b/src/common/Gateway.sol
@@ -3,19 +3,19 @@ pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
 import {BytesLib} from "src/misc/libraries/BytesLib.sol";
-import {Recoverable, IRecoverable, ETH_ADDRESS} from "src/misc/Recoverable.sol";
 import {TransientArrayLib} from "src/misc/libraries/TransientArrayLib.sol";
 import {TransientBytesLib} from "src/misc/libraries/TransientBytesLib.sol";
 import {TransientStorageLib} from "src/misc/libraries/TransientStorageLib.sol";
+import {Recoverable, IRecoverable, ETH_ADDRESS} from "src/misc/Recoverable.sol";
 
+import {PoolId} from "src/common/types/PoolId.sol";
+import {IRoot} from "src/common/interfaces/IRoot.sol";
 import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {IGasService} from "src/common/interfaces/IGasService.sol";
 import {IGateway} from "src/common/interfaces/IGateway.sol";
+import {IGasService} from "src/common/interfaces/IGasService.sol";
+import {IMessageSender} from "src/common/interfaces/IMessageSender.sol";
 import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
 import {IMessageProcessor} from "src/common/interfaces/IMessageProcessor.sol";
-import {IMessageSender} from "src/common/interfaces/IMessageSender.sol";
-import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {PoolId} from "src/common/types/PoolId.sol";
 
 /// @title  Gateway
 /// @notice Routing contract that forwards outgoing messages to multiple adapters (1 full message, n-1 proofs)

--- a/src/common/Gateway.sol
+++ b/src/common/Gateway.sol
@@ -8,13 +8,13 @@ import {TransientArrayLib} from "src/misc/libraries/TransientArrayLib.sol";
 import {TransientBytesLib} from "src/misc/libraries/TransientBytesLib.sol";
 import {TransientStorageLib} from "src/misc/libraries/TransientStorageLib.sol";
 
-import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {IGasService} from "src/common/interfaces/IGasService.sol";
 import {IAdapter} from "src/common/interfaces/IAdapter.sol";
+import {IGasService} from "src/common/interfaces/IGasService.sol";
+import {IGateway} from "src/common/interfaces/IGateway.sol";
+import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
 import {IMessageProcessor} from "src/common/interfaces/IMessageProcessor.sol";
 import {IMessageSender} from "src/common/interfaces/IMessageSender.sol";
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
-import {IGateway} from "src/common/interfaces/IGateway.sol";
+import {IRoot} from "src/common/interfaces/IRoot.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
 
 /// @title  Gateway
@@ -321,4 +321,3 @@ contract Gateway is Auth, Recoverable, IGateway {
         return keccak256(abi.encode("outboundBatch", centrifugeId, poolId));
     }
 }
-

--- a/src/common/Guardian.sol
+++ b/src/common/Guardian.sol
@@ -3,14 +3,14 @@ pragma solidity 0.8.28;
 
 import {CastLib} from "src/misc/libraries/CastLib.sol";
 
+import {PoolId} from "src/common/types/PoolId.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
+import {IRoot} from "src/common/interfaces/IRoot.sol";
 import {IAdapter} from "src/common/interfaces/IAdapter.sol";
 import {IGuardian, ISafe} from "src/common/interfaces/IGuardian.sol";
+import {IRootMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
 import {IHubGuardianActions} from "src/common/interfaces/IGuardianActions.sol";
 import {IMultiAdapter} from "src/common/interfaces/adapters/IMultiAdapter.sol";
-import {IRootMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
-import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {PoolId} from "src/common/types/PoolId.sol";
 
 contract Guardian is IGuardian {
     using CastLib for address;

--- a/src/common/Guardian.sol
+++ b/src/common/Guardian.sol
@@ -3,14 +3,14 @@ pragma solidity 0.8.28;
 
 import {CastLib} from "src/misc/libraries/CastLib.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
-import {IRoot} from "src/common/interfaces/IRoot.sol";
 import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {IMultiAdapter} from "src/common/interfaces/adapters/IMultiAdapter.sol";
 import {IGuardian, ISafe} from "src/common/interfaces/IGuardian.sol";
-import {IRootMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
 import {IHubGuardianActions} from "src/common/interfaces/IGuardianActions.sol";
+import {IMultiAdapter} from "src/common/interfaces/adapters/IMultiAdapter.sol";
+import {IRootMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
+import {IRoot} from "src/common/interfaces/IRoot.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
 
 contract Guardian is IGuardian {
     using CastLib for address;

--- a/src/common/MessageDispatcher.sol
+++ b/src/common/MessageDispatcher.sol
@@ -1,28 +1,28 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 import {Auth} from "src/misc/Auth.sol";
+import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {D18, d18} from "src/misc/types/D18.sol";
 import {IRecoverable} from "src/misc/interfaces/IRecoverable.sol";
+import {MathLib} from "src/misc/libraries/MathLib.sol";
 
-import {MessageLib, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
 import {IGateway} from "src/common/interfaces/IGateway.sol";
+import {IMessageDispatcher} from "src/common/interfaces/IMessageDispatcher.sol";
 import {IRoot} from "src/common/interfaces/IRoot.sol";
+import {ISpokeMessageSender, IHubMessageSender, IRootMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
+import {ITokenRecoverer} from "src/common/interfaces/ITokenRecoverer.sol";
+import {MessageLib, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
+import {ShareClassId} from "src/common/types/ShareClassId.sol";
+
 import {
     ISpokeGatewayHandler,
     IBalanceSheetGatewayHandler,
     IHubGatewayHandler
 } from "src/common/interfaces/IGatewayHandlers.sol";
-import {ISpokeMessageSender, IHubMessageSender, IRootMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
-
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {PoolId} from "src/common/types/PoolId.sol";
-import {IMessageDispatcher} from "src/common/interfaces/IMessageDispatcher.sol";
-import {ITokenRecoverer} from "src/common/interfaces/ITokenRecoverer.sol";
 
 contract MessageDispatcher is Auth, IMessageDispatcher {
     using CastLib for *;

--- a/src/common/MessageDispatcher.sol
+++ b/src/common/MessageDispatcher.sol
@@ -2,21 +2,21 @@
 pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {D18} from "src/misc/types/D18.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {D18, d18} from "src/misc/types/D18.sol";
-import {IRecoverable} from "src/misc/interfaces/IRecoverable.sol";
 import {MathLib} from "src/misc/libraries/MathLib.sol";
+import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {IRecoverable} from "src/misc/interfaces/IRecoverable.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
-import {IGateway} from "src/common/interfaces/IGateway.sol";
-import {IMessageDispatcher} from "src/common/interfaces/IMessageDispatcher.sol";
-import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {ISpokeMessageSender, IHubMessageSender, IRootMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
-import {ITokenRecoverer} from "src/common/interfaces/ITokenRecoverer.sol";
-import {MessageLib, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
+import {IRoot} from "src/common/interfaces/IRoot.sol";
+import {IGateway} from "src/common/interfaces/IGateway.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {ITokenRecoverer} from "src/common/interfaces/ITokenRecoverer.sol";
+import {IMessageDispatcher} from "src/common/interfaces/IMessageDispatcher.sol";
+import {MessageLib, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
+import {ISpokeMessageSender, IHubMessageSender, IRootMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
 
 import {
     ISpokeGatewayHandler,

--- a/src/common/MessageProcessor.sol
+++ b/src/common/MessageProcessor.sol
@@ -2,20 +2,20 @@
 pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {D18} from "src/misc/types/D18.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {D18, d18} from "src/misc/types/D18.sol";
+import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 import {IRecoverable} from "src/misc/interfaces/IRecoverable.sol";
 
+import {PoolId} from "src/common/types/PoolId.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
+import {IRoot} from "src/common/interfaces/IRoot.sol";
+import {ShareClassId} from "src/common/types/ShareClassId.sol";
 import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
+import {ITokenRecoverer} from "src/common/interfaces/ITokenRecoverer.sol";
 import {IMessageProcessor} from "src/common/interfaces/IMessageProcessor.sol";
 import {IMessageProperties} from "src/common/interfaces/IMessageProperties.sol";
-import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {ITokenRecoverer} from "src/common/interfaces/ITokenRecoverer.sol";
 import {MessageType, MessageLib, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
 import {
     ISpokeGatewayHandler,

--- a/src/common/MessageProcessor.sol
+++ b/src/common/MessageProcessor.sol
@@ -1,27 +1,27 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 import {Auth} from "src/misc/Auth.sol";
+import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {D18, d18} from "src/misc/types/D18.sol";
 import {IRecoverable} from "src/misc/interfaces/IRecoverable.sol";
 
-import {MessageType, MessageLib, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
 import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
 import {IMessageProcessor} from "src/common/interfaces/IMessageProcessor.sol";
 import {IMessageProperties} from "src/common/interfaces/IMessageProperties.sol";
 import {IRoot} from "src/common/interfaces/IRoot.sol";
+import {ITokenRecoverer} from "src/common/interfaces/ITokenRecoverer.sol";
+import {MessageType, MessageLib, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
+import {ShareClassId} from "src/common/types/ShareClassId.sol";
+
 import {
     ISpokeGatewayHandler,
     IBalanceSheetGatewayHandler,
     IHubGatewayHandler
 } from "src/common/interfaces/IGatewayHandlers.sol";
-
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ITokenRecoverer} from "src/common/interfaces/ITokenRecoverer.sol";
 
 contract MessageProcessor is Auth, IMessageProcessor {
     using CastLib for *;

--- a/src/common/PoolEscrow.sol
+++ b/src/common/PoolEscrow.sol
@@ -2,15 +2,15 @@
 pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
+import {Escrow} from "src/misc/Escrow.sol";
 import {IERC20} from "src/misc/interfaces/IERC20.sol";
 import {IERC6909} from "src/misc/interfaces/IERC6909.sol";
-import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
 import {Recoverable} from "src/misc/Recoverable.sol";
-import {Escrow} from "src/misc/Escrow.sol";
+import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
 
+import {Holding, IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {Holding, IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
 
 /// @title  Escrow
 /// @notice Escrow contract that holds assets for a specific pool separated by share classes.

--- a/src/common/PoolEscrow.sol
+++ b/src/common/PoolEscrow.sol
@@ -1,16 +1,12 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
 import {Escrow} from "src/misc/Escrow.sol";
-import {IERC20} from "src/misc/interfaces/IERC20.sol";
-import {IERC6909} from "src/misc/interfaces/IERC6909.sol";
 import {Recoverable} from "src/misc/Recoverable.sol";
-import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
 
-import {Holding, IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {Holding, IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
 
 /// @title  Escrow
 /// @notice Escrow contract that holds assets for a specific pool separated by share classes.

--- a/src/common/TokenRecoverer.sol
+++ b/src/common/TokenRecoverer.sol
@@ -6,7 +6,6 @@ import {IRecoverable} from "src/misc/interfaces/IRecoverable.sol";
 
 import {IRoot} from "src/common/interfaces/IRoot.sol";
 import {ITokenRecoverer} from "src/common/interfaces/ITokenRecoverer.sol";
-import {IRecoverable} from "src/misc/interfaces/IRecoverable.sol";
 
 contract TokenRecoverer is Auth, ITokenRecoverer {
     IRoot public immutable root;

--- a/src/common/adapters/AxelarAdapter.sol
+++ b/src/common/adapters/AxelarAdapter.sol
@@ -3,6 +3,9 @@ pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
+
+import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
+
 import {
     IAxelarAdapter,
     IAdapter,
@@ -12,7 +15,6 @@ import {
     AxelarDestination,
     IAxelarExecutable
 } from "src/common/interfaces/adapters/IAxelarAdapter.sol";
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
 
 /// @title  Axelar Adapter
 /// @notice Routing contract that integrates with an Axelar Gateway

--- a/src/common/adapters/MultiAdapter.sol
+++ b/src/common/adapters/MultiAdapter.sol
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 import {ArrayLib} from "src/misc/libraries/ArrayLib.sol";
+import {Auth} from "src/misc/Auth.sol";
+import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {MathLib} from "src/misc/libraries/MathLib.sol";
 
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
 import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {MessageProofLib} from "src/common/libraries/MessageProofLib.sol";
+import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
 import {IMultiAdapter, MAX_ADAPTER_COUNT} from "src/common/interfaces/adapters/IMultiAdapter.sol";
+import {MessageProofLib} from "src/common/libraries/MessageProofLib.sol";
 
 contract MultiAdapter is Auth, IMultiAdapter {
     using CastLib for *;

--- a/src/common/adapters/MultiAdapter.sol
+++ b/src/common/adapters/MultiAdapter.sol
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {ArrayLib} from "src/misc/libraries/ArrayLib.sol";
 import {Auth} from "src/misc/Auth.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {MathLib} from "src/misc/libraries/MathLib.sol";
+import {ArrayLib} from "src/misc/libraries/ArrayLib.sol";
+import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 
 import {IAdapter} from "src/common/interfaces/IAdapter.sol";
+import {MessageProofLib} from "src/common/libraries/MessageProofLib.sol";
 import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
 import {IMultiAdapter, MAX_ADAPTER_COUNT} from "src/common/interfaces/adapters/IMultiAdapter.sol";
-import {MessageProofLib} from "src/common/libraries/MessageProofLib.sol";
 
 contract MultiAdapter is Auth, IMultiAdapter {
     using CastLib for *;

--- a/src/common/adapters/WormholeAdapter.sol
+++ b/src/common/adapters/WormholeAdapter.sol
@@ -3,7 +3,9 @@ pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
+
 import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
+
 import {
     IWormholeAdapter,
     IAdapter,

--- a/src/common/factories/PoolEscrowFactory.sol
+++ b/src/common/factories/PoolEscrowFactory.sol
@@ -3,11 +3,10 @@ pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
+import {IPoolEscrowProvider, IPoolEscrowFactory} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
 import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
 import {PoolEscrow} from "src/common/PoolEscrow.sol";
-
-import {IPoolEscrowProvider, IPoolEscrowFactory} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
 
 contract PoolEscrowFactory is Auth, IPoolEscrowFactory {
     address public immutable root;

--- a/src/common/factories/PoolEscrowFactory.sol
+++ b/src/common/factories/PoolEscrowFactory.sol
@@ -3,10 +3,10 @@ pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
 
-import {IPoolEscrowProvider, IPoolEscrowFactory} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
-import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
-import {PoolEscrow} from "src/common/PoolEscrow.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {PoolEscrow} from "src/common/PoolEscrow.sol";
+import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
+import {IPoolEscrowProvider, IPoolEscrowFactory} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
 
 contract PoolEscrowFactory is Auth, IPoolEscrowFactory {
     address public immutable root;

--- a/src/common/factories/interfaces/IPoolEscrowFactory.sol
+++ b/src/common/factories/interfaces/IPoolEscrowFactory.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {PoolId} from "src/common/types/PoolId.sol";
 import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
 
 interface IPoolEscrowProvider {
     /// @notice Returns the deterministic address of an escrow contract based on a given pool id wrapped into the

--- a/src/common/factories/interfaces/IPoolEscrowFactory.sol
+++ b/src/common/factories/interfaces/IPoolEscrowFactory.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
 
 interface IPoolEscrowProvider {
     /// @notice Returns the deterministic address of an escrow contract based on a given pool id wrapped into the

--- a/src/common/interfaces/IGateway.sol
+++ b/src/common/interfaces/IGateway.sol
@@ -3,9 +3,9 @@ pragma solidity >=0.5.0;
 
 import {IRecoverable} from "src/misc/interfaces/IRecoverable.sol";
 
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
-import {IMessageSender} from "src/common/interfaces/IMessageSender.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {IMessageSender} from "src/common/interfaces/IMessageSender.sol";
+import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
 
 /// @notice Interface for dispatch-only gateway
 interface IGateway is IMessageHandler, IMessageSender, IRecoverable {

--- a/src/common/interfaces/IGatewayHandlers.sol
+++ b/src/common/interfaces/IGatewayHandlers.sol
@@ -3,9 +3,9 @@ pragma solidity >=0.5.0;
 
 import {D18} from "src/misc/types/D18.sol";
 
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {ShareClassId} from "src/common/types/ShareClassId.sol";
 import {VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
 
 /// -----------------------------------------------------

--- a/src/common/interfaces/IGatewayHandlers.sol
+++ b/src/common/interfaces/IGatewayHandlers.sol
@@ -3,8 +3,8 @@ pragma solidity >=0.5.0;
 
 import {D18} from "src/misc/types/D18.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 import {VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
 

--- a/src/common/interfaces/IGatewaySenders.sol
+++ b/src/common/interfaces/IGatewaySenders.sol
@@ -3,9 +3,9 @@ pragma solidity >=0.5.0;
 
 import {D18} from "src/misc/types/D18.sol";
 
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {ShareClassId} from "src/common/types/ShareClassId.sol";
 import {VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
 
 interface ILocalCentrifugeId {

--- a/src/common/interfaces/IGatewaySenders.sol
+++ b/src/common/interfaces/IGatewaySenders.sol
@@ -3,8 +3,8 @@ pragma solidity >=0.5.0;
 
 import {D18} from "src/misc/types/D18.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 import {VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
 

--- a/src/common/interfaces/IGuardian.sol
+++ b/src/common/interfaces/IGuardian.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.5.0;
 
-import {PoolId} from "src/common/types/PoolId.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
 import {IAdapter} from "src/common/interfaces/IAdapter.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
 
 interface ISafe {
     function isOwner(address signer) external view returns (bool);

--- a/src/common/interfaces/IGuardian.sol
+++ b/src/common/interfaces/IGuardian.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.5.0;
 
+import {PoolId} from "src/common/types/PoolId.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
 import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {PoolId} from "src/common/types/PoolId.sol";
 
 interface ISafe {
     function isOwner(address signer) external view returns (bool);

--- a/src/common/interfaces/IGuardianActions.sol
+++ b/src/common/interfaces/IGuardianActions.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.5.0;
 
-import {AssetId} from "src/common/types/AssetId.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
 
 interface IHubGuardianActions {
     /// @notice Creates a new pool. `msg.sender` will be the admin of the created pool.

--- a/src/common/interfaces/IPoolEscrow.sol
+++ b/src/common/interfaces/IPoolEscrow.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.5.0;
 
-import {IRecoverable} from "src/misc/Recoverable.sol";
 import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
+import {IRecoverable} from "src/misc/Recoverable.sol";
 
 import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";

--- a/src/common/interfaces/IPoolEscrow.sol
+++ b/src/common/interfaces/IPoolEscrow.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.5.0;
 
-import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
 import {IRecoverable} from "src/misc/Recoverable.sol";
+import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
 
 import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";

--- a/src/common/interfaces/IRoot.sol
+++ b/src/common/interfaces/IRoot.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.5.0;
 
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
 
 interface IRoot {
     // --- Events ---

--- a/src/common/interfaces/IRoot.sol
+++ b/src/common/interfaces/IRoot.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.5.0;
 
-
 interface IRoot {
     // --- Events ---
     event File(bytes32 indexed what, uint256 data);

--- a/src/common/interfaces/adapters/IMultiAdapter.sol
+++ b/src/common/interfaces/adapters/IMultiAdapter.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.5.0;
 
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
 import {IAdapter} from "src/common/interfaces/IAdapter.sol";
+import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
 
 uint8 constant MAX_ADAPTER_COUNT = 8;
 

--- a/src/common/libraries/MessageLib.sol
+++ b/src/common/libraries/MessageLib.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
 
 // NOTE: Should never exceed 254 messages because id == 255 corresponds to message proofs
 enum MessageType {

--- a/src/common/libraries/MessageLib.sol
+++ b/src/common/libraries/MessageLib.sol
@@ -4,8 +4,8 @@ pragma solidity 0.8.28;
 import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
 
 // NOTE: Should never exceed 254 messages because id == 255 corresponds to message proofs
 enum MessageType {

--- a/src/common/libraries/PricingLib.sol
+++ b/src/common/libraries/PricingLib.sol
@@ -2,9 +2,9 @@
 pragma solidity 0.8.28;
 
 import {D18, d18} from "src/misc/types/D18.sol";
+import {MathLib} from "src/misc/libraries/MathLib.sol";
 import {IERC20Metadata} from "src/misc/interfaces/IERC20.sol";
 import {IERC6909MetadataExt} from "src/misc/interfaces/IERC6909.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
 
 import {PricingLib} from "src/common/libraries/PricingLib.sol";
 

--- a/src/common/libraries/PricingLib.sol
+++ b/src/common/libraries/PricingLib.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {MathLib} from "src/misc/libraries/MathLib.sol";
+import {D18, d18} from "src/misc/types/D18.sol";
 import {IERC20Metadata} from "src/misc/interfaces/IERC20.sol";
 import {IERC6909MetadataExt} from "src/misc/interfaces/IERC6909.sol";
-import {D18, d18} from "src/misc/types/D18.sol";
+import {MathLib} from "src/misc/libraries/MathLib.sol";
 
 import {PricingLib} from "src/common/libraries/PricingLib.sol";
 

--- a/src/common/libraries/RequestCallbackMessageLib.sol
+++ b/src/common/libraries/RequestCallbackMessageLib.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 
 enum RequestCallbackType {
     /// @dev Placeholder for null request callback type

--- a/src/common/libraries/RequestMessageLib.sol
+++ b/src/common/libraries/RequestMessageLib.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 
 enum RequestType {
     /// @dev Placeholder for null request type

--- a/src/hooks/FreezeOnly.sol
+++ b/src/hooks/FreezeOnly.sol
@@ -2,10 +2,10 @@
 pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
-import {BitmapLib} from "src/misc/libraries/BitmapLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 import {IERC165} from "src/misc/interfaces/IERC7575.sol";
+import {BitmapLib} from "src/misc/libraries/BitmapLib.sol";
 
 import {IRoot} from "src/common/interfaces/IRoot.sol";
 import {ITransferHook, HookData} from "src/common/interfaces/ITransferHook.sol";

--- a/src/hooks/FreezeOnly.sol
+++ b/src/hooks/FreezeOnly.sol
@@ -2,18 +2,18 @@
 pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 import {BitmapLib} from "src/misc/libraries/BitmapLib.sol";
+import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {IERC165} from "src/misc/interfaces/IERC7575.sol";
 
 import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {UpdateRestrictionType, UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
-
 import {ITransferHook, HookData} from "src/common/interfaces/ITransferHook.sol";
+
 import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
 
 import {IFreezable} from "src/hooks/interfaces/IFreezable.sol";
+import {UpdateRestrictionType, UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
 /// @title  Freeze Only
 /// @notice Hook implementation that:

--- a/src/hooks/FullRestrictions.sol
+++ b/src/hooks/FullRestrictions.sol
@@ -2,10 +2,10 @@
 pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
-import {BitmapLib} from "src/misc/libraries/BitmapLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 import {IERC165} from "src/misc/interfaces/IERC7575.sol";
+import {BitmapLib} from "src/misc/libraries/BitmapLib.sol";
 
 import {IRoot} from "src/common/interfaces/IRoot.sol";
 import {ITransferHook, HookData, ESCROW_HOOK_ID} from "src/common/interfaces/ITransferHook.sol";

--- a/src/hooks/FullRestrictions.sol
+++ b/src/hooks/FullRestrictions.sol
@@ -2,19 +2,19 @@
 pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {BitmapLib} from "src/misc/libraries/BitmapLib.sol";
 import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {IERC165} from "src/misc/interfaces/IERC7575.sol";
 
-import {UpdateRestrictionType, UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 import {IRoot} from "src/common/interfaces/IRoot.sol";
-
 import {ITransferHook, HookData, ESCROW_HOOK_ID} from "src/common/interfaces/ITransferHook.sol";
+
 import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
 
 import {IFreezable} from "src/hooks/interfaces/IFreezable.sol";
 import {IMemberlist} from "src/hooks/interfaces/IMemberlist.sol";
+import {UpdateRestrictionType, UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
 /// @title  Full Restrictions
 /// @notice Hook implementation that:

--- a/src/hooks/RedemptionRestrictions.sol
+++ b/src/hooks/RedemptionRestrictions.sol
@@ -2,10 +2,10 @@
 pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
-import {BitmapLib} from "src/misc/libraries/BitmapLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 import {IERC165} from "src/misc/interfaces/IERC7575.sol";
+import {BitmapLib} from "src/misc/libraries/BitmapLib.sol";
 
 import {IRoot} from "src/common/interfaces/IRoot.sol";
 import {ITransferHook, HookData, ESCROW_HOOK_ID} from "src/common/interfaces/ITransferHook.sol";

--- a/src/hooks/RedemptionRestrictions.sol
+++ b/src/hooks/RedemptionRestrictions.sol
@@ -2,19 +2,19 @@
 pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 import {BitmapLib} from "src/misc/libraries/BitmapLib.sol";
+import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {IERC165} from "src/misc/interfaces/IERC7575.sol";
 
 import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {UpdateRestrictionType, UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
-
 import {ITransferHook, HookData, ESCROW_HOOK_ID} from "src/common/interfaces/ITransferHook.sol";
+
 import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
 
 import {IFreezable} from "src/hooks/interfaces/IFreezable.sol";
 import {IMemberlist} from "src/hooks/interfaces/IMemberlist.sol";
+import {UpdateRestrictionType, UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
 /// @title  Redemption Restrictions
 /// @notice Hook implementation that:

--- a/src/hooks/libraries/UpdateRestrictionMessageLib.sol
+++ b/src/hooks/libraries/UpdateRestrictionMessageLib.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 
 enum UpdateRestrictionType {
     /// @dev Placeholder for null update restriction type

--- a/src/hub/Accounting.sol
+++ b/src/hub/Accounting.sol
@@ -4,8 +4,8 @@ pragma solidity 0.8.28;
 import {Auth} from "src/misc/Auth.sol";
 import {TransientStorageLib} from "src/misc/libraries/TransientStorageLib.sol";
 
-import {AccountId} from "src/common/types/AccountId.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {AccountId} from "src/common/types/AccountId.sol";
 
 import {IAccounting, JournalEntry} from "src/hub/interfaces/IAccounting.sol";
 

--- a/src/hub/Accounting.sol
+++ b/src/hub/Accounting.sol
@@ -2,11 +2,12 @@
 pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
+import {TransientStorageLib} from "src/misc/libraries/TransientStorageLib.sol";
 
 import {AccountId} from "src/common/types/AccountId.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+
 import {IAccounting, JournalEntry} from "src/hub/interfaces/IAccounting.sol";
-import {TransientStorageLib} from "src/misc/libraries/TransientStorageLib.sol";
 
 /// @notice In a transaction there can be multiple journal entries for different pools,
 /// which can be interleaved. We want entries for the same pool to share the same journal ID.

--- a/src/hub/Holdings.sol
+++ b/src/hub/Holdings.sol
@@ -14,7 +14,6 @@ import {PricingLib} from "src/common/libraries/PricingLib.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
 import {IHoldings, Holding, HoldingAccount, Snapshot} from "src/hub/interfaces/IHoldings.sol";
-import {IHoldings, Holding} from "src/hub/interfaces/IHoldings.sol";
 import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
 
 /// @title  Holdings

--- a/src/hub/Holdings.sol
+++ b/src/hub/Holdings.sol
@@ -2,19 +2,19 @@
 pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
+import {D18} from "src/misc/types/D18.sol";
 import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {d18, D18} from "src/misc/types/D18.sol";
 
-import {AccountId} from "src/common/types/AccountId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {ISnapshotHook} from "src/common/interfaces/ISnapshotHook.sol";
-import {IValuation} from "src/common/interfaces/IValuation.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
+import {AccountId} from "src/common/types/AccountId.sol";
 import {PricingLib} from "src/common/libraries/PricingLib.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {IValuation} from "src/common/interfaces/IValuation.sol";
+import {ISnapshotHook} from "src/common/interfaces/ISnapshotHook.sol";
 
-import {IHoldings, Holding, HoldingAccount, Snapshot} from "src/hub/interfaces/IHoldings.sol";
 import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
+import {IHoldings, Holding, HoldingAccount, Snapshot} from "src/hub/interfaces/IHoldings.sol";
 
 /// @title  Holdings
 /// @notice Bookkeeping of the holdings and its associated accounting IDs for each pool.

--- a/src/hub/Holdings.sol
+++ b/src/hub/Holdings.sol
@@ -1,21 +1,21 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {MathLib} from "src/misc/libraries/MathLib.sol";
 import {Auth} from "src/misc/Auth.sol";
+import {MathLib} from "src/misc/libraries/MathLib.sol";
 import {d18, D18} from "src/misc/types/D18.sol";
 
-import {IValuation} from "src/common/interfaces/IValuation.sol";
-import {PricingLib} from "src/common/libraries/PricingLib.sol";
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
 import {AccountId} from "src/common/types/AccountId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
 import {ISnapshotHook} from "src/common/interfaces/ISnapshotHook.sol";
+import {IValuation} from "src/common/interfaces/IValuation.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
+import {PricingLib} from "src/common/libraries/PricingLib.sol";
+import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
+import {IHoldings, Holding, HoldingAccount, Snapshot} from "src/hub/interfaces/IHoldings.sol";
 import {IHoldings, Holding} from "src/hub/interfaces/IHoldings.sol";
 import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
-import {IHoldings, Holding, HoldingAccount, Snapshot} from "src/hub/interfaces/IHoldings.sol";
 
 /// @title  Holdings
 /// @notice Bookkeeping of the holdings and its associated accounting IDs for each pool.

--- a/src/hub/Hub.sol
+++ b/src/hub/Hub.sol
@@ -2,29 +2,29 @@
 pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
-import {D18, d18} from "src/misc/types/D18.sol";
+import {D18} from "src/misc/types/D18.sol";
+import {Recoverable} from "src/misc/Recoverable.sol";
 import {MathLib} from "src/misc/libraries/MathLib.sol";
 import {Multicall, IMulticall} from "src/misc/Multicall.sol";
-import {Recoverable} from "src/misc/Recoverable.sol";
 
-import {AccountId} from "src/common/types/AccountId.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
+import {AccountId} from "src/common/types/AccountId.sol";
 import {IGateway} from "src/common/interfaces/IGateway.sol";
+import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {IValuation} from "src/common/interfaces/IValuation.sol";
+import {ISnapshotHook} from "src/common/interfaces/ISnapshotHook.sol";
+import {IHubMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
 import {IHubGatewayHandler} from "src/common/interfaces/IGatewayHandlers.sol";
 import {IHubGuardianActions} from "src/common/interfaces/IGuardianActions.sol";
-import {IHubMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
-import {IPoolEscrow, IPoolEscrowFactory} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
-import {ISnapshotHook} from "src/common/interfaces/ISnapshotHook.sol";
-import {IValuation} from "src/common/interfaces/IValuation.sol";
-import {PoolId} from "src/common/types/PoolId.sol";
 import {RequestCallbackMessageLib} from "src/common/libraries/RequestCallbackMessageLib.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {IPoolEscrow, IPoolEscrowFactory} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
 
-import {IAccounting, JournalEntry} from "src/hub/interfaces/IAccounting.sol";
 import {IHoldings} from "src/hub/interfaces/IHoldings.sol";
-import {IHub, VaultUpdateKind} from "src/hub/interfaces/IHub.sol";
 import {IHubHelpers} from "src/hub/interfaces/IHubHelpers.sol";
 import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
+import {IHub, VaultUpdateKind} from "src/hub/interfaces/IHub.sol";
+import {IAccounting, JournalEntry} from "src/hub/interfaces/IAccounting.sol";
 import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
 
 /// @title  Hub

--- a/src/hub/Hub.sol
+++ b/src/hub/Hub.sol
@@ -1,31 +1,31 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
+import {Auth} from "src/misc/Auth.sol";
 import {D18, d18} from "src/misc/types/D18.sol";
 import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {Auth} from "src/misc/Auth.sol";
 import {Multicall, IMulticall} from "src/misc/Multicall.sol";
 import {Recoverable} from "src/misc/Recoverable.sol";
 
-import {IValuation} from "src/common/interfaces/IValuation.sol";
+import {AccountId} from "src/common/types/AccountId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
 import {IGateway} from "src/common/interfaces/IGateway.sol";
 import {IHubGatewayHandler} from "src/common/interfaces/IGatewayHandlers.sol";
-import {IHubMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
 import {IHubGuardianActions} from "src/common/interfaces/IGuardianActions.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {AccountId} from "src/common/types/AccountId.sol";
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ISnapshotHook} from "src/common/interfaces/ISnapshotHook.sol";
-import {RequestCallbackMessageLib} from "src/common/libraries/RequestCallbackMessageLib.sol";
+import {IHubMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
 import {IPoolEscrow, IPoolEscrowFactory} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
+import {ISnapshotHook} from "src/common/interfaces/ISnapshotHook.sol";
+import {IValuation} from "src/common/interfaces/IValuation.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
+import {RequestCallbackMessageLib} from "src/common/libraries/RequestCallbackMessageLib.sol";
+import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
 import {IAccounting, JournalEntry} from "src/hub/interfaces/IAccounting.sol";
-import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
-import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
 import {IHoldings} from "src/hub/interfaces/IHoldings.sol";
 import {IHub, VaultUpdateKind} from "src/hub/interfaces/IHub.sol";
 import {IHubHelpers} from "src/hub/interfaces/IHubHelpers.sol";
+import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
+import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
 
 /// @title  Hub
 /// @notice Central pool management contract, that brings together all functions in one place.

--- a/src/hub/HubHelpers.sol
+++ b/src/hub/HubHelpers.sol
@@ -5,20 +5,20 @@ import {Auth} from "src/misc/Auth.sol";
 import {D18, d18} from "src/misc/types/D18.sol";
 import {MathLib} from "src/misc/libraries/MathLib.sol";
 
-import {AccountId} from "src/common/types/AccountId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {IHubMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
-import {IValuation} from "src/common/interfaces/IValuation.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
-import {RequestCallbackMessageLib} from "src/common/libraries/RequestCallbackMessageLib.sol";
-import {RequestMessageLib, RequestType} from "src/common/libraries/RequestMessageLib.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
+import {AccountId} from "src/common/types/AccountId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {IValuation} from "src/common/interfaces/IValuation.sol";
+import {IHubMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
+import {RequestMessageLib, RequestType} from "src/common/libraries/RequestMessageLib.sol";
+import {RequestCallbackMessageLib} from "src/common/libraries/RequestCallbackMessageLib.sol";
 
-import {IAccounting} from "src/hub/interfaces/IAccounting.sol";
-import {IHoldings, HoldingAccount} from "src/hub/interfaces/IHoldings.sol";
 import {IHub, AccountType} from "src/hub/interfaces/IHub.sol";
+import {IAccounting} from "src/hub/interfaces/IAccounting.sol";
 import {IHubHelpers} from "src/hub/interfaces/IHubHelpers.sol";
 import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
+import {IHoldings, HoldingAccount} from "src/hub/interfaces/IHoldings.sol";
 import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
 
 contract HubHelpers is Auth, IHubHelpers {

--- a/src/hub/HubHelpers.sol
+++ b/src/hub/HubHelpers.sol
@@ -1,25 +1,25 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
+import {Auth} from "src/misc/Auth.sol";
 import {D18, d18} from "src/misc/types/D18.sol";
 import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {Auth} from "src/misc/Auth.sol";
 
-import {IValuation} from "src/common/interfaces/IValuation.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
 import {AccountId} from "src/common/types/AccountId.sol";
-import {PoolId} from "src/common/types/PoolId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
 import {IHubMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
-import {RequestMessageLib, RequestType} from "src/common/libraries/RequestMessageLib.sol";
+import {IValuation} from "src/common/interfaces/IValuation.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
 import {RequestCallbackMessageLib} from "src/common/libraries/RequestCallbackMessageLib.sol";
+import {RequestMessageLib, RequestType} from "src/common/libraries/RequestMessageLib.sol";
+import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
-import {IHubHelpers} from "src/hub/interfaces/IHubHelpers.sol";
 import {IAccounting} from "src/hub/interfaces/IAccounting.sol";
+import {IHoldings, HoldingAccount} from "src/hub/interfaces/IHoldings.sol";
+import {IHub, AccountType} from "src/hub/interfaces/IHub.sol";
+import {IHubHelpers} from "src/hub/interfaces/IHubHelpers.sol";
 import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
 import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
-import {IHub, AccountType} from "src/hub/interfaces/IHub.sol";
-import {IHoldings, HoldingAccount} from "src/hub/interfaces/IHoldings.sol";
 
 contract HubHelpers is Auth, IHubHelpers {
     using MathLib for uint256;

--- a/src/hub/HubRegistry.sol
+++ b/src/hub/HubRegistry.sol
@@ -2,11 +2,12 @@
 pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
 import {IERC6909Decimals} from "src/misc/interfaces/IERC6909.sol";
+import {MathLib} from "src/misc/libraries/MathLib.sol";
 
-import {PoolId, newPoolId} from "src/common/types/PoolId.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
+import {PoolId, newPoolId} from "src/common/types/PoolId.sol";
+
 import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
 
 /// @title  Hub Registry

--- a/src/hub/HubRegistry.sol
+++ b/src/hub/HubRegistry.sol
@@ -2,8 +2,8 @@
 pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
-import {IERC6909Decimals} from "src/misc/interfaces/IERC6909.sol";
 import {MathLib} from "src/misc/libraries/MathLib.sol";
+import {IERC6909Decimals} from "src/misc/interfaces/IERC6909.sol";
 
 import {AssetId} from "src/common/types/AssetId.sol";
 import {PoolId, newPoolId} from "src/common/types/PoolId.sol";

--- a/src/hub/ShareClassManager.sol
+++ b/src/hub/ShareClassManager.sol
@@ -2,17 +2,18 @@
 pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
+import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {D18, d18} from "src/misc/types/D18.sol";
 import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
-import {ShareClassId, newShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
 import {PricingLib} from "src/common/libraries/PricingLib.sol";
+import {ShareClassId, newShareClassId} from "src/common/types/ShareClassId.sol";
 
 import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
+
 import {
     IShareClassManager,
     EpochInvestAmounts,

--- a/src/hub/ShareClassManager.sol
+++ b/src/hub/ShareClassManager.sol
@@ -2,13 +2,13 @@
 pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {D18, d18} from "src/misc/types/D18.sol";
+import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {MathLib} from "src/misc/libraries/MathLib.sol";
+import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
 import {PricingLib} from "src/common/libraries/PricingLib.sol";
 import {ShareClassId, newShareClassId} from "src/common/types/ShareClassId.sol";
 

--- a/src/hub/interfaces/IAccounting.sol
+++ b/src/hub/interfaces/IAccounting.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.5.0;
 
-import {AccountId} from "src/common/types/AccountId.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {AccountId} from "src/common/types/AccountId.sol";
 
 struct JournalEntry {
     uint128 value;

--- a/src/hub/interfaces/IHoldings.sol
+++ b/src/hub/interfaces/IHoldings.sol
@@ -3,12 +3,12 @@ pragma solidity >=0.5.0;
 
 import {D18} from "src/misc/types/D18.sol";
 
-import {AccountId} from "src/common/types/AccountId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {ISnapshotHook} from "src/common/interfaces/ISnapshotHook.sol";
-import {IValuation} from "src/common/interfaces/IValuation.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
+import {AccountId} from "src/common/types/AccountId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {IValuation} from "src/common/interfaces/IValuation.sol";
+import {ISnapshotHook} from "src/common/interfaces/ISnapshotHook.sol";
 
 struct Holding {
     uint128 assetAmount;

--- a/src/hub/interfaces/IHoldings.sol
+++ b/src/hub/interfaces/IHoldings.sol
@@ -3,12 +3,12 @@ pragma solidity >=0.5.0;
 
 import {D18} from "src/misc/types/D18.sol";
 
+import {AccountId} from "src/common/types/AccountId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
+import {ISnapshotHook} from "src/common/interfaces/ISnapshotHook.sol";
 import {IValuation} from "src/common/interfaces/IValuation.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {AccountId} from "src/common/types/AccountId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {ISnapshotHook} from "src/common/interfaces/ISnapshotHook.sol";
 
 struct Holding {
     uint128 assetAmount;

--- a/src/hub/interfaces/IHub.sol
+++ b/src/hub/interfaces/IHub.sol
@@ -3,21 +3,20 @@ pragma solidity >=0.5.0;
 
 import {D18} from "src/misc/types/D18.sol";
 
-import {IValuation} from "src/common/interfaces/IValuation.sol";
-import {VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
+import {AccountId} from "src/common/types/AccountId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
 import {IGateway} from "src/common/interfaces/IGateway.sol";
 import {IHubMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
-
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {AccountId} from "src/common/types/AccountId.sol";
-import {PoolId} from "src/common/types/PoolId.sol";
 import {ISnapshotHook} from "src/common/interfaces/ISnapshotHook.sol";
+import {IValuation} from "src/common/interfaces/IValuation.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
+import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
 
-import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
 import {IAccounting, JournalEntry} from "src/hub/interfaces/IAccounting.sol";
-import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
 import {IHoldings} from "src/hub/interfaces/IHoldings.sol";
+import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
+import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
 
 /// @notice Account types used by Hub
 enum AccountType {

--- a/src/hub/interfaces/IHub.sol
+++ b/src/hub/interfaces/IHub.sol
@@ -3,19 +3,19 @@ pragma solidity >=0.5.0;
 
 import {D18} from "src/misc/types/D18.sol";
 
-import {AccountId} from "src/common/types/AccountId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {IGateway} from "src/common/interfaces/IGateway.sol";
-import {IHubMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
-import {ISnapshotHook} from "src/common/interfaces/ISnapshotHook.sol";
-import {IValuation} from "src/common/interfaces/IValuation.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
+import {AccountId} from "src/common/types/AccountId.sol";
+import {IGateway} from "src/common/interfaces/IGateway.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {IValuation} from "src/common/interfaces/IValuation.sol";
 import {VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
+import {ISnapshotHook} from "src/common/interfaces/ISnapshotHook.sol";
+import {IHubMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
 
-import {IAccounting, JournalEntry} from "src/hub/interfaces/IAccounting.sol";
 import {IHoldings} from "src/hub/interfaces/IHoldings.sol";
 import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
+import {IAccounting, JournalEntry} from "src/hub/interfaces/IAccounting.sol";
 import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
 
 /// @notice Account types used by Hub

--- a/src/hub/interfaces/IHubHelpers.sol
+++ b/src/hub/interfaces/IHubHelpers.sol
@@ -3,10 +3,10 @@ pragma solidity >=0.5.0;
 
 import {D18} from "src/misc/types/D18.sol";
 
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {AccountId} from "src/common/types/AccountId.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
-import {AccountId} from "src/common/types/AccountId.sol";
+import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
 import {HoldingAccount} from "src/hub/interfaces/IHoldings.sol";
 

--- a/src/hub/interfaces/IHubHelpers.sol
+++ b/src/hub/interfaces/IHubHelpers.sol
@@ -3,9 +3,9 @@ pragma solidity >=0.5.0;
 
 import {D18} from "src/misc/types/D18.sol";
 
-import {AccountId} from "src/common/types/AccountId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
+import {AccountId} from "src/common/types/AccountId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
 import {HoldingAccount} from "src/hub/interfaces/IHoldings.sol";

--- a/src/hub/interfaces/IHubRegistry.sol
+++ b/src/hub/interfaces/IHubRegistry.sol
@@ -3,10 +3,8 @@ pragma solidity >=0.5.0;
 
 import {IERC6909Decimals} from "src/misc/interfaces/IERC6909.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
-
-import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
 
 interface IHubRegistry is IERC6909Decimals {
     event NewAsset(AssetId indexed assetId, uint8 decimals);

--- a/src/hub/interfaces/IHubRegistry.sol
+++ b/src/hub/interfaces/IHubRegistry.sol
@@ -3,8 +3,9 @@ pragma solidity >=0.5.0;
 
 import {IERC6909Decimals} from "src/misc/interfaces/IERC6909.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
+
 import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
 
 interface IHubRegistry is IERC6909Decimals {

--- a/src/hub/interfaces/IShareClassManager.sol
+++ b/src/hub/interfaces/IShareClassManager.sol
@@ -3,8 +3,8 @@ pragma solidity >=0.5.0;
 
 import {D18} from "src/misc/types/D18.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
 struct EpochRedeemAmounts {

--- a/src/hub/interfaces/IShareClassManager.sol
+++ b/src/hub/interfaces/IShareClassManager.sol
@@ -2,8 +2,9 @@
 pragma solidity >=0.5.0;
 
 import {D18} from "src/misc/types/D18.sol";
-import {PoolId} from "src/common/types/PoolId.sol";
+
 import {AssetId} from "src/common/types/AssetId.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
 struct EpochRedeemAmounts {

--- a/src/managers/OnOfframpManager.sol
+++ b/src/managers/OnOfframpManager.sol
@@ -5,17 +5,17 @@ import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {IERC165} from "src/misc/interfaces/IERC165.sol";
 import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
 import {IBalanceSheet} from "src/spoke/interfaces/IBalanceSheet.sol";
 import {IUpdateContract} from "src/spoke/interfaces/IUpdateContract.sol";
 import {UpdateContractType, UpdateContractMessageLib} from "src/spoke/libraries/UpdateContractMessageLib.sol";
 
-import {IDepositManager, IWithdrawManager} from "src/managers/interfaces/IBalanceSheetManager.sol";
-import {IOnOfframpManagerFactory} from "src/managers/interfaces/IOnOfframpManagerFactory.sol";
 import {IOnOfframpManager} from "src/managers/interfaces/IOnOfframpManager.sol";
+import {IOnOfframpManagerFactory} from "src/managers/interfaces/IOnOfframpManagerFactory.sol";
+import {IDepositManager, IWithdrawManager} from "src/managers/interfaces/IBalanceSheetManager.sol";
 
 /// @title  OnOfframpManager
 /// @notice Balance sheet manager for depositing and withdrawing ERC20 assets.

--- a/src/managers/OnOfframpManager.sol
+++ b/src/managers/OnOfframpManager.sol
@@ -5,17 +5,17 @@ import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {IERC165} from "src/misc/interfaces/IERC165.sol";
 import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {UpdateContractType, UpdateContractMessageLib} from "src/spoke/libraries/UpdateContractMessageLib.sol";
 
 import {IBalanceSheet} from "src/spoke/interfaces/IBalanceSheet.sol";
 import {IUpdateContract} from "src/spoke/interfaces/IUpdateContract.sol";
+import {UpdateContractType, UpdateContractMessageLib} from "src/spoke/libraries/UpdateContractMessageLib.sol";
 
-import {IOnOfframpManager} from "src/managers/interfaces/IOnOfframpManager.sol";
-import {IOnOfframpManagerFactory} from "src/managers/interfaces/IOnOfframpManagerFactory.sol";
 import {IDepositManager, IWithdrawManager} from "src/managers/interfaces/IBalanceSheetManager.sol";
+import {IOnOfframpManagerFactory} from "src/managers/interfaces/IOnOfframpManagerFactory.sol";
+import {IOnOfframpManager} from "src/managers/interfaces/IOnOfframpManager.sol";
 
 /// @title  OnOfframpManager
 /// @notice Balance sheet manager for depositing and withdrawing ERC20 assets.

--- a/src/misc/ERC20.sol
+++ b/src/misc/ERC20.sol
@@ -3,9 +3,8 @@ pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
 import {EIP712Lib} from "src/misc/libraries/EIP712Lib.sol";
-import {SignatureLib} from "src/misc/libraries/SignatureLib.sol";
-
 import {IERC20, IERC20Metadata, IERC20Permit} from "src/misc/interfaces/IERC20.sol";
+import {SignatureLib} from "src/misc/libraries/SignatureLib.sol";
 
 /// @title  ERC20
 /// @notice Standard ERC-20 implementation, with mint/burn functionality and permit logic.

--- a/src/misc/ERC20.sol
+++ b/src/misc/ERC20.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
 import {EIP712Lib} from "src/misc/libraries/EIP712Lib.sol";
-import {IERC20, IERC20Metadata, IERC20Permit} from "src/misc/interfaces/IERC20.sol";
 import {SignatureLib} from "src/misc/libraries/SignatureLib.sol";
+import {IERC20, IERC20Metadata, IERC20Permit} from "src/misc/interfaces/IERC20.sol";
 
 /// @title  ERC20
 /// @notice Standard ERC-20 implementation, with mint/burn functionality and permit logic.

--- a/src/misc/Escrow.sol
+++ b/src/misc/Escrow.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
 import {IERC20} from "src/misc/interfaces/IERC20.sol";
-import {IERC6909} from "src/misc/interfaces/IERC6909.sol";
 import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
+import {IERC6909} from "src/misc/interfaces/IERC6909.sol";
 import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
 
 contract Escrow is Auth, IEscrow {

--- a/src/misc/Escrow.sol
+++ b/src/misc/Escrow.sol
@@ -4,8 +4,8 @@ pragma solidity 0.8.28;
 import {Auth} from "src/misc/Auth.sol";
 import {IERC20} from "src/misc/interfaces/IERC20.sol";
 import {IERC6909} from "src/misc/interfaces/IERC6909.sol";
-import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
 import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
+import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
 
 contract Escrow is Auth, IEscrow {
     constructor(address deployer) Auth(deployer) {}

--- a/src/misc/IdentityValuation.sol
+++ b/src/misc/IdentityValuation.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
+import {d18} from "src/misc/types/D18.sol";
+import {MathLib} from "src/misc/libraries/MathLib.sol";
 import {IERC6909Decimals} from "src/misc/interfaces/IERC6909.sol";
 import {IIdentityValuation} from "src/misc/interfaces/IIdentityValuation.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {d18} from "src/misc/types/D18.sol";
 
 import {AssetId} from "src/common/types/AssetId.sol";
 import {BaseValuation} from "src/common/BaseValuation.sol";
-import {IValuation} from "src/common/interfaces/IValuation.sol";
 import {PricingLib} from "src/common/libraries/PricingLib.sol";
+import {IValuation} from "src/common/interfaces/IValuation.sol";
 
 contract IdentityValuation is BaseValuation, IIdentityValuation {
     using MathLib for *;

--- a/src/misc/IdentityValuation.sol
+++ b/src/misc/IdentityValuation.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {d18} from "src/misc/types/D18.sol";
-import {IIdentityValuation} from "src/misc/interfaces/IIdentityValuation.sol";
 import {IERC6909Decimals} from "src/misc/interfaces/IERC6909.sol";
+import {IIdentityValuation} from "src/misc/interfaces/IIdentityValuation.sol";
 import {MathLib} from "src/misc/libraries/MathLib.sol";
+import {d18} from "src/misc/types/D18.sol";
 
-import {IValuation} from "src/common/interfaces/IValuation.sol";
-import {BaseValuation} from "src/common/BaseValuation.sol";
-import {PricingLib} from "src/common/libraries/PricingLib.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
+import {BaseValuation} from "src/common/BaseValuation.sol";
+import {IValuation} from "src/common/interfaces/IValuation.sol";
+import {PricingLib} from "src/common/libraries/PricingLib.sol";
 
 contract IdentityValuation is BaseValuation, IIdentityValuation {
     using MathLib for *;

--- a/src/misc/Recoverable.sol
+++ b/src/misc/Recoverable.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
 import {IERC6909} from "src/misc/interfaces/IERC6909.sol";
-import {IRecoverable, ETH_ADDRESS} from "src/misc/interfaces/IRecoverable.sol";
 import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
+import {IRecoverable, ETH_ADDRESS} from "src/misc/interfaces/IRecoverable.sol";
 
 abstract contract Recoverable is Auth, IRecoverable {
     /// @inheritdoc IRecoverable

--- a/src/misc/Recoverable.sol
+++ b/src/misc/Recoverable.sol
@@ -3,9 +3,8 @@ pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
 import {IERC6909} from "src/misc/interfaces/IERC6909.sol";
-import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
-
 import {IRecoverable, ETH_ADDRESS} from "src/misc/interfaces/IRecoverable.sol";
+import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
 
 abstract contract Recoverable is Auth, IRecoverable {
     /// @inheritdoc IRecoverable

--- a/src/spoke/BalanceSheet.sol
+++ b/src/spoke/BalanceSheet.sol
@@ -2,29 +2,29 @@
 pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {D18, d18} from "src/misc/types/D18.sol";
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {IERC6909} from "src/misc/interfaces/IERC6909.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {Multicall, IMulticall} from "src/misc/Multicall.sol";
 import {Recoverable} from "src/misc/Recoverable.sol";
+import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {MathLib} from "src/misc/libraries/MathLib.sol";
+import {IERC6909} from "src/misc/interfaces/IERC6909.sol";
+import {Multicall, IMulticall} from "src/misc/Multicall.sol";
 import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
 import {TransientStorageLib} from "src/misc/libraries/TransientStorageLib.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
-import {IBalanceSheetGatewayHandler} from "src/common/interfaces/IGatewayHandlers.sol";
-import {IGateway} from "src/common/interfaces/IGateway.sol";
-import {IPoolEscrowProvider} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
-import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
-import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {ISpokeMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
+import {IRoot} from "src/common/interfaces/IRoot.sol";
+import {IGateway} from "src/common/interfaces/IGateway.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
+import {ISpokeMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
+import {IBalanceSheetGatewayHandler} from "src/common/interfaces/IGatewayHandlers.sol";
+import {IPoolEscrowProvider} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
 
-import {IBalanceSheet, ShareQueueAmount, AssetQueueAmount} from "src/spoke/interfaces/IBalanceSheet.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
 import {ISpoke} from "src/spoke/interfaces/ISpoke.sol";
+import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+import {IBalanceSheet, ShareQueueAmount, AssetQueueAmount} from "src/spoke/interfaces/IBalanceSheet.sol";
 
 /// @title  Balance Sheet
 /// @notice Management contract that integrates all balance sheet functions of a pool:

--- a/src/spoke/BalanceSheet.sol
+++ b/src/spoke/BalanceSheet.sol
@@ -2,29 +2,29 @@
 pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
 import {D18, d18} from "src/misc/types/D18.sol";
+import {IAuth} from "src/misc/interfaces/IAuth.sol";
 import {IERC6909} from "src/misc/interfaces/IERC6909.sol";
+import {MathLib} from "src/misc/libraries/MathLib.sol";
+import {Multicall, IMulticall} from "src/misc/Multicall.sol";
 import {Recoverable} from "src/misc/Recoverable.sol";
 import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
 import {TransientStorageLib} from "src/misc/libraries/TransientStorageLib.sol";
-import {Multicall, IMulticall} from "src/misc/Multicall.sol";
 
+import {AssetId} from "src/common/types/AssetId.sol";
+import {IBalanceSheetGatewayHandler} from "src/common/interfaces/IGatewayHandlers.sol";
+import {IGateway} from "src/common/interfaces/IGateway.sol";
+import {IPoolEscrowProvider} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
+import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
 import {IRoot} from "src/common/interfaces/IRoot.sol";
 import {ISpokeMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
-import {IBalanceSheetGatewayHandler} from "src/common/interfaces/IGatewayHandlers.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {IGateway} from "src/common/interfaces/IGateway.sol";
-import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
-import {IPoolEscrowProvider} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
 
-import {ISpoke} from "src/spoke/interfaces/ISpoke.sol";
 import {IBalanceSheet, ShareQueueAmount, AssetQueueAmount} from "src/spoke/interfaces/IBalanceSheet.sol";
 import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+import {ISpoke} from "src/spoke/interfaces/ISpoke.sol";
 
 /// @title  Balance Sheet
 /// @notice Management contract that integrates all balance sheet functions of a pool:

--- a/src/spoke/ShareToken.sol
+++ b/src/spoke/ShareToken.sol
@@ -3,8 +3,10 @@ pragma solidity 0.8.28;
 
 import {ERC20} from "src/misc/ERC20.sol";
 import {IERC20} from "src/misc/interfaces/IERC20.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
 import {IERC7575Share, IERC165} from "src/misc/interfaces/IERC7575.sol";
+import {MathLib} from "src/misc/libraries/MathLib.sol";
+
+import {IShareToken, IERC1404} from "src/spoke/interfaces/IShareToken.sol";
 
 import {
     ITransferHook,
@@ -14,7 +16,6 @@ import {
     ERROR_CODE_ID,
     ERROR_MESSAGE
 } from "src/common/interfaces/ITransferHook.sol";
-import {IShareToken, IERC1404} from "src/spoke/interfaces/IShareToken.sol";
 
 /// @title  Share Token
 /// @notice Extension of ERC20 + ERC1404,

--- a/src/spoke/ShareToken.sol
+++ b/src/spoke/ShareToken.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.28;
 
 import {ERC20} from "src/misc/ERC20.sol";
 import {IERC20} from "src/misc/interfaces/IERC20.sol";
-import {IERC7575Share, IERC165} from "src/misc/interfaces/IERC7575.sol";
 import {MathLib} from "src/misc/libraries/MathLib.sol";
+import {IERC7575Share, IERC165} from "src/misc/interfaces/IERC7575.sol";
 
 import {IShareToken, IERC1404} from "src/spoke/interfaces/IShareToken.sol";
 

--- a/src/spoke/Spoke.sol
+++ b/src/spoke/Spoke.sol
@@ -1,37 +1,37 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IERC20Metadata} from "src/misc/interfaces/IERC20.sol";
-import {IERC6909MetadataExt} from "src/misc/interfaces/IERC6909.sol";
 import {Auth} from "src/misc/Auth.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
 import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {D18} from "src/misc/types/D18.sol";
-import {Recoverable} from "src/misc/Recoverable.sol";
 import {IERC165} from "src/misc/interfaces/IERC7575.sol";
+import {IERC20Metadata} from "src/misc/interfaces/IERC20.sol";
+import {IERC6909MetadataExt} from "src/misc/interfaces/IERC6909.sol";
+import {MathLib} from "src/misc/libraries/MathLib.sol";
+import {Recoverable} from "src/misc/Recoverable.sol";
 import {ReentrancyProtection} from "src/misc/ReentrancyProtection.sol";
 
-import {VaultUpdateKind, MessageLib} from "src/common/libraries/MessageLib.sol";
 import {IGateway} from "src/common/interfaces/IGateway.sol";
+import {IPoolEscrowFactory} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
+import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
 import {ISpokeGatewayHandler} from "src/common/interfaces/IGatewayHandlers.sol";
 import {ISpokeMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
-import {newAssetId, AssetId} from "src/common/types/AssetId.sol";
+import {ITransferHook} from "src/common/interfaces/ITransferHook.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
-import {IPoolEscrowFactory} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
-import {ITransferHook} from "src/common/interfaces/ITransferHook.sol";
+import {VaultUpdateKind, MessageLib} from "src/common/libraries/MessageLib.sol";
+import {newAssetId, AssetId} from "src/common/types/AssetId.sol";
 
-import {IVaultFactory} from "src/spoke/factories/interfaces/IVaultFactory.sol";
-import {IVault} from "src/spoke/interfaces/IVault.sol";
-import {ITokenFactory} from "src/spoke/factories/interfaces/ITokenFactory.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
-import {IUpdateContract} from "src/spoke/interfaces/IUpdateContract.sol";
 import {AssetIdKey, Pool, ShareClassDetails, VaultDetails, ISpoke} from "src/spoke/interfaces/ISpoke.sol";
-import {Price} from "src/spoke/types/Price.sol";
-import {IVaultManager} from "src/spoke/interfaces/IVaultManager.sol";
 import {IRequestManager} from "src/spoke/interfaces/IRequestManager.sol";
+import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+import {ITokenFactory} from "src/spoke/factories/interfaces/ITokenFactory.sol";
+import {IUpdateContract} from "src/spoke/interfaces/IUpdateContract.sol";
+import {IVaultFactory} from "src/spoke/factories/interfaces/IVaultFactory.sol";
+import {IVaultManager} from "src/spoke/interfaces/IVaultManager.sol";
+import {IVault} from "src/spoke/interfaces/IVault.sol";
+import {Price} from "src/spoke/types/Price.sol";
 
 /// @title  Spoke
 /// @notice This contract manages which pools & share classes exist, controlling allowed pool currencies,

--- a/src/spoke/Spoke.sol
+++ b/src/spoke/Spoke.sol
@@ -2,36 +2,36 @@
 pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {D18} from "src/misc/types/D18.sol";
+import {Recoverable} from "src/misc/Recoverable.sol";
+import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {MathLib} from "src/misc/libraries/MathLib.sol";
+import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 import {IERC165} from "src/misc/interfaces/IERC7575.sol";
 import {IERC20Metadata} from "src/misc/interfaces/IERC20.sol";
 import {IERC6909MetadataExt} from "src/misc/interfaces/IERC6909.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {Recoverable} from "src/misc/Recoverable.sol";
 import {ReentrancyProtection} from "src/misc/ReentrancyProtection.sol";
 
-import {IGateway} from "src/common/interfaces/IGateway.sol";
-import {IPoolEscrowFactory} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
-import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
-import {ISpokeGatewayHandler} from "src/common/interfaces/IGatewayHandlers.sol";
-import {ISpokeMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
-import {ITransferHook} from "src/common/interfaces/ITransferHook.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {IGateway} from "src/common/interfaces/IGateway.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {VaultUpdateKind, MessageLib} from "src/common/libraries/MessageLib.sol";
 import {newAssetId, AssetId} from "src/common/types/AssetId.sol";
+import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
+import {ITransferHook} from "src/common/interfaces/ITransferHook.sol";
+import {ISpokeMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
+import {ISpokeGatewayHandler} from "src/common/interfaces/IGatewayHandlers.sol";
+import {VaultUpdateKind, MessageLib} from "src/common/libraries/MessageLib.sol";
+import {IPoolEscrowFactory} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
 
-import {AssetIdKey, Pool, ShareClassDetails, VaultDetails, ISpoke} from "src/spoke/interfaces/ISpoke.sol";
-import {IRequestManager} from "src/spoke/interfaces/IRequestManager.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
-import {ITokenFactory} from "src/spoke/factories/interfaces/ITokenFactory.sol";
-import {IUpdateContract} from "src/spoke/interfaces/IUpdateContract.sol";
-import {IVaultFactory} from "src/spoke/factories/interfaces/IVaultFactory.sol";
-import {IVaultManager} from "src/spoke/interfaces/IVaultManager.sol";
-import {IVault} from "src/spoke/interfaces/IVault.sol";
 import {Price} from "src/spoke/types/Price.sol";
+import {IVault} from "src/spoke/interfaces/IVault.sol";
+import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+import {IVaultManager} from "src/spoke/interfaces/IVaultManager.sol";
+import {IRequestManager} from "src/spoke/interfaces/IRequestManager.sol";
+import {IUpdateContract} from "src/spoke/interfaces/IUpdateContract.sol";
+import {ITokenFactory} from "src/spoke/factories/interfaces/ITokenFactory.sol";
+import {IVaultFactory} from "src/spoke/factories/interfaces/IVaultFactory.sol";
+import {AssetIdKey, Pool, ShareClassDetails, VaultDetails, ISpoke} from "src/spoke/interfaces/ISpoke.sol";
 
 /// @title  Spoke
 /// @notice This contract manages which pools & share classes exist, controlling allowed pool currencies,

--- a/src/spoke/factories/TokenFactory.sol
+++ b/src/spoke/factories/TokenFactory.sol
@@ -3,9 +3,9 @@ pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
 
+import {ShareToken} from "src/spoke/ShareToken.sol";
 import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
 import {ITokenFactory} from "src/spoke/factories/interfaces/ITokenFactory.sol";
-import {ShareToken} from "src/spoke/ShareToken.sol";
 
 /// @title  Share Token Factory
 /// @dev    Utility for deploying new share class token contracts

--- a/src/spoke/factories/TokenFactory.sol
+++ b/src/spoke/factories/TokenFactory.sol
@@ -3,9 +3,9 @@ pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
 
-import {ShareToken} from "src/spoke/ShareToken.sol";
-import {ITokenFactory} from "src/spoke/factories/interfaces/ITokenFactory.sol";
 import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+import {ITokenFactory} from "src/spoke/factories/interfaces/ITokenFactory.sol";
+import {ShareToken} from "src/spoke/ShareToken.sol";
 
 /// @title  Share Token Factory
 /// @dev    Utility for deploying new share class token contracts

--- a/src/spoke/factories/interfaces/IVaultFactory.sol
+++ b/src/spoke/factories/interfaces/IVaultFactory.sol
@@ -4,8 +4,8 @@ pragma solidity 0.8.28;
 import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
 import {IVault} from "src/spoke/interfaces/IVault.sol";
+import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
 
 interface IVaultFactory {
     error UnsupportedTokenId();

--- a/src/spoke/interfaces/IBalanceSheet.sol
+++ b/src/spoke/interfaces/IBalanceSheet.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.5.0;
 
-import {D18, d18} from "src/misc/types/D18.sol";
+import {D18} from "src/misc/types/D18.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
-import {IPoolEscrowProvider} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
-import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
-import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {ISpokeMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
+import {IRoot} from "src/common/interfaces/IRoot.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
+import {ISpokeMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
+import {IPoolEscrowProvider} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
 
 import {ISpoke} from "src/spoke/interfaces/ISpoke.sol";
 

--- a/src/spoke/interfaces/IBalanceSheet.sol
+++ b/src/spoke/interfaces/IBalanceSheet.sol
@@ -3,13 +3,13 @@ pragma solidity >=0.5.0;
 
 import {D18, d18} from "src/misc/types/D18.sol";
 
+import {AssetId} from "src/common/types/AssetId.sol";
+import {IPoolEscrowProvider} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
+import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
 import {IRoot} from "src/common/interfaces/IRoot.sol";
+import {ISpokeMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {ISpokeMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
-import {IPoolEscrowProvider} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
 
 import {ISpoke} from "src/spoke/interfaces/ISpoke.sol";
 

--- a/src/spoke/interfaces/IRequestManager.sol
+++ b/src/spoke/interfaces/IRequestManager.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.5.0;
 
-import {AssetId} from "src/common/types/AssetId.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
 interface IRequestManager {

--- a/src/spoke/interfaces/IRequestManager.sol
+++ b/src/spoke/interfaces/IRequestManager.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.5.0;
 
-import {PoolId} from "src/common/types/PoolId.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
 interface IRequestManager {

--- a/src/spoke/interfaces/ISpoke.sol
+++ b/src/spoke/interfaces/ISpoke.sol
@@ -3,15 +3,15 @@ pragma solidity >=0.5.0;
 
 import {D18, d18} from "src/misc/types/D18.sol";
 
+import {AssetId} from "src/common/types/AssetId.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
 
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
-import {IVaultFactory} from "src/spoke/factories/interfaces/IVaultFactory.sol";
-import {IVault, VaultKind} from "src/spoke/interfaces/IVault.sol";
-import {Price} from "src/spoke/types/Price.sol";
 import {IRequestManager} from "src/spoke/interfaces/IRequestManager.sol";
+import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+import {IVault, VaultKind} from "src/spoke/interfaces/IVault.sol";
+import {IVaultFactory} from "src/spoke/factories/interfaces/IVaultFactory.sol";
+import {Price} from "src/spoke/types/Price.sol";
 
 /// @dev Centrifuge pools
 struct Pool {

--- a/src/spoke/interfaces/ISpoke.sol
+++ b/src/spoke/interfaces/ISpoke.sol
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.5.0;
 
-import {D18, d18} from "src/misc/types/D18.sol";
+import {D18} from "src/misc/types/D18.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
-import {IRequestManager} from "src/spoke/interfaces/IRequestManager.sol";
+import {Price} from "src/spoke/types/Price.sol";
 import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
 import {IVault, VaultKind} from "src/spoke/interfaces/IVault.sol";
+import {IRequestManager} from "src/spoke/interfaces/IRequestManager.sol";
 import {IVaultFactory} from "src/spoke/factories/interfaces/IVaultFactory.sol";
-import {Price} from "src/spoke/types/Price.sol";
 
 /// @dev Centrifuge pools
 struct Pool {

--- a/src/spoke/interfaces/IUpdateContract.sol
+++ b/src/spoke/interfaces/IUpdateContract.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.5.0;
 
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
 interface IUpdateContract {
     error UnknownUpdateContractType();

--- a/src/spoke/interfaces/IVaultManager.sol
+++ b/src/spoke/interfaces/IVaultManager.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.5.0;
 
-import {AssetId} from "src/common/types/AssetId.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
 import {IVault} from "src/spoke/interfaces/IVault.sol";

--- a/src/spoke/interfaces/IVaultManager.sol
+++ b/src/spoke/interfaces/IVaultManager.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.5.0;
 
+import {AssetId} from "src/common/types/AssetId.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
 
 import {IVault} from "src/spoke/interfaces/IVault.sol";
 

--- a/src/spoke/libraries/UpdateContractMessageLib.sol
+++ b/src/spoke/libraries/UpdateContractMessageLib.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 
 enum UpdateContractType {
     /// @dev Placeholder for null update restriction type

--- a/src/vaults/AsyncRequestManager.sol
+++ b/src/vaults/AsyncRequestManager.sol
@@ -2,37 +2,37 @@
 pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {D18, d18} from "src/misc/types/D18.sol";
-import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
 import {Recoverable} from "src/misc/Recoverable.sol";
+import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {MathLib} from "src/misc/libraries/MathLib.sol";
+import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
+import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
-import {ESCROW_HOOK_ID} from "src/common/interfaces/ITransferHook.sol";
-import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
 import {PricingLib} from "src/common/libraries/PricingLib.sol";
-import {RequestCallbackType, RequestCallbackMessageLib} from "src/common/libraries/RequestCallbackMessageLib.sol";
-import {RequestMessageLib} from "src/common/libraries/RequestMessageLib.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
+import {ESCROW_HOOK_ID} from "src/common/interfaces/ITransferHook.sol";
+import {RequestMessageLib} from "src/common/libraries/RequestMessageLib.sol";
+import {RequestCallbackType, RequestCallbackMessageLib} from "src/common/libraries/RequestCallbackMessageLib.sol";
 
-import {IAsyncDepositManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {IAsyncRedeemManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {IAsyncRequestManager, AsyncInvestmentState} from "src/vaults/interfaces/IVaultManagers.sol";
-import {IAsyncVault, IAsyncRedeemVault} from "src/vaults/interfaces/IAsyncVault.sol";
-import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
 import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IDepositManager} from "src/vaults/interfaces/IVaultManagers.sol";
 import {IRedeemManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {IDepositManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {IAsyncRedeemManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {IAsyncDepositManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
+import {IAsyncVault, IAsyncRedeemVault} from "src/vaults/interfaces/IAsyncVault.sol";
+import {IAsyncRequestManager, AsyncInvestmentState} from "src/vaults/interfaces/IVaultManagers.sol";
 
-import {IBalanceSheet} from "src/spoke/interfaces/IBalanceSheet.sol";
-import {IRequestManager} from "src/spoke/interfaces/IRequestManager.sol";
+import {IVault} from "src/spoke/interfaces/IVault.sol";
 import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+import {IBalanceSheet} from "src/spoke/interfaces/IBalanceSheet.sol";
 import {ISpoke, VaultDetails} from "src/spoke/interfaces/ISpoke.sol";
 import {IVaultManager} from "src/spoke/interfaces/IVaultManager.sol";
-import {IVault} from "src/spoke/interfaces/IVault.sol";
+import {IRequestManager} from "src/spoke/interfaces/IRequestManager.sol";
 
 /// @title  Async Request Manager
 /// @notice This is the main contract vaults interact with for

--- a/src/vaults/AsyncRequestManager.sol
+++ b/src/vaults/AsyncRequestManager.sol
@@ -2,38 +2,37 @@
 pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
 import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {D18, d18} from "src/misc/types/D18.sol";
 import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
+import {MathLib} from "src/misc/libraries/MathLib.sol";
 import {Recoverable} from "src/misc/Recoverable.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
-import {PricingLib} from "src/common/libraries/PricingLib.sol";
-import {RequestMessageLib} from "src/common/libraries/RequestMessageLib.sol";
-import {RequestCallbackType, RequestCallbackMessageLib} from "src/common/libraries/RequestCallbackMessageLib.sol";
 import {ESCROW_HOOK_ID} from "src/common/interfaces/ITransferHook.sol";
 import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
+import {PricingLib} from "src/common/libraries/PricingLib.sol";
+import {RequestCallbackType, RequestCallbackMessageLib} from "src/common/libraries/RequestCallbackMessageLib.sol";
+import {RequestMessageLib} from "src/common/libraries/RequestMessageLib.sol";
+import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
-import {ISpoke, VaultDetails} from "src/spoke/interfaces/ISpoke.sol";
-import {IBalanceSheet} from "src/spoke/interfaces/IBalanceSheet.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
-import {IVault} from "src/spoke/interfaces/IVault.sol";
-import {IVaultManager} from "src/spoke/interfaces/IVaultManager.sol";
-import {IRequestManager} from "src/spoke/interfaces/IRequestManager.sol";
-
-import {IAsyncRequestManager, AsyncInvestmentState} from "src/vaults/interfaces/IVaultManagers.sol";
-import {IAsyncRedeemManager} from "src/vaults/interfaces/IVaultManagers.sol";
 import {IAsyncDepositManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {IDepositManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {IRedeemManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {IAsyncRedeemManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {IAsyncRequestManager, AsyncInvestmentState} from "src/vaults/interfaces/IVaultManagers.sol";
+import {IAsyncVault, IAsyncRedeemVault} from "src/vaults/interfaces/IAsyncVault.sol";
 import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
 import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IAsyncVault, IAsyncRedeemVault} from "src/vaults/interfaces/IAsyncVault.sol";
+import {IDepositManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {IRedeemManager} from "src/vaults/interfaces/IVaultManagers.sol";
+
+import {IBalanceSheet} from "src/spoke/interfaces/IBalanceSheet.sol";
+import {IRequestManager} from "src/spoke/interfaces/IRequestManager.sol";
 import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+import {ISpoke, VaultDetails} from "src/spoke/interfaces/ISpoke.sol";
+import {IVaultManager} from "src/spoke/interfaces/IVaultManager.sol";
+import {IVault} from "src/spoke/interfaces/IVault.sol";
 
 /// @title  Async Request Manager
 /// @notice This is the main contract vaults interact with for

--- a/src/vaults/AsyncVault.sol
+++ b/src/vaults/AsyncVault.sol
@@ -9,13 +9,13 @@ import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
-import {BaseAsyncRedeemVault} from "src/vaults/BaseVaults.sol";
 import {BaseVault} from "src/vaults/BaseVaults.sol";
-import {IAsyncRedeemVault, IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
+import {BaseAsyncRedeemVault} from "src/vaults/BaseVaults.sol";
 import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {IAsyncRedeemVault, IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
 
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
 import {VaultKind} from "src/spoke/interfaces/IVault.sol";
+import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
 
 /// @title  AsyncVault
 /// @notice Asynchronous Tokenized Vault standard implementation for Centrifuge pools

--- a/src/vaults/AsyncVault.sol
+++ b/src/vaults/AsyncVault.sol
@@ -3,18 +3,19 @@ pragma solidity 0.8.28;
 
 import "src/misc/interfaces/IERC7540.sol";
 import "src/misc/interfaces/IERC7575.sol";
-import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
 import {IERC20} from "src/misc/interfaces/IERC20.sol";
+import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
 
 import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
-import {IAsyncRedeemVault, IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
-import {VaultKind} from "src/spoke/interfaces/IVault.sol";
-import {BaseVault} from "src/vaults/BaseVaults.sol";
 import {BaseAsyncRedeemVault} from "src/vaults/BaseVaults.sol";
+import {BaseVault} from "src/vaults/BaseVaults.sol";
+import {IAsyncRedeemVault, IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
 import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
+
 import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+import {VaultKind} from "src/spoke/interfaces/IVault.sol";
 
 /// @title  AsyncVault
 /// @notice Asynchronous Tokenized Vault standard implementation for Centrifuge pools

--- a/src/vaults/BaseVaults.sol
+++ b/src/vaults/BaseVaults.sol
@@ -4,26 +4,26 @@ pragma solidity 0.8.28;
 import "src/misc/interfaces/IERC7540.sol";
 import "src/misc/interfaces/IERC7575.sol";
 import {Auth} from "src/misc/Auth.sol";
-import {IERC20Metadata} from "src/misc/interfaces/IERC20.sol";
 import {EIP712Lib} from "src/misc/libraries/EIP712Lib.sol";
-import {SignatureLib} from "src/misc/libraries/SignatureLib.sol";
-import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
+import {IERC20Metadata} from "src/misc/interfaces/IERC20.sol";
+import {IERC7575} from "src/misc/interfaces/IERC7575.sol";
 import {Recoverable} from "src/misc/Recoverable.sol";
+import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
+import {SignatureLib} from "src/misc/libraries/SignatureLib.sol";
 
 import {IRoot} from "src/common/interfaces/IRoot.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IAsyncRedeemVault} from "src/vaults/interfaces/IAsyncVault.sol";
-import {IERC7575} from "src/misc/interfaces/IERC7575.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
 import {IAsyncRedeemManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {ISyncDepositManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {IAsyncRedeemVault} from "src/vaults/interfaces/IAsyncVault.sol";
 import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
+import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
+import {ISyncDepositManager} from "src/vaults/interfaces/IVaultManagers.sol";
+
 import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
-import {IVault} from "src/spoke/interfaces/IVaultManager.sol";
 import {IVaultManager} from "src/spoke/interfaces/IVaultManager.sol";
+import {IVault} from "src/spoke/interfaces/IVaultManager.sol";
 
 abstract contract BaseVault is Auth, Recoverable, IBaseVault {
     /// @dev Requests for Centrifuge pool are non-fungible and all have ID = 0

--- a/src/vaults/BaseVaults.sol
+++ b/src/vaults/BaseVaults.sol
@@ -1,29 +1,29 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
+import {Auth} from "src/misc/Auth.sol";
 import "src/misc/interfaces/IERC7540.sol";
 import "src/misc/interfaces/IERC7575.sol";
-import {Auth} from "src/misc/Auth.sol";
+import {Recoverable} from "src/misc/Recoverable.sol";
+import {IERC7575} from "src/misc/interfaces/IERC7575.sol";
 import {EIP712Lib} from "src/misc/libraries/EIP712Lib.sol";
 import {IERC20Metadata} from "src/misc/interfaces/IERC20.sol";
-import {IERC7575} from "src/misc/interfaces/IERC7575.sol";
-import {Recoverable} from "src/misc/Recoverable.sol";
-import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
 import {SignatureLib} from "src/misc/libraries/SignatureLib.sol";
+import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
 
-import {IRoot} from "src/common/interfaces/IRoot.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {IRoot} from "src/common/interfaces/IRoot.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
-import {IAsyncRedeemManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {IAsyncRedeemVault} from "src/vaults/interfaces/IAsyncVault.sol";
-import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
 import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
+import {IAsyncRedeemVault} from "src/vaults/interfaces/IAsyncVault.sol";
+import {IAsyncRedeemManager} from "src/vaults/interfaces/IVaultManagers.sol";
 import {ISyncDepositManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
 
+import {IVault} from "src/spoke/interfaces/IVaultManager.sol";
 import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
 import {IVaultManager} from "src/spoke/interfaces/IVaultManager.sol";
-import {IVault} from "src/spoke/interfaces/IVaultManager.sol";
 
 abstract contract BaseVault is Auth, Recoverable, IBaseVault {
     /// @dev Requests for Centrifuge pool are non-fungible and all have ID = 0

--- a/src/vaults/SyncDepositVault.sol
+++ b/src/vaults/SyncDepositVault.sol
@@ -6,14 +6,14 @@ import {IERC165} from "src/misc/interfaces/IERC7575.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
-import {BaseAsyncRedeemVault, BaseSyncDepositVault} from "src/vaults/BaseVaults.sol";
 import {BaseVault} from "src/vaults/BaseVaults.sol";
 import {IAsyncRedeemManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
 import {ISyncDepositManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
+import {BaseAsyncRedeemVault, BaseSyncDepositVault} from "src/vaults/BaseVaults.sol";
 
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
 import {VaultKind} from "src/spoke/interfaces/IVault.sol";
+import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
 
 /// @title  SyncDepositVault
 /// @notice Partially (a)synchronous Tokenized Vault implementation with synchronous deposits

--- a/src/vaults/SyncDepositVault.sol
+++ b/src/vaults/SyncDepositVault.sol
@@ -6,12 +6,13 @@ import {IERC165} from "src/misc/interfaces/IERC7575.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
-import {BaseVault} from "src/vaults/BaseVaults.sol";
 import {BaseAsyncRedeemVault, BaseSyncDepositVault} from "src/vaults/BaseVaults.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+import {BaseVault} from "src/vaults/BaseVaults.sol";
 import {IAsyncRedeemManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {ISyncDepositManager} from "src/vaults/interfaces/IVaultManagers.sol";
 import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
+import {ISyncDepositManager} from "src/vaults/interfaces/IVaultManagers.sol";
+
+import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
 import {VaultKind} from "src/spoke/interfaces/IVault.sol";
 
 /// @title  SyncDepositVault

--- a/src/vaults/SyncManager.sol
+++ b/src/vaults/SyncManager.sol
@@ -5,22 +5,23 @@ import {Auth} from "src/misc/Auth.sol";
 import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {d18, D18} from "src/misc/types/D18.sol";
 import {Recoverable} from "src/misc/Recoverable.sol";
+import {d18, D18} from "src/misc/types/D18.sol";
 
-import {UpdateContractMessageLib, UpdateContractType} from "src/spoke/libraries/UpdateContractMessageLib.sol";
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
 import {PricingLib} from "src/common/libraries/PricingLib.sol";
+import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
 import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {ISpoke, VaultDetails} from "src/spoke/interfaces/ISpoke.sol";
-import {IBalanceSheet} from "src/spoke/interfaces/IBalanceSheet.sol";
-import {ISyncManager, ISyncDepositValuation} from "src/vaults/interfaces/IVaultManagers.sol";
 import {IDepositManager} from "src/vaults/interfaces/IVaultManagers.sol";
 import {ISyncDepositManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {ISyncManager, ISyncDepositValuation} from "src/vaults/interfaces/IVaultManagers.sol";
+
+import {IBalanceSheet} from "src/spoke/interfaces/IBalanceSheet.sol";
+import {ISpoke, VaultDetails} from "src/spoke/interfaces/ISpoke.sol";
 import {IUpdateContract} from "src/spoke/interfaces/IUpdateContract.sol";
+import {UpdateContractMessageLib, UpdateContractType} from "src/spoke/libraries/UpdateContractMessageLib.sol";
 
 /// @title  Sync Manager
 /// @notice This is the main contract for synchronous ERC-4626 deposits.

--- a/src/vaults/SyncManager.sol
+++ b/src/vaults/SyncManager.sol
@@ -2,14 +2,14 @@
 pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {D18} from "src/misc/types/D18.sol";
+import {Recoverable} from "src/misc/Recoverable.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {Recoverable} from "src/misc/Recoverable.sol";
-import {d18, D18} from "src/misc/types/D18.sol";
+import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
 import {PricingLib} from "src/common/libraries/PricingLib.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 

--- a/src/vaults/VaultRouter.sol
+++ b/src/vaults/VaultRouter.sol
@@ -2,24 +2,25 @@
 pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
-import {Multicall, IMulticall} from "src/misc/Multicall.sol";
-import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {IERC20, IERC20Permit} from "src/misc/interfaces/IERC20.sol";
 import {IERC7540Deposit} from "src/misc/interfaces/IERC7540.sol";
-import {Recoverable} from "src/misc/Recoverable.sol";
 import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
+import {Multicall, IMulticall} from "src/misc/Multicall.sol";
+import {Recoverable} from "src/misc/Recoverable.sol";
+import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
 
 import {IGateway} from "src/common/interfaces/IGateway.sol";
 import {IMessageDispatcher} from "src/common/interfaces/IMessageDispatcher.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
-import {IVaultRouter} from "src/vaults/interfaces/IVaultRouter.sol";
-import {ISpoke, VaultDetails} from "src/spoke/interfaces/ISpoke.sol";
 import {BaseSyncDepositVault} from "src/vaults/BaseVaults.sol";
+import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
+import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
+import {IVaultRouter} from "src/vaults/interfaces/IVaultRouter.sol";
+
+import {ISpoke, VaultDetails} from "src/spoke/interfaces/ISpoke.sol";
 
 /// @title  VaultRouter
 /// @notice This is a helper contract, designed to be the entrypoint for EOAs.

--- a/src/vaults/VaultRouter.sol
+++ b/src/vaults/VaultRouter.sol
@@ -2,22 +2,22 @@
 pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
+import {Recoverable} from "src/misc/Recoverable.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {IERC20, IERC20Permit} from "src/misc/interfaces/IERC20.sol";
-import {IERC7540Deposit} from "src/misc/interfaces/IERC7540.sol";
 import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
 import {Multicall, IMulticall} from "src/misc/Multicall.sol";
-import {Recoverable} from "src/misc/Recoverable.sol";
+import {IERC7540Deposit} from "src/misc/interfaces/IERC7540.sol";
+import {IERC20, IERC20Permit} from "src/misc/interfaces/IERC20.sol";
 import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
 
-import {IGateway} from "src/common/interfaces/IGateway.sol";
-import {IMessageDispatcher} from "src/common/interfaces/IMessageDispatcher.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {IGateway} from "src/common/interfaces/IGateway.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {IMessageDispatcher} from "src/common/interfaces/IMessageDispatcher.sol";
 
 import {BaseSyncDepositVault} from "src/vaults/BaseVaults.sol";
-import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
 import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
+import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
 import {IVaultRouter} from "src/vaults/interfaces/IVaultRouter.sol";
 
 import {ISpoke, VaultDetails} from "src/spoke/interfaces/ISpoke.sol";

--- a/src/vaults/factories/AsyncVaultFactory.sol
+++ b/src/vaults/factories/AsyncVaultFactory.sol
@@ -9,9 +9,9 @@ import {ShareClassId} from "src/common/types/ShareClassId.sol";
 import {AsyncVault} from "src/vaults/AsyncVault.sol";
 import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
 
+import {IVault} from "src/spoke/interfaces/IVault.sol";
 import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
 import {IVaultFactory} from "src/spoke/factories/interfaces/IVaultFactory.sol";
-import {IVault} from "src/spoke/interfaces/IVault.sol";
 
 /// @title  ERC7540 Vault Factory
 /// @dev    Utility for deploying new vault contracts

--- a/src/vaults/factories/AsyncVaultFactory.sol
+++ b/src/vaults/factories/AsyncVaultFactory.sol
@@ -7,10 +7,11 @@ import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
 import {AsyncVault} from "src/vaults/AsyncVault.sol";
-import {IVaultFactory} from "src/spoke/factories/interfaces/IVaultFactory.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
-import {IVault} from "src/spoke/interfaces/IVault.sol";
 import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
+
+import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+import {IVaultFactory} from "src/spoke/factories/interfaces/IVaultFactory.sol";
+import {IVault} from "src/spoke/interfaces/IVault.sol";
 
 /// @title  ERC7540 Vault Factory
 /// @dev    Utility for deploying new vault contracts

--- a/src/vaults/factories/SyncDepositVaultFactory.sol
+++ b/src/vaults/factories/SyncDepositVaultFactory.sol
@@ -7,13 +7,13 @@ import {IAuth} from "src/misc/interfaces/IAuth.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
+import {SyncDepositVault} from "src/vaults/SyncDepositVault.sol";
 import {IAsyncRedeemManager} from "src/vaults/interfaces/IVaultManagers.sol";
 import {ISyncDepositManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {SyncDepositVault} from "src/vaults/SyncDepositVault.sol";
 
+import {IVault} from "src/spoke/interfaces/IVault.sol";
 import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
 import {IVaultFactory} from "src/spoke/factories/interfaces/IVaultFactory.sol";
-import {IVault} from "src/spoke/interfaces/IVault.sol";
 
 /// @title  Sync Vault Factory
 /// @dev    Utility for deploying new vault contracts

--- a/src/vaults/factories/SyncDepositVaultFactory.sol
+++ b/src/vaults/factories/SyncDepositVaultFactory.sol
@@ -7,11 +7,12 @@ import {IAuth} from "src/misc/interfaces/IAuth.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
-import {SyncDepositVault} from "src/vaults/SyncDepositVault.sol";
-import {IVaultFactory} from "src/spoke/factories/interfaces/IVaultFactory.sol";
 import {IAsyncRedeemManager} from "src/vaults/interfaces/IVaultManagers.sol";
 import {ISyncDepositManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {SyncDepositVault} from "src/vaults/SyncDepositVault.sol";
+
 import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+import {IVaultFactory} from "src/spoke/factories/interfaces/IVaultFactory.sol";
 import {IVault} from "src/spoke/interfaces/IVault.sol";
 
 /// @title  Sync Vault Factory

--- a/src/vaults/interfaces/IAsyncVault.sol
+++ b/src/vaults/interfaces/IAsyncVault.sol
@@ -3,8 +3,8 @@ pragma solidity >=0.5.0;
 
 import {IERC7540Redeem, IERC7887Redeem, IERC7887Deposit, IERC7540Deposit} from "src/misc/interfaces/IERC7540.sol";
 
-import {IAsyncRedeemManager} from "src/vaults/interfaces/IVaultManagers.sol";
 import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
+import {IAsyncRedeemManager} from "src/vaults/interfaces/IVaultManagers.sol";
 
 /**
  * @title  IAsyncRedeemVault

--- a/src/vaults/interfaces/IBaseRequestManager.sol
+++ b/src/vaults/interfaces/IBaseRequestManager.sol
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {PoolId} from "src/common/types/PoolId.sol";
 import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
 
 import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
-
-import {ISpoke} from "src/spoke/interfaces/ISpoke.sol";
-import {IVaultManager} from "src/spoke/interfaces/IVaultManager.sol";
-import {IRequestManager} from "src/spoke/interfaces/IRequestManager.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
 
 import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
+
+import {IRequestManager} from "src/spoke/interfaces/IRequestManager.sol";
+import {ISpoke} from "src/spoke/interfaces/ISpoke.sol";
+import {IVaultManager} from "src/spoke/interfaces/IVaultManager.sol";
 
 interface IBaseRequestManager is IVaultManager, IRequestManager {
     event File(bytes32 indexed what, address data);

--- a/src/vaults/interfaces/IBaseRequestManager.sol
+++ b/src/vaults/interfaces/IBaseRequestManager.sol
@@ -3,14 +3,14 @@ pragma solidity 0.8.28;
 
 import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
 
-import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
 
 import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
 
-import {IRequestManager} from "src/spoke/interfaces/IRequestManager.sol";
 import {ISpoke} from "src/spoke/interfaces/ISpoke.sol";
 import {IVaultManager} from "src/spoke/interfaces/IVaultManager.sol";
+import {IRequestManager} from "src/spoke/interfaces/IRequestManager.sol";
 
 interface IBaseRequestManager is IVaultManager, IRequestManager {
     event File(bytes32 indexed what, address data);

--- a/src/vaults/interfaces/IBaseVault.sol
+++ b/src/vaults/interfaces/IBaseVault.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.5.0;
 
-import {IERC7540Operator, IERC7714, IERC7741} from "src/misc/interfaces/IERC7540.sol";
 import {IERC7575} from "src/misc/interfaces/IERC7575.sol";
 import {IRecoverable} from "src/misc/interfaces/IRecoverable.sol";
+import {IERC7540Operator, IERC7714, IERC7741} from "src/misc/interfaces/IERC7540.sol";
 
 import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";

--- a/src/vaults/interfaces/IBaseVault.sol
+++ b/src/vaults/interfaces/IBaseVault.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.5.0;
 
-import {IERC7575} from "src/misc/interfaces/IERC7575.sol";
 import {IERC7540Operator, IERC7714, IERC7741} from "src/misc/interfaces/IERC7540.sol";
+import {IERC7575} from "src/misc/interfaces/IERC7575.sol";
 import {IRecoverable} from "src/misc/interfaces/IRecoverable.sol";
 
 import {PoolId} from "src/common/types/PoolId.sol";

--- a/src/vaults/interfaces/IVaultManagers.sol
+++ b/src/vaults/interfaces/IVaultManagers.sol
@@ -3,14 +3,14 @@ pragma solidity 0.8.28;
 
 import {D18} from "src/misc/types/D18.sol";
 
+import {AssetId} from "src/common/types/AssetId.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-
-import {IUpdateContract} from "src/spoke/interfaces/IUpdateContract.sol";
 
 import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
 import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
+
+import {IUpdateContract} from "src/spoke/interfaces/IUpdateContract.sol";
 
 interface IDepositManager {
     /// @notice Processes owner's asset deposit after the epoch has been executed on the corresponding CP instance and

--- a/src/vaults/interfaces/IVaultManagers.sol
+++ b/src/vaults/interfaces/IVaultManagers.sol
@@ -3,12 +3,12 @@ pragma solidity 0.8.28;
 
 import {D18} from "src/misc/types/D18.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
-import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
 import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
+import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
 
 import {IUpdateContract} from "src/spoke/interfaces/IUpdateContract.sol";
 

--- a/src/vaults/interfaces/IVaultRouter.sol
+++ b/src/vaults/interfaces/IVaultRouter.sol
@@ -5,9 +5,10 @@ import {IMulticall} from "src/misc/interfaces/IMulticall.sol";
 
 import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
+
 import {BaseSyncDepositVault} from "src/vaults/BaseVaults.sol";
+import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
+import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
 
 interface IVaultRouter is IMulticall {
     // --- Events ---

--- a/src/vaults/interfaces/IVaultRouter.sol
+++ b/src/vaults/interfaces/IVaultRouter.sol
@@ -7,8 +7,8 @@ import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
 import {BaseSyncDepositVault} from "src/vaults/BaseVaults.sol";
-import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
 import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
+import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
 
 interface IVaultRouter is IMulticall {
     // --- Events ---

--- a/src/vaults/legacy/LegacyVaultAdapter.sol
+++ b/src/vaults/legacy/LegacyVaultAdapter.sol
@@ -5,11 +5,11 @@ import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
 import {AsyncVault} from "src/vaults/AsyncVault.sol";
-import {BaseAsyncRedeemVault, IAsyncRedeemVault} from "src/vaults/BaseVaults.sol";
+import {ILegacyVault} from "src/vaults/legacy/interfaces/ILegacyVault.sol";
 import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {BaseAsyncRedeemVault, IAsyncRedeemVault} from "src/vaults/BaseVaults.sol";
 import {IInvestmentManager} from "src/vaults/legacy/interfaces/IInvestmentManager.sol";
 import {ILegacyVaultAdapter} from "src/vaults/legacy/interfaces/ILegacyVaultAdapter.sol";
-import {ILegacyVault} from "src/vaults/legacy/interfaces/ILegacyVault.sol";
 
 import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
 

--- a/src/vaults/legacy/LegacyVaultAdapter.sol
+++ b/src/vaults/legacy/LegacyVaultAdapter.sol
@@ -4,13 +4,14 @@ pragma solidity 0.8.28;
 import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
-import {ILegacyVault} from "src/vaults/legacy/interfaces/ILegacyVault.sol";
+import {AsyncVault} from "src/vaults/AsyncVault.sol";
+import {BaseAsyncRedeemVault, IAsyncRedeemVault} from "src/vaults/BaseVaults.sol";
+import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
 import {IInvestmentManager} from "src/vaults/legacy/interfaces/IInvestmentManager.sol";
 import {ILegacyVaultAdapter} from "src/vaults/legacy/interfaces/ILegacyVaultAdapter.sol";
+import {ILegacyVault} from "src/vaults/legacy/interfaces/ILegacyVault.sol";
+
 import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
-import {AsyncVault} from "src/vaults/AsyncVault.sol";
-import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {BaseAsyncRedeemVault, IAsyncRedeemVault} from "src/vaults/BaseVaults.sol";
 
 /// @title  LegacyVaultAdapter
 /// @notice An adapter connecting legacy ERC-7540 vaults from Centrifuge V2 to Centrifuge V3.

--- a/test/common/mocks/MockAdapter.sol
+++ b/test/common/mocks/MockAdapter.sol
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "forge-std/Test.sol";
 import {Auth} from "src/misc/Auth.sol";
 
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
 import {IAdapter} from "src/common/interfaces/IAdapter.sol";
+import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
 
 import "test/common/mocks/Mock.sol";
+
+import "forge-std/Test.sol";
 
 contract MockAdapter is Auth, Mock, IAdapter {
     IMessageHandler public immutable gateway;

--- a/test/common/mocks/MockValuation.sol
+++ b/test/common/mocks/MockValuation.sol
@@ -2,13 +2,13 @@
 pragma solidity 0.8.28;
 
 import {D18, d18} from "src/misc/types/D18.sol";
-import {IERC6909Decimals} from "src/misc/interfaces/IERC6909.sol";
 import {MathLib} from "src/misc/libraries/MathLib.sol";
+import {IERC6909Decimals} from "src/misc/interfaces/IERC6909.sol";
 
 import {AssetId} from "src/common/types/AssetId.sol";
 import {BaseValuation} from "src/common/BaseValuation.sol";
-import {IValuation} from "src/common/interfaces/IValuation.sol";
 import {PricingLib} from "src/common/libraries/PricingLib.sol";
+import {IValuation} from "src/common/interfaces/IValuation.sol";
 
 struct Price {
     D18 value;

--- a/test/common/mocks/MockValuation.sol
+++ b/test/common/mocks/MockValuation.sol
@@ -2,14 +2,13 @@
 pragma solidity 0.8.28;
 
 import {D18, d18} from "src/misc/types/D18.sol";
+import {IERC6909Decimals} from "src/misc/interfaces/IERC6909.sol";
 import {MathLib} from "src/misc/libraries/MathLib.sol";
 
-import {IERC6909Decimals} from "src/misc/interfaces/IERC6909.sol";
-
-import {IValuation} from "src/common/interfaces/IValuation.sol";
-import {BaseValuation} from "src/common/BaseValuation.sol";
-import {PricingLib} from "src/common/libraries/PricingLib.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
+import {BaseValuation} from "src/common/BaseValuation.sol";
+import {IValuation} from "src/common/interfaces/IValuation.sol";
+import {PricingLib} from "src/common/libraries/PricingLib.sol";
 
 struct Price {
     D18 value;

--- a/test/common/types/AccountId.t.sol
+++ b/test/common/types/AccountId.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "forge-std/Test.sol";
-
 import {AccountId} from "src/common/types/AccountId.sol";
+
+import "forge-std/Test.sol";
 
 contract AccountIdTest is Test {
     function testAccountId(uint32 id) public pure {

--- a/test/common/types/AssetId.t.sol
+++ b/test/common/types/AssetId.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "forge-std/Test.sol";
-
 import {AssetId, newAssetId} from "src/common/types/AssetId.sol";
+
+import "forge-std/Test.sol";
 
 contract AssetIdTest is Test {
     function testAssetId(uint32 counter, uint16 centrifugeId) public pure {

--- a/test/common/types/PoolId.t.sol
+++ b/test/common/types/PoolId.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "forge-std/Test.sol";
-
 import {PoolId, newPoolId} from "src/common/types/PoolId.sol";
+
+import "forge-std/Test.sol";
 
 contract PoolIdTest is Test {
     function testPoolId(uint48 id, uint16 centrifugeId) public pure {

--- a/test/common/types/ShareClassId.t.sol
+++ b/test/common/types/ShareClassId.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {PoolId, newPoolId} from "src/common/types/PoolId.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId, newShareClassId} from "src/common/types/ShareClassId.sol";
 
 import "forge-std/Test.sol";

--- a/test/common/types/ShareClassId.t.sol
+++ b/test/common/types/ShareClassId.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "forge-std/Test.sol";
-
-import {ShareClassId, newShareClassId} from "src/common/types/ShareClassId.sol";
 import {PoolId, newPoolId} from "src/common/types/PoolId.sol";
+import {ShareClassId, newShareClassId} from "src/common/types/ShareClassId.sol";
+
+import "forge-std/Test.sol";
 
 contract ShareClassIdTest is Test {
     function testShareClassId(bytes16 id) public pure {

--- a/test/common/unit/AxelarAdapter.t.sol
+++ b/test/common/unit/AxelarAdapter.t.sol
@@ -1,12 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
 
-import {AxelarAdapter, IAdapter, IAxelarAdapter, IAxelarExecutable} from "src/common/adapters/AxelarAdapter.sol";
 import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
+import {AxelarAdapter, IAdapter, IAxelarExecutable} from "src/common/adapters/AxelarAdapter.sol";
 
 import {Mock} from "test/common/mocks/Mock.sol";
 

--- a/test/common/unit/AxelarAdapter.t.sol
+++ b/test/common/unit/AxelarAdapter.t.sol
@@ -1,15 +1,16 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "forge-std/Test.sol";
-
 import {BytesLib} from "src/misc/libraries/BytesLib.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {Mock} from "test/common/mocks/Mock.sol";
-
 import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {IAuth} from "src/misc/interfaces/IAuth.sol";
+
 import {AxelarAdapter, IAdapter, IAxelarAdapter, IAxelarExecutable} from "src/common/adapters/AxelarAdapter.sol";
 import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
+
+import {Mock} from "test/common/mocks/Mock.sol";
+
+import "forge-std/Test.sol";
 
 contract MockAxelarGateway is Mock {
     function validateContractCall(bytes32, string calldata, string calldata, bytes32) public view returns (bool) {

--- a/test/common/unit/GasService.t.sol
+++ b/test/common/unit/GasService.t.sol
@@ -1,11 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-
-import {GasService, IGasService} from "src/common/GasService.sol";
-import {IMessageProperties} from "src/common/interfaces/IMessageProperties.sol";
-import {MessageType, MessageLib} from "src/common/libraries/MessageLib.sol";
+import {GasService} from "src/common/GasService.sol";
+import {MessageLib} from "src/common/libraries/MessageLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/unit/GasService.t.sol
+++ b/test/common/unit/GasService.t.sol
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "forge-std/Test.sol";
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
+
+import {GasService, IGasService} from "src/common/GasService.sol";
 import {IMessageProperties} from "src/common/interfaces/IMessageProperties.sol";
 import {MessageType, MessageLib} from "src/common/libraries/MessageLib.sol";
-import {GasService, IGasService} from "src/common/GasService.sol";
+
+import "forge-std/Test.sol";
 
 contract GasServiceTest is Test {
     using MessageLib for *;

--- a/test/common/unit/Gateway.t.sol
+++ b/test/common/unit/Gateway.t.sol
@@ -8,13 +8,10 @@ import {TransientArrayLib} from "src/misc/libraries/TransientArrayLib.sol";
 import {TransientBytesLib} from "src/misc/libraries/TransientBytesLib.sol";
 import {TransientStorageLib} from "src/misc/libraries/TransientStorageLib.sol";
 
-import {Gateway, IRoot, IGasService, IGateway} from "src/common/Gateway.sol";
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
-import {IMessageProcessor} from "src/common/interfaces/IMessageProcessor.sol";
-import {IMessageProperties} from "src/common/interfaces/IMessageProperties.sol";
-import {MessageProofLib} from "src/common/libraries/MessageProofLib.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {IAdapter} from "src/common/interfaces/IAdapter.sol";
+import {Gateway, IRoot, IGasService, IGateway} from "src/common/Gateway.sol";
+import {IMessageProperties} from "src/common/interfaces/IMessageProperties.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/unit/Gateway.t.sol
+++ b/test/common/unit/Gateway.t.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "forge-std/Test.sol";
-
 import {Auth, IAuth} from "src/misc/Auth.sol";
 import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 import {Recoverable, IRecoverable} from "src/misc/Recoverable.sol";
@@ -12,11 +10,13 @@ import {TransientStorageLib} from "src/misc/libraries/TransientStorageLib.sol";
 
 import {Gateway, IRoot, IGasService, IGateway} from "src/common/Gateway.sol";
 import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {PoolId} from "src/common/types/PoolId.sol";
-import {IMessageProperties} from "src/common/interfaces/IMessageProperties.sol";
-import {IMessageProcessor} from "src/common/interfaces/IMessageProcessor.sol";
 import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
+import {IMessageProcessor} from "src/common/interfaces/IMessageProcessor.sol";
+import {IMessageProperties} from "src/common/interfaces/IMessageProperties.sol";
 import {MessageProofLib} from "src/common/libraries/MessageProofLib.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
+
+import "forge-std/Test.sol";
 
 // -----------------------------------------
 //     MESSAGE MOCKING

--- a/test/common/unit/MultiAdapter.t.sol
+++ b/test/common/unit/MultiAdapter.t.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth, IAuth} from "src/misc/Auth.sol";
+import {IAuth} from "src/misc/Auth.sol";
 import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 
 import {IAdapter} from "src/common/interfaces/IAdapter.sol";
+import {MultiAdapter} from "src/common/adapters/MultiAdapter.sol";
+import {MessageProofLib} from "src/common/libraries/MessageProofLib.sol";
 import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
 import {IMultiAdapter, MAX_ADAPTER_COUNT} from "src/common/interfaces/adapters/IMultiAdapter.sol";
-import {MessageProofLib} from "src/common/libraries/MessageProofLib.sol";
-import {MultiAdapter} from "src/common/adapters/MultiAdapter.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/unit/MultiAdapter.t.sol
+++ b/test/common/unit/MultiAdapter.t.sol
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "forge-std/Test.sol";
-
 import {Auth, IAuth} from "src/misc/Auth.sol";
 import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 
-import {MultiAdapter} from "src/common/adapters/MultiAdapter.sol";
-import {IMultiAdapter, MAX_ADAPTER_COUNT} from "src/common/interfaces/adapters/IMultiAdapter.sol";
 import {IAdapter} from "src/common/interfaces/IAdapter.sol";
 import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
+import {IMultiAdapter, MAX_ADAPTER_COUNT} from "src/common/interfaces/adapters/IMultiAdapter.sol";
 import {MessageProofLib} from "src/common/libraries/MessageProofLib.sol";
+import {MultiAdapter} from "src/common/adapters/MultiAdapter.sol";
+
+import "forge-std/Test.sol";
 
 // -----------------------------------------
 //     MOCKING

--- a/test/common/unit/PoolEscrow.t.sol
+++ b/test/common/unit/PoolEscrow.t.sol
@@ -1,16 +1,17 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "forge-std/Test.sol";
+import {ERC20} from "src/misc/ERC20.sol";
+import {Escrow, IEscrow} from "src/misc/Escrow.sol";
+import {IAuth} from "src/misc/interfaces/IAuth.sol";
+
+import {PoolEscrow, IPoolEscrow} from "src/common/PoolEscrow.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
+import {ShareClassId} from "src/common/types/ShareClassId.sol";
+
 import {MockERC6909} from "test/misc/mocks/MockERC6909.sol";
 
-import {ERC20} from "src/misc/ERC20.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {Escrow, IEscrow} from "src/misc/Escrow.sol";
-
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {PoolId} from "src/common/types/PoolId.sol";
-import {PoolEscrow, IPoolEscrow} from "src/common/PoolEscrow.sol";
+import "forge-std/Test.sol";
 
 contract EscrowTestBase is Test {
     address spender = makeAddr("spender");

--- a/test/common/unit/PoolEscrow.t.sol
+++ b/test/common/unit/PoolEscrow.t.sol
@@ -5,9 +5,9 @@ import {ERC20} from "src/misc/ERC20.sol";
 import {Escrow, IEscrow} from "src/misc/Escrow.sol";
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
 
-import {PoolEscrow, IPoolEscrow} from "src/common/PoolEscrow.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolEscrow, IPoolEscrow} from "src/common/PoolEscrow.sol";
 
 import {MockERC6909} from "test/misc/mocks/MockERC6909.sol";
 

--- a/test/common/unit/TokenRecoverer.t.sol
+++ b/test/common/unit/TokenRecoverer.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import {Auth, IAuth} from "src/misc/Auth.sol";
+import {IAuth} from "src/misc/Auth.sol";
 import {IRecoverable} from "src/misc/interfaces/IRecoverable.sol";
 
 import {IRoot} from "src/common/interfaces/IRoot.sol";

--- a/test/common/unit/WormholeAdapter.t.sol
+++ b/test/common/unit/WormholeAdapter.t.sol
@@ -1,17 +1,18 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "forge-std/Test.sol";
-
 import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
+
+import {IAdapter} from "src/common/interfaces/IAdapter.sol";
+import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
+import {IWormholeAdapter} from "src/common/interfaces/adapters/IWormholeAdapter.sol";
+import {WormholeAdapter} from "src/common/adapters/WormholeAdapter.sol";
+
 import {Mock} from "test/common/mocks/Mock.sol";
 
-import {WormholeAdapter} from "src/common/adapters/WormholeAdapter.sol";
-import {IWormholeAdapter} from "src/common/interfaces/adapters/IWormholeAdapter.sol";
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
+import "forge-std/Test.sol";
 
 contract MockWormholeDeliveryProvider {
     uint16 public immutable chainId = 2;

--- a/test/common/unit/WormholeAdapter.t.sol
+++ b/test/common/unit/WormholeAdapter.t.sol
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {CastLib} from "src/misc/libraries/CastLib.sol";
 
 import {IAdapter} from "src/common/interfaces/IAdapter.sol";
+import {WormholeAdapter} from "src/common/adapters/WormholeAdapter.sol";
 import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
 import {IWormholeAdapter} from "src/common/interfaces/adapters/IWormholeAdapter.sol";
-import {WormholeAdapter} from "src/common/adapters/WormholeAdapter.sol";
 
 import {Mock} from "test/common/mocks/Mock.sol";
 

--- a/test/common/unit/factories/PoolEscrowFactory.t.sol
+++ b/test/common/unit/factories/PoolEscrowFactory.t.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "forge-std/Test.sol";
-
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {PoolEscrow} from "src/common/PoolEscrow.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
 import {IPoolEscrowFactory} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
 import {PoolEscrowFactory} from "src/common/factories/PoolEscrowFactory.sol";
+import {PoolEscrow} from "src/common/PoolEscrow.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
+
+import "forge-std/Test.sol";
 
 contract PoolEscrowFactoryTest is Test {
     PoolEscrowFactory factory;

--- a/test/common/unit/factories/PoolEscrowFactory.t.sol
+++ b/test/common/unit/factories/PoolEscrowFactory.t.sol
@@ -3,10 +3,10 @@ pragma solidity 0.8.28;
 
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
 
-import {IPoolEscrowFactory} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
-import {PoolEscrowFactory} from "src/common/factories/PoolEscrowFactory.sol";
-import {PoolEscrow} from "src/common/PoolEscrow.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {PoolEscrow} from "src/common/PoolEscrow.sol";
+import {PoolEscrowFactory} from "src/common/factories/PoolEscrowFactory.sol";
+import {IPoolEscrowFactory} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/unit/libraries/MessageLib.t.sol
+++ b/test/common/unit/libraries/MessageLib.t.sol
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {AccountId} from "src/common/types/AccountId.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
 import {MessageProofLib} from "src/common/libraries/MessageProofLib.sol";
 import {MessageType, MessageLib} from "src/common/libraries/MessageLib.sol";
-import {PoolId} from "src/common/types/PoolId.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/unit/libraries/MessageLib.t.sol
+++ b/test/common/unit/libraries/MessageLib.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {MessageType, MessageLib} from "src/common/libraries/MessageLib.sol";
 import {AccountId} from "src/common/types/AccountId.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
-import {PoolId} from "src/common/types/PoolId.sol";
 import {MessageProofLib} from "src/common/libraries/MessageProofLib.sol";
+import {MessageType, MessageLib} from "src/common/libraries/MessageLib.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/hooks/integration/FreelyTransferable.t.sol
+++ b/test/hooks/integration/FreelyTransferable.t.sol
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "test/spoke/BaseTest.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {RedemptionRestrictions} from "src/hooks/RedemptionRestrictions.sol";
+
 import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
+
+import {RedemptionRestrictions} from "src/hooks/RedemptionRestrictions.sol";
+
+import "test/spoke/BaseTest.sol";
 
 contract RedemptionRestrictionsTest is BaseTest {
     using CastLib for *;

--- a/test/hooks/mocks/MockSnapshotHook.sol
+++ b/test/hooks/mocks/MockSnapshotHook.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {ISnapshotHook} from "src/common/interfaces/ISnapshotHook.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {ISnapshotHook} from "src/common/interfaces/ISnapshotHook.sol";
 
 contract MockSnapshotHook is ISnapshotHook {
     mapping(PoolId => mapping(ShareClassId => mapping(uint16 centrifugeId => uint256 counter))) public synced;

--- a/test/hooks/unit/libraries/UpdateRestrictionManagerLib.t.sol
+++ b/test/hooks/unit/libraries/UpdateRestrictionManagerLib.t.sol
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {UpdateRestrictionType, UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 import {AccountId} from "src/common/types/AccountId.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+
+import {UpdateRestrictionType, UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/hooks/unit/libraries/UpdateRestrictionManagerLib.t.sol
+++ b/test/hooks/unit/libraries/UpdateRestrictionManagerLib.t.sol
@@ -1,11 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {AccountId} from "src/common/types/AccountId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {PoolId} from "src/common/types/PoolId.sol";
-
-import {UpdateRestrictionType, UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/hub/integration/BaseTest.sol
+++ b/test/hub/integration/BaseTest.sol
@@ -1,30 +1,31 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import "forge-std/Test.sol";
-
-import {D18, d18} from "src/misc/types/D18.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
+import {D18, d18} from "src/misc/types/D18.sol";
 import {IMulticall} from "src/misc/interfaces/IMulticall.sol";
+import {MathLib} from "src/misc/libraries/MathLib.sol";
 
-import {IValuation} from "src/common/interfaces/IValuation.sol";
-import {PricingLib} from "src/common/libraries/PricingLib.sol";
-import {MessageLib, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {AssetId, newAssetId} from "src/common/types/AssetId.sol";
-import {PoolId} from "src/common/types/PoolId.sol";
 import {AccountId} from "src/common/types/AccountId.sol";
+import {AssetId, newAssetId} from "src/common/types/AssetId.sol";
+import {IAdapter} from "src/common/interfaces/IAdapter.sol";
 import {IGasService} from "src/common/interfaces/IGasService.sol";
+import {IValuation} from "src/common/interfaces/IValuation.sol";
+import {MessageLib, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
+import {PricingLib} from "src/common/libraries/PricingLib.sol";
+import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
-import {HubDeployer, ISafe} from "script/HubDeployer.s.sol";
-import {MESSAGE_COST_ENV} from "script/CommonDeployer.s.sol";
 import {AccountType} from "src/hub/interfaces/IHub.sol";
 import {JournalEntry} from "src/hub/interfaces/IAccounting.sol";
 
-import {MockVaults} from "test/hub/mocks/MockVaults.sol";
+import {HubDeployer, ISafe} from "script/HubDeployer.s.sol";
+import {MESSAGE_COST_ENV} from "script/CommonDeployer.s.sol";
+
 import {MockValuation} from "test/common/mocks/MockValuation.sol";
+import {MockVaults} from "test/hub/mocks/MockVaults.sol";
+
+import "forge-std/Test.sol";
 
 contract BaseTest is HubDeployer, Test {
     uint16 constant CHAIN_CP = 5;

--- a/test/hub/integration/BaseTest.sol
+++ b/test/hub/integration/BaseTest.sol
@@ -1,29 +1,17 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {D18, d18} from "src/misc/types/D18.sol";
-import {IMulticall} from "src/misc/interfaces/IMulticall.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
 
+import {PoolId} from "src/common/types/PoolId.sol";
 import {AccountId} from "src/common/types/AccountId.sol";
 import {AssetId, newAssetId} from "src/common/types/AssetId.sol";
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {IGasService} from "src/common/interfaces/IGasService.sol";
-import {IValuation} from "src/common/interfaces/IValuation.sol";
-import {MessageLib, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
-import {PoolId} from "src/common/types/PoolId.sol";
-import {PricingLib} from "src/common/libraries/PricingLib.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-
-import {AccountType} from "src/hub/interfaces/IHub.sol";
-import {JournalEntry} from "src/hub/interfaces/IAccounting.sol";
 
 import {HubDeployer, ISafe} from "script/HubDeployer.s.sol";
 import {MESSAGE_COST_ENV} from "script/CommonDeployer.s.sol";
 
-import {MockValuation} from "test/common/mocks/MockValuation.sol";
 import {MockVaults} from "test/hub/mocks/MockVaults.sol";
+import {MockValuation} from "test/common/mocks/MockValuation.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/hub/integration/BatchingAndPayment.t.sol
+++ b/test/hub/integration/BatchingAndPayment.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import "test/hub/integration/BaseTest.sol";
-
 import {IGateway} from "src/common/interfaces/IGateway.sol";
+
+import "test/hub/integration/BaseTest.sol";
 
 contract TestBatchingAndPayment is BaseTest {
     /// Test the following:

--- a/test/hub/integration/BatchingAndPayment.t.sol
+++ b/test/hub/integration/BatchingAndPayment.t.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import {IGateway} from "src/common/interfaces/IGateway.sol";
-
 import "test/hub/integration/BaseTest.sol";
 
 contract TestBatchingAndPayment is BaseTest {

--- a/test/hub/integration/Cases.t.sol
+++ b/test/hub/integration/Cases.t.sol
@@ -1,6 +1,16 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
+import {D18, d18} from "src/misc/types/D18.sol";
+import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {MathLib} from "src/misc/libraries/MathLib.sol";
+
+import {PoolId} from "src/common/types/PoolId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
+import {MessageLib} from "src/common/libraries/MessageLib.sol";
+import {PricingLib} from "src/common/libraries/PricingLib.sol";
+import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
 import {RequestCallbackMessageLib} from "src/common/libraries/RequestCallbackMessageLib.sol";
 
 import "test/hub/integration/BaseTest.sol";

--- a/test/hub/mocks/MockVaults.sol
+++ b/test/hub/mocks/MockVaults.sol
@@ -2,20 +2,17 @@
 pragma solidity ^0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
-
-import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {BytesLib} from "src/misc/libraries/BytesLib.sol";
-
-import {MessageLib} from "src/common/libraries/MessageLib.sol";
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
-import {RequestMessageLib} from "src/common/libraries/RequestMessageLib.sol";
-
-import {AssetId} from "src/common/types/AssetId.sol";
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {D18, d18} from "src/misc/types/D18.sol";
 
+import {AssetId} from "src/common/types/AssetId.sol";
 import {IAdapter} from "src/common/interfaces/IAdapter.sol";
+import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
+import {MessageLib} from "src/common/libraries/MessageLib.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
+import {RequestMessageLib} from "src/common/libraries/RequestMessageLib.sol";
+import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/hub/mocks/MockVaults.sol
+++ b/test/hub/mocks/MockVaults.sol
@@ -2,17 +2,17 @@
 pragma solidity ^0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {D18} from "src/misc/types/D18.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {D18, d18} from "src/misc/types/D18.sol";
+import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 
+import {PoolId} from "src/common/types/PoolId.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
 import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
 import {MessageLib} from "src/common/libraries/MessageLib.sol";
-import {PoolId} from "src/common/types/PoolId.sol";
-import {RequestMessageLib} from "src/common/libraries/RequestMessageLib.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
+import {RequestMessageLib} from "src/common/libraries/RequestMessageLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/hub/unit/Accounting.t.sol
+++ b/test/hub/unit/Accounting.t.sol
@@ -1,13 +1,15 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "forge-std/Test.sol";
-
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {PoolId} from "src/common/types/PoolId.sol";
+
 import {AccountId} from "src/common/types/AccountId.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
+
 import {Accounting} from "src/hub/Accounting.sol";
 import {IAccounting, JournalEntry} from "src/hub/interfaces/IAccounting.sol";
+
+import "forge-std/Test.sol";
 
 enum AccountType {
     Asset,

--- a/test/hub/unit/Accounting.t.sol
+++ b/test/hub/unit/Accounting.t.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.28;
 
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
 
-import {AccountId} from "src/common/types/AccountId.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {AccountId} from "src/common/types/AccountId.sol";
 
 import {Accounting} from "src/hub/Accounting.sol";
 import {IAccounting, JournalEntry} from "src/hub/interfaces/IAccounting.sol";

--- a/test/hub/unit/Holdings.t.sol
+++ b/test/hub/unit/Holdings.t.sol
@@ -1,20 +1,21 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import "forge-std/Test.sol";
-
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
 import {d18} from "src/misc/types/D18.sol";
 
+import {AccountId} from "src/common/types/AccountId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
 import {IValuation} from "src/common/interfaces/IValuation.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {AccountId} from "src/common/types/AccountId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {Holdings} from "src/hub/Holdings.sol";
-import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
+
 import {AccountType} from "src/hub/interfaces/IHub.sol";
+import {Holdings} from "src/hub/Holdings.sol";
 import {IHoldings, HoldingAccount} from "src/hub/interfaces/IHoldings.sol";
+import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
+
+import "forge-std/Test.sol";
 
 PoolId constant POOL_A = PoolId.wrap(42);
 ShareClassId constant SC_1 = ShareClassId.wrap(bytes16("1"));

--- a/test/hub/unit/Holdings.t.sol
+++ b/test/hub/unit/Holdings.t.sol
@@ -1,19 +1,18 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
 import {d18} from "src/misc/types/D18.sol";
+import {IAuth} from "src/misc/interfaces/IAuth.sol";
 
-import {AccountId} from "src/common/types/AccountId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {IValuation} from "src/common/interfaces/IValuation.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
+import {AccountId} from "src/common/types/AccountId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {IValuation} from "src/common/interfaces/IValuation.sol";
 
-import {AccountType} from "src/hub/interfaces/IHub.sol";
 import {Holdings} from "src/hub/Holdings.sol";
-import {IHoldings, HoldingAccount} from "src/hub/interfaces/IHoldings.sol";
 import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
+import {IHoldings, HoldingAccount} from "src/hub/interfaces/IHoldings.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/hub/unit/Hub.t.sol
+++ b/test/hub/unit/Hub.t.sol
@@ -1,26 +1,26 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import "forge-std/Test.sol";
-
 import {D18} from "src/misc/types/D18.sol";
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
 
-import {IValuation} from "src/common/interfaces/IValuation.sol";
-import {IGateway} from "src/common/interfaces/IGateway.sol";
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
 import {AccountId} from "src/common/types/AccountId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
+import {IGateway} from "src/common/interfaces/IGateway.sol";
 import {ISnapshotHook} from "src/common/interfaces/ISnapshotHook.sol";
+import {IValuation} from "src/common/interfaces/IValuation.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
+import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
-import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
-import {IHoldings} from "src/hub/interfaces/IHoldings.sol";
+import {Hub} from "src/hub/Hub.sol";
 import {IAccounting, JournalEntry} from "src/hub/interfaces/IAccounting.sol";
-import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
+import {IHoldings} from "src/hub/interfaces/IHoldings.sol";
 import {IHub, VaultUpdateKind} from "src/hub/interfaces/IHub.sol";
 import {IHubHelpers} from "src/hub/interfaces/IHubHelpers.sol";
-import {Hub} from "src/hub/Hub.sol";
+import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
+import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
+
+import "forge-std/Test.sol";
 
 contract TestCommon is Test {
     uint16 constant CHAIN_A = 23;

--- a/test/hub/unit/Hub.t.sol
+++ b/test/hub/unit/Hub.t.sol
@@ -4,20 +4,20 @@ pragma solidity ^0.8.28;
 import {D18} from "src/misc/types/D18.sol";
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
 
-import {AccountId} from "src/common/types/AccountId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {IGateway} from "src/common/interfaces/IGateway.sol";
-import {ISnapshotHook} from "src/common/interfaces/ISnapshotHook.sol";
-import {IValuation} from "src/common/interfaces/IValuation.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
+import {AccountId} from "src/common/types/AccountId.sol";
+import {IGateway} from "src/common/interfaces/IGateway.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {IValuation} from "src/common/interfaces/IValuation.sol";
+import {ISnapshotHook} from "src/common/interfaces/ISnapshotHook.sol";
 
 import {Hub} from "src/hub/Hub.sol";
-import {IAccounting, JournalEntry} from "src/hub/interfaces/IAccounting.sol";
 import {IHoldings} from "src/hub/interfaces/IHoldings.sol";
-import {IHub, VaultUpdateKind} from "src/hub/interfaces/IHub.sol";
 import {IHubHelpers} from "src/hub/interfaces/IHubHelpers.sol";
 import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
+import {IHub, VaultUpdateKind} from "src/hub/interfaces/IHub.sol";
+import {IAccounting, JournalEntry} from "src/hub/interfaces/IAccounting.sol";
 import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
 
 import "forge-std/Test.sol";

--- a/test/hub/unit/HubHelpers.t.sol
+++ b/test/hub/unit/HubHelpers.t.sol
@@ -3,15 +3,14 @@ pragma solidity ^0.8.28;
 
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
-import {IHubMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {IHubMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
 
 import {HubHelpers} from "src/hub/HubHelpers.sol";
-import {Hub} from "src/hub/Hub.sol";
-import {IAccounting} from "src/hub/interfaces/IAccounting.sol";
 import {IHoldings} from "src/hub/interfaces/IHoldings.sol";
+import {IAccounting} from "src/hub/interfaces/IAccounting.sol";
 import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
 import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
 

--- a/test/hub/unit/HubHelpers.t.sol
+++ b/test/hub/unit/HubHelpers.t.sol
@@ -1,20 +1,21 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import "forge-std/Test.sol";
-
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
-import {IHoldings} from "src/hub/interfaces/IHoldings.sol";
-import {IAccounting} from "src/hub/interfaces/IAccounting.sol";
 import {IHubMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
-import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
-import {Hub} from "src/hub/Hub.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
+import {ShareClassId} from "src/common/types/ShareClassId.sol";
+
 import {HubHelpers} from "src/hub/HubHelpers.sol";
+import {Hub} from "src/hub/Hub.sol";
+import {IAccounting} from "src/hub/interfaces/IAccounting.sol";
+import {IHoldings} from "src/hub/interfaces/IHoldings.sol";
+import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
+import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
+
+import "forge-std/Test.sol";
 
 contract TestCommon is Test {
     IHoldings immutable holdings = IHoldings(makeAddr("Holdings"));

--- a/test/hub/unit/HubRegistry.t.sol
+++ b/test/hub/unit/HubRegistry.t.sol
@@ -1,17 +1,18 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "forge-std/Test.sol";
-
-import {MathLib} from "src/misc/libraries/MathLib.sol";
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {MathLib} from "src/misc/libraries/MathLib.sol";
 
-import {PoolId, newPoolId} from "src/common/types/PoolId.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
+import {PoolId, newPoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
+
 import {HubRegistry} from "src/hub/HubRegistry.sol";
 import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
 import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
+
+import "forge-std/Test.sol";
 
 contract HubRegistryTest is Test {
     using MathLib for uint256;

--- a/test/hub/unit/ShareClassManager.t.sol
+++ b/test/hub/unit/ShareClassManager.t.sol
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {D18, d18} from "src/misc/types/D18.sol";
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {MathLib} from "src/misc/libraries/MathLib.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
 import {PricingLib} from "src/common/libraries/PricingLib.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
+import {ShareClassManager} from "src/hub/ShareClassManager.sol";
 import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
 import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
-import {ShareClassManager} from "src/hub/ShareClassManager.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/hub/unit/ShareClassManager.t.sol
+++ b/test/hub/unit/ShareClassManager.t.sol
@@ -1,18 +1,21 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import "forge-std/Test.sol";
-
-import {MathLib} from "src/misc/libraries/MathLib.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {D18, d18} from "src/misc/types/D18.sol";
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {MathLib} from "src/misc/libraries/MathLib.sol";
 
-import {PricingLib} from "src/common/libraries/PricingLib.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
+import {PricingLib} from "src/common/libraries/PricingLib.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
+
+import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
+import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
+import {ShareClassManager} from "src/hub/ShareClassManager.sol";
+
+import "forge-std/Test.sol";
 
 import {
     IShareClassManager,
@@ -24,9 +27,6 @@ import {
     QueuedOrder,
     RequestType
 } from "src/hub/interfaces/IShareClassManager.sol";
-import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
-import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
-import {ShareClassManager} from "src/hub/ShareClassManager.sol";
 
 uint16 constant CHAIN_ID = 1;
 uint64 constant POOL_ID = 42;

--- a/test/integration/EndToEnd.t.sol
+++ b/test/integration/EndToEnd.t.sol
@@ -1,57 +1,57 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import "forge-std/Test.sol";
-
-import {ERC20} from "src/misc/ERC20.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {IdentityValuation} from "src/misc/IdentityValuation.sol";
 import {D18, d18} from "src/misc/types/D18.sol";
+import {ERC20} from "src/misc/ERC20.sol";
 import {IRecoverable} from "src/misc/interfaces/IRecoverable.sol";
+import {IdentityValuation} from "src/misc/IdentityValuation.sol";
 import {MathLib} from "src/misc/libraries/MathLib.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId, newAssetId} from "src/common/types/AssetId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
 import {AccountId} from "src/common/types/AccountId.sol";
-import {ISafe} from "src/common/interfaces/IGuardian.sol";
-import {Guardian} from "src/common/Guardian.sol";
-import {Root} from "src/common/Root.sol";
+import {AssetId, newAssetId} from "src/common/types/AssetId.sol";
 import {Gateway} from "src/common/Gateway.sol";
+import {Guardian} from "src/common/Guardian.sol";
+import {ISafe} from "src/common/interfaces/IGuardian.sol";
 import {MessageLib, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
 import {PricingLib} from "src/common/libraries/PricingLib.sol";
+import {Root} from "src/common/Root.sol";
+import {ShareClassId} from "src/common/types/ShareClassId.sol";
+
+import {AsyncRequestManager} from "src/vaults/AsyncRequestManager.sol";
+import {AsyncVaultFactory} from "src/vaults/factories/AsyncVaultFactory.sol";
+import {IAsyncRedeemVault} from "src/vaults/interfaces/IAsyncVault.sol";
+import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
+import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
+import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
+import {SyncDepositVaultFactory} from "src/vaults/factories/SyncDepositVaultFactory.sol";
+import {SyncDepositVault} from "src/vaults/SyncDepositVault.sol";
+import {SyncManager} from "src/vaults/SyncManager.sol";
+import {VaultRouter} from "src/vaults/VaultRouter.sol";
+
+import {Accounting} from "src/hub/Accounting.sol";
+import {Holdings} from "src/hub/Holdings.sol";
+import {HubRegistry} from "src/hub/HubRegistry.sol";
+import {Hub} from "src/hub/Hub.sol";
+import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
+import {ShareClassManager} from "src/hub/ShareClassManager.sol";
+
+import {BalanceSheet} from "src/spoke/BalanceSheet.sol";
+import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+import {Spoke} from "src/spoke/Spoke.sol";
+import {UpdateContractMessageLib} from "src/spoke/libraries/UpdateContractMessageLib.sol";
 
 import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
-import {Hub} from "src/hub/Hub.sol";
-import {HubRegistry} from "src/hub/HubRegistry.sol";
-import {Accounting} from "src/hub/Accounting.sol";
-import {Holdings} from "src/hub/Holdings.sol";
-import {ShareClassManager} from "src/hub/ShareClassManager.sol";
-import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
-
-import {VaultRouter} from "src/vaults/VaultRouter.sol";
-import {Spoke} from "src/spoke/Spoke.sol";
-import {BalanceSheet} from "src/spoke/BalanceSheet.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
-import {UpdateContractMessageLib} from "src/spoke/libraries/UpdateContractMessageLib.sol";
-
-import {AsyncRequestManager} from "src/vaults/AsyncRequestManager.sol";
-import {SyncManager} from "src/vaults/SyncManager.sol";
-import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
-import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
-import {SyncDepositVault} from "src/vaults/SyncDepositVault.sol";
-import {AsyncVaultFactory} from "src/vaults/factories/AsyncVaultFactory.sol";
-import {SyncDepositVaultFactory} from "src/vaults/factories/SyncDepositVaultFactory.sol";
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IAsyncRedeemVault} from "src/vaults/interfaces/IAsyncVault.sol";
-
-import {FullDeployer, HubDeployer, SpokeDeployer} from "script/FullDeployer.s.sol";
 import {CommonDeployer, MESSAGE_COST_ENV} from "script/CommonDeployer.s.sol";
+import {FullDeployer, HubDeployer, SpokeDeployer} from "script/FullDeployer.s.sol";
 
 import {LocalAdapter} from "test/integration/adapters/LocalAdapter.sol";
-import {MockValuation} from "test/common/mocks/MockValuation.sol";
 import {MockSnapshotHook} from "test/hooks/mocks/MockSnapshotHook.sol";
+import {MockValuation} from "test/common/mocks/MockValuation.sol";
+
+import "forge-std/Test.sol";
 
 /// End to end testing assuming two full deployments in two different chains
 ///

--- a/test/integration/EndToEnd.t.sol
+++ b/test/integration/EndToEnd.t.sol
@@ -1,55 +1,48 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {D18, d18} from "src/misc/types/D18.sol";
 import {ERC20} from "src/misc/ERC20.sol";
-import {IRecoverable} from "src/misc/interfaces/IRecoverable.sol";
-import {IdentityValuation} from "src/misc/IdentityValuation.sol";
+import {D18, d18} from "src/misc/types/D18.sol";
+import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {MathLib} from "src/misc/libraries/MathLib.sol";
+import {IdentityValuation} from "src/misc/IdentityValuation.sol";
 
-import {AccountId} from "src/common/types/AccountId.sol";
-import {AssetId, newAssetId} from "src/common/types/AssetId.sol";
+import {Root} from "src/common/Root.sol";
 import {Gateway} from "src/common/Gateway.sol";
 import {Guardian} from "src/common/Guardian.sol";
-import {ISafe} from "src/common/interfaces/IGuardian.sol";
-import {MessageLib, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {AccountId} from "src/common/types/AccountId.sol";
+import {ISafe} from "src/common/interfaces/IGuardian.sol";
 import {PricingLib} from "src/common/libraries/PricingLib.sol";
-import {Root} from "src/common/Root.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {AssetId, newAssetId} from "src/common/types/AssetId.sol";
+import {VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
 
-import {AsyncRequestManager} from "src/vaults/AsyncRequestManager.sol";
-import {AsyncVaultFactory} from "src/vaults/factories/AsyncVaultFactory.sol";
-import {IAsyncRedeemVault} from "src/vaults/interfaces/IAsyncVault.sol";
-import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
-import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {SyncDepositVaultFactory} from "src/vaults/factories/SyncDepositVaultFactory.sol";
-import {SyncDepositVault} from "src/vaults/SyncDepositVault.sol";
 import {SyncManager} from "src/vaults/SyncManager.sol";
 import {VaultRouter} from "src/vaults/VaultRouter.sol";
+import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
+import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
+import {AsyncRequestManager} from "src/vaults/AsyncRequestManager.sol";
+import {IAsyncRedeemVault} from "src/vaults/interfaces/IAsyncVault.sol";
 
-import {Accounting} from "src/hub/Accounting.sol";
-import {Holdings} from "src/hub/Holdings.sol";
-import {HubRegistry} from "src/hub/HubRegistry.sol";
 import {Hub} from "src/hub/Hub.sol";
-import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
+import {Holdings} from "src/hub/Holdings.sol";
+import {Accounting} from "src/hub/Accounting.sol";
+import {HubRegistry} from "src/hub/HubRegistry.sol";
 import {ShareClassManager} from "src/hub/ShareClassManager.sol";
 
-import {BalanceSheet} from "src/spoke/BalanceSheet.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
 import {Spoke} from "src/spoke/Spoke.sol";
+import {BalanceSheet} from "src/spoke/BalanceSheet.sol";
 import {UpdateContractMessageLib} from "src/spoke/libraries/UpdateContractMessageLib.sol";
 
 import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
-import {CommonDeployer, MESSAGE_COST_ENV} from "script/CommonDeployer.s.sol";
-import {FullDeployer, HubDeployer, SpokeDeployer} from "script/FullDeployer.s.sol";
+import {FullDeployer} from "script/FullDeployer.s.sol";
+import {MESSAGE_COST_ENV} from "script/CommonDeployer.s.sol";
 
-import {LocalAdapter} from "test/integration/adapters/LocalAdapter.sol";
-import {MockSnapshotHook} from "test/hooks/mocks/MockSnapshotHook.sol";
 import {MockValuation} from "test/common/mocks/MockValuation.sol";
+import {MockSnapshotHook} from "test/hooks/mocks/MockSnapshotHook.sol";
+import {LocalAdapter} from "test/integration/adapters/LocalAdapter.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/integration/ThreeChainEndToEnd.t.sol
+++ b/test/integration/ThreeChainEndToEnd.t.sol
@@ -1,18 +1,24 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import {IERC20} from "src/misc/interfaces/IERC20.sol";
-import {IRecoverable} from "src/misc/interfaces/IRecoverable.sol";
+import {CastLib} from "src/misc/libraries/CastLib.sol";
 
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
+import {ISafe} from "src/common/interfaces/IGuardian.sol";
 import {IGateway} from "src/common/interfaces/IGateway.sol";
+import {MessageLib} from "src/common/libraries/MessageLib.sol";
+import {ShareClassId} from "src/common/types/ShareClassId.sol";
 import {IMultiAdapter} from "src/common/interfaces/adapters/IMultiAdapter.sol";
 
 import {IHub} from "src/hub/interfaces/IHub.sol";
 
 import {ISpoke} from "src/spoke/interfaces/ISpoke.sol";
+import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+
+import {FullDeployer} from "script/FullDeployer.s.sol";
 
 import "test/integration/EndToEnd.t.sol";
+import {LocalAdapter} from "test/integration/adapters/LocalAdapter.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/integration/ThreeChainEndToEnd.t.sol
+++ b/test/integration/ThreeChainEndToEnd.t.sol
@@ -1,20 +1,20 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import "forge-std/Test.sol";
-
-import {IRecoverable} from "src/misc/interfaces/IRecoverable.sol";
 import {IERC20} from "src/misc/interfaces/IERC20.sol";
+import {IRecoverable} from "src/misc/interfaces/IRecoverable.sol";
 
 import {IAdapter} from "src/common/interfaces/IAdapter.sol";
 import {IGateway} from "src/common/interfaces/IGateway.sol";
 import {IMultiAdapter} from "src/common/interfaces/adapters/IMultiAdapter.sol";
 
-import {ISpoke} from "src/spoke/interfaces/ISpoke.sol";
-
 import {IHub} from "src/hub/interfaces/IHub.sol";
 
+import {ISpoke} from "src/spoke/interfaces/ISpoke.sol";
+
 import "test/integration/EndToEnd.t.sol";
+
+import "forge-std/Test.sol";
 
 enum CrossChainDirection {
     WithIntermediaryHub, // C -> A -> B (Hub is on A)

--- a/test/integration/adapters/LocalAdapter.sol
+++ b/test/integration/adapters/LocalAdapter.sol
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "forge-std/Test.sol";
-
 import {Auth} from "src/misc/Auth.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
+
 import {IAdapter} from "src/common/interfaces/IAdapter.sol";
+import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
+
+import "forge-std/Test.sol";
 
 /// An adapter that sends the message to another MessageHandler and acts as MessageHandler too.
 contract LocalAdapter is Test, Auth, IAdapter, IMessageHandler {

--- a/test/integration/adapters/LocalAdapter.sol
+++ b/test/integration/adapters/LocalAdapter.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.28;
 
 import {Auth} from "src/misc/Auth.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
 
 import {IAdapter} from "src/common/interfaces/IAdapter.sol";
 import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";

--- a/test/managers/integration/OnOfframpManager.t.sol
+++ b/test/managers/integration/OnOfframpManager.t.sol
@@ -1,23 +1,23 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {D18, d18} from "src/misc/types/D18.sol";
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {IERC165} from "src/misc/interfaces/IERC165.sol";
-import {IERC7751} from "src/misc/interfaces/IERC7751.sol";
 import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
+import {IERC7751} from "src/misc/interfaces/IERC7751.sol";
 
 import {AssetId} from "src/common/types/AssetId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
 import {UpdateContractMessageLib} from "src/spoke/libraries/UpdateContractMessageLib.sol";
 
-import {IDepositManager, IWithdrawManager} from "src/managers/interfaces/IBalanceSheetManager.sol";
-import {IOnOfframpManager} from "src/managers/interfaces/IOnOfframpManager.sol";
-import {OnOfframpManagerFactory} from "src/managers/OnOfframpManager.sol";
-
 import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+
+import {OnOfframpManagerFactory} from "src/managers/OnOfframpManager.sol";
+import {IOnOfframpManager} from "src/managers/interfaces/IOnOfframpManager.sol";
+import {IDepositManager, IWithdrawManager} from "src/managers/interfaces/IBalanceSheetManager.sol";
 
 import "test/spoke/BaseTest.sol";
 

--- a/test/managers/integration/OnOfframpManager.t.sol
+++ b/test/managers/integration/OnOfframpManager.t.sol
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import "test/spoke/BaseTest.sol";
+import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {D18, d18} from "src/misc/types/D18.sol";
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {IERC165} from "src/misc/interfaces/IERC165.sol";
 import {IERC7751} from "src/misc/interfaces/IERC7751.sol";
 import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
@@ -14,11 +13,13 @@ import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
 import {UpdateContractMessageLib} from "src/spoke/libraries/UpdateContractMessageLib.sol";
 
-import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
-
-import {OnOfframpManagerFactory} from "src/managers/OnOfframpManager.sol";
 import {IDepositManager, IWithdrawManager} from "src/managers/interfaces/IBalanceSheetManager.sol";
 import {IOnOfframpManager} from "src/managers/interfaces/IOnOfframpManager.sol";
+import {OnOfframpManagerFactory} from "src/managers/OnOfframpManager.sol";
+
+import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+
+import "test/spoke/BaseTest.sol";
 
 abstract contract OnOfframpManagerBaseTest is BaseTest {
     using CastLib for *;

--- a/test/misc/unit/BaseValuation.t.sol
+++ b/test/misc/unit/BaseValuation.t.sol
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.28;
 
-import {D18, d18} from "src/misc/types/D18.sol";
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
 import {IERC6909Decimals} from "src/misc/interfaces/IERC6909.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
 
 import {AssetId} from "src/common/types/AssetId.sol";
 import {BaseValuation} from "src/common/BaseValuation.sol";

--- a/test/misc/unit/BaseValuation.t.sol
+++ b/test/misc/unit/BaseValuation.t.sol
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.28;
 
-import "forge-std/Test.sol";
-
 import {D18, d18} from "src/misc/types/D18.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
 import {IERC6909Decimals} from "src/misc/interfaces/IERC6909.sol";
+import {MathLib} from "src/misc/libraries/MathLib.sol";
 
-import {IBaseValuation} from "src/common/interfaces/IBaseValuation.sol";
-import {BaseValuation} from "src/common/BaseValuation.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
+import {BaseValuation} from "src/common/BaseValuation.sol";
+import {IBaseValuation} from "src/common/interfaces/IBaseValuation.sol";
+
+import "forge-std/Test.sol";
 
 contract BaseValuationImpl is BaseValuation {
     constructor(IERC6909Decimals assetRegistry, address deployer) BaseValuation(assetRegistry, deployer) {}

--- a/test/misc/unit/EIP712Lib.t.sol
+++ b/test/misc/unit/EIP712Lib.t.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "forge-std/Test.sol";
 import "src/misc/libraries/EIP712Lib.sol";
+
+import "forge-std/Test.sol";
 
 contract EIP712LibTest is Test {
     function testCalculateDomainSeparator() public view {

--- a/test/misc/unit/ERC20.t.sol
+++ b/test/misc/unit/ERC20.t.sol
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {IERC20, IERC20Permit} from "src/misc/interfaces/IERC20.sol";
-import {IERC1271} from "src/misc/libraries/SignatureLib.sol";
-
 import {ERC20} from "src/misc/ERC20.sol";
+import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {IERC1271} from "src/misc/libraries/SignatureLib.sol";
+import {IERC20, IERC20Permit} from "src/misc/interfaces/IERC20.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/IdentityValuation.t.sol
+++ b/test/misc/unit/IdentityValuation.t.sol
@@ -1,14 +1,15 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.28;
 
-import "forge-std/Test.sol";
-
 import {D18, d18} from "src/misc/types/D18.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
 import {IdentityValuation} from "src/misc/IdentityValuation.sol";
-import {MockERC6909} from "test/misc/mocks/MockERC6909.sol";
+import {MathLib} from "src/misc/libraries/MathLib.sol";
 
 import {AssetId} from "src/common/types/AssetId.sol";
+
+import {MockERC6909} from "test/misc/mocks/MockERC6909.sol";
+
+import "forge-std/Test.sol";
 
 AssetId constant C6 = AssetId.wrap(6);
 AssetId constant C18 = AssetId.wrap(18);

--- a/test/misc/unit/IdentityValuation.t.sol
+++ b/test/misc/unit/IdentityValuation.t.sol
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.28;
 
-import {D18, d18} from "src/misc/types/D18.sol";
 import {IdentityValuation} from "src/misc/IdentityValuation.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
 
 import {AssetId} from "src/common/types/AssetId.sol";
 

--- a/test/misc/unit/Multicall.t.sol
+++ b/test/misc/unit/Multicall.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.28;
 
-import "forge-std/Test.sol";
-
 import {IMulticall} from "src/misc/interfaces/IMulticall.sol";
 import {Multicall} from "src/misc/Multicall.sol";
 import {ReentrancyProtection} from "src/misc/ReentrancyProtection.sol";
+
+import "forge-std/Test.sol";
 
 contract ExternalContract {
     MulticallImpl public multicall;

--- a/test/misc/unit/Multicall.t.sol
+++ b/test/misc/unit/Multicall.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.28;
 
-import {IMulticall} from "src/misc/interfaces/IMulticall.sol";
 import {Multicall} from "src/misc/Multicall.sol";
+import {IMulticall} from "src/misc/interfaces/IMulticall.sol";
 import {ReentrancyProtection} from "src/misc/ReentrancyProtection.sol";
 
 import "forge-std/Test.sol";

--- a/test/misc/unit/Recoverable.t.sol
+++ b/test/misc/unit/Recoverable.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import {Auth, IAuth} from "src/misc/Auth.sol";
 import {ERC20} from "src/misc/ERC20.sol";
+import {Auth, IAuth} from "src/misc/Auth.sol";
 import {Recoverable} from "src/misc/Recoverable.sol";
 
 import {MockERC6909} from "test/misc/mocks/MockERC6909.sol";

--- a/test/misc/unit/Recoverable.t.sol
+++ b/test/misc/unit/Recoverable.t.sol
@@ -2,11 +2,12 @@
 pragma solidity ^0.8.28;
 
 import {Auth, IAuth} from "src/misc/Auth.sol";
-import {Recoverable} from "src/misc/Recoverable.sol";
 import {ERC20} from "src/misc/ERC20.sol";
+import {Recoverable} from "src/misc/Recoverable.sol";
+
+import {MockERC6909} from "test/misc/mocks/MockERC6909.sol";
 
 import "forge-std/Test.sol";
-import {MockERC6909} from "test/misc/mocks/MockERC6909.sol";
 
 contract RecoverableImpl is Recoverable {
     constructor(address deployer) Auth(deployer) {}

--- a/test/misc/unit/SignatureLib.t.sol
+++ b/test/misc/unit/SignatureLib.t.sol
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "forge-std/Test.sol";
-import "src/misc/libraries/SignatureLib.sol";
 import "src/misc/libraries/EIP712Lib.sol";
+import "src/misc/libraries/SignatureLib.sol";
+
+import "forge-std/Test.sol";
 
 contract MockValidSigner {
     function isValidSignature(bytes32, bytes memory) public pure returns (bytes4) {

--- a/test/misc/unit/libraries/ArrayLib.t.sol
+++ b/test/misc/unit/libraries/ArrayLib.t.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "forge-std/Test.sol";
 import {ArrayLib} from "src/misc/libraries/ArrayLib.sol";
+
+import "forge-std/Test.sol";
 
 contract ArrayLibTest is Test {
     // Used for testDecreaseFirstNValues (which requires storage pointers)

--- a/test/misc/unit/libraries/BytesLib.t.sol
+++ b/test/misc/unit/libraries/BytesLib.t.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "forge-std/Test.sol";
 import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+
+import "forge-std/Test.sol";
 
 contract BytesLibTest is Test {
     function testSlice(bytes memory data, bytes memory randomStart, bytes memory randomEnd) public pure {

--- a/test/misc/unit/libraries/CastLib.t.sol
+++ b/test/misc/unit/libraries/CastLib.t.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "forge-std/Test.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
+
+import "forge-std/Test.sol";
 
 contract CastLibTest is Test {
     function testToAddress(address addr) public pure {

--- a/test/misc/unit/libraries/D18.t.sol
+++ b/test/misc/unit/libraries/D18.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.28;
 
-import "src/misc/libraries/MathLib.sol";
 import "src/misc/types/D18.sol";
+import "src/misc/libraries/MathLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/libraries/D18.t.sol
+++ b/test/misc/unit/libraries/D18.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.28;
 
-import "forge-std/Test.sol";
-
-import "src/misc/types/D18.sol";
 import "src/misc/libraries/MathLib.sol";
+import "src/misc/types/D18.sol";
+
+import "forge-std/Test.sol";
 
 contract D18Test is Test {
     function testFuzzAdd(uint128 a, uint128 b) public pure {

--- a/test/misc/unit/libraries/MathLib.t.sol
+++ b/test/misc/unit/libraries/MathLib.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.28;
 
-import "forge-std/Test.sol";
-
 import "src/misc/libraries/MathLib.sol";
+
+import "forge-std/Test.sol";
 
 contract MathLibTest is Test {
     using MathLib for uint256;

--- a/test/misc/unit/libraries/PricingLib.t.sol
+++ b/test/misc/unit/libraries/PricingLib.t.sol
@@ -2,8 +2,8 @@
 pragma solidity 0.8.28;
 
 import {D18, d18} from "src/misc/types/D18.sol";
-import {IERC20Metadata} from "src/misc/interfaces/IERC20.sol";
 import {MathLib} from "src/misc/libraries/MathLib.sol";
+import {IERC20Metadata} from "src/misc/interfaces/IERC20.sol";
 
 import {PricingLib} from "src/common/libraries/PricingLib.sol";
 

--- a/test/misc/unit/libraries/PricingLib.t.sol
+++ b/test/misc/unit/libraries/PricingLib.t.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.28;
 
-import "forge-std/Test.sol";
-
-import {MathLib} from "src/misc/libraries/MathLib.sol";
 import {D18, d18} from "src/misc/types/D18.sol";
 import {IERC20Metadata} from "src/misc/interfaces/IERC20.sol";
+import {MathLib} from "src/misc/libraries/MathLib.sol";
 
 import {PricingLib} from "src/common/libraries/PricingLib.sol";
+
+import "forge-std/Test.sol";
 
 contract PricingLibBaseTest is Test {
     using PricingLib for *;

--- a/test/misc/unit/libraries/SafeTransferLib.t.sol
+++ b/test/misc/unit/libraries/SafeTransferLib.t.sol
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "forge-std/Test.sol";
 import {IERC20} from "src/misc/interfaces/IERC20.sol";
 import {IERC7751} from "src/misc/interfaces/IERC7751.sol";
 import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
+
+import "forge-std/Test.sol";
 
 /// @dev Token not returning any boolean.
 contract ERC20WithoutBoolean {

--- a/test/misc/unit/libraries/SafeTransferLib.t.sol
+++ b/test/misc/unit/libraries/SafeTransferLib.t.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IERC20} from "src/misc/interfaces/IERC20.sol";
 import {IERC7751} from "src/misc/interfaces/IERC7751.sol";
 import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
 

--- a/test/misc/unit/libraries/StringLib.t.sol
+++ b/test/misc/unit/libraries/StringLib.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "forge-std/Test.sol";
-
 import "src/misc/libraries/StringLib.sol";
+
+import "forge-std/Test.sol";
 
 contract StringLibTest is Test {
     function testStringIsEmpty() public pure {

--- a/test/misc/unit/libraries/TransientArrayLib.t.sol
+++ b/test/misc/unit/libraries/TransientArrayLib.t.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "forge-std/Test.sol";
 import {TransientArrayLib} from "src/misc/libraries/TransientArrayLib.sol";
+
+import "forge-std/Test.sol";
 
 contract TransientArrayLibTest is Test {
     function testTransientArray(bytes32 invalidKey) public {

--- a/test/misc/unit/libraries/TransientBytesLib.t.sol
+++ b/test/misc/unit/libraries/TransientBytesLib.t.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "forge-std/Test.sol";
 import {TransientBytesLib} from "src/misc/libraries/TransientBytesLib.sol";
+
+import "forge-std/Test.sol";
 
 contract TransientBytesLibTest is Test {
     function testTransientBytes(bytes calldata data1, bytes calldata data2, bytes32 invalidKey) public {

--- a/test/misc/unit/libraries/TransientStorageLib.t.sol
+++ b/test/misc/unit/libraries/TransientStorageLib.t.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "forge-std/Test.sol";
 import {TransientStorageLib} from "src/misc/libraries/TransientStorageLib.sol";
+
+import "forge-std/Test.sol";
 
 contract TransientStorageLibTest is Test {
     function testAddress(bytes32 key, address value) public {

--- a/test/spoke/BaseTest.sol
+++ b/test/spoke/BaseTest.sol
@@ -3,44 +3,50 @@ pragma solidity 0.8.28;
 pragma abicoder v2;
 
 import "src/misc/interfaces/IERC20.sol";
-import {IERC6909Fungible} from "src/misc/interfaces/IERC6909.sol";
 import {ERC20} from "src/misc/ERC20.sol";
-import {MockERC6909} from "test/misc/mocks/MockERC6909.sol";
 import {Escrow} from "src/misc/Escrow.sol";
+import {IERC6909Fungible} from "src/misc/interfaces/IERC6909.sol";
 
-import {MessageType, MessageLib, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
-import {ISafe} from "src/common/interfaces/IGuardian.sol";
-import {Root} from "src/common/Root.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
 import {Gateway} from "src/common/Gateway.sol";
 import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {newAssetId} from "src/common/types/AssetId.sol";
+import {ISafe} from "src/common/interfaces/IGuardian.sol";
+import {MessageType, MessageLib, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
 import {PoolId, newPoolId} from "src/common/types/PoolId.sol";
+import {Root} from "src/common/Root.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {MESSAGE_COST_ENV} from "script/CommonDeployer.s.sol";
+import {newAssetId} from "src/common/types/AssetId.sol";
 
-// core contracts
 import {AsyncRequestManager} from "src/vaults/AsyncRequestManager.sol";
-import {Spoke} from "src/spoke/Spoke.sol";
 import {AsyncVaultFactory} from "src/vaults/factories/AsyncVaultFactory.sol";
-import {TokenFactory} from "src/spoke/factories/TokenFactory.sol";
 import {AsyncVault} from "src/vaults/AsyncVault.sol";
-import {ShareToken} from "src/spoke/ShareToken.sol";
+
 import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
-import {FullRestrictions} from "src/hooks/FullRestrictions.sol";
 import {IVaultFactory} from "src/spoke/factories/interfaces/IVaultFactory.sol";
+import {ShareToken} from "src/spoke/ShareToken.sol";
+import {Spoke} from "src/spoke/Spoke.sol";
+import {TokenFactory} from "src/spoke/factories/TokenFactory.sol";
 import {VaultKind} from "src/spoke/interfaces/IVault.sol";
 
-// scripts
+import {FullRestrictions} from "src/hooks/FullRestrictions.sol";
+
+import {MESSAGE_COST_ENV} from "script/CommonDeployer.s.sol";
 import {SpokeDeployer} from "script/SpokeDeployer.s.sol";
 
-// mocks
-import {MockCentrifugeChain} from "test/spoke/mocks/MockCentrifugeChain.sol";
 import {MockAdapter} from "test/common/mocks/MockAdapter.sol";
+import {MockCentrifugeChain} from "test/spoke/mocks/MockCentrifugeChain.sol";
+import {MockERC6909} from "test/misc/mocks/MockERC6909.sol";
 import {MockSafe} from "test/spoke/mocks/MockSafe.sol";
 
-// test env
 import "forge-std/Test.sol";
+
+// core contracts
+
+// scripts
+
+// mocks
+
+// test env
 
 contract BaseTest is SpokeDeployer, Test {
     using MessageLib for *;

--- a/test/spoke/BaseTest.sol
+++ b/test/spoke/BaseTest.sol
@@ -4,39 +4,35 @@ pragma abicoder v2;
 
 import "src/misc/interfaces/IERC20.sol";
 import {ERC20} from "src/misc/ERC20.sol";
-import {Escrow} from "src/misc/Escrow.sol";
 import {IERC6909Fungible} from "src/misc/interfaces/IERC6909.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
-import {Gateway} from "src/common/Gateway.sol";
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {ISafe} from "src/common/interfaces/IGuardian.sol";
-import {MessageType, MessageLib, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
-import {PoolId, newPoolId} from "src/common/types/PoolId.sol";
 import {Root} from "src/common/Root.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {Gateway} from "src/common/Gateway.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
 import {newAssetId} from "src/common/types/AssetId.sol";
+import {ISafe} from "src/common/interfaces/IGuardian.sol";
+import {IAdapter} from "src/common/interfaces/IAdapter.sol";
+import {PoolId, newPoolId} from "src/common/types/PoolId.sol";
+import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {MessageLib, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
 
+import {AsyncVault} from "src/vaults/AsyncVault.sol";
 import {AsyncRequestManager} from "src/vaults/AsyncRequestManager.sol";
 import {AsyncVaultFactory} from "src/vaults/factories/AsyncVaultFactory.sol";
-import {AsyncVault} from "src/vaults/AsyncVault.sol";
 
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
-import {IVaultFactory} from "src/spoke/factories/interfaces/IVaultFactory.sol";
-import {ShareToken} from "src/spoke/ShareToken.sol";
 import {Spoke} from "src/spoke/Spoke.sol";
-import {TokenFactory} from "src/spoke/factories/TokenFactory.sol";
 import {VaultKind} from "src/spoke/interfaces/IVault.sol";
+import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+import {TokenFactory} from "src/spoke/factories/TokenFactory.sol";
+import {IVaultFactory} from "src/spoke/factories/interfaces/IVaultFactory.sol";
 
-import {FullRestrictions} from "src/hooks/FullRestrictions.sol";
-
-import {MESSAGE_COST_ENV} from "script/CommonDeployer.s.sol";
 import {SpokeDeployer} from "script/SpokeDeployer.s.sol";
+import {MESSAGE_COST_ENV} from "script/CommonDeployer.s.sol";
 
+import {MockSafe} from "test/spoke/mocks/MockSafe.sol";
+import {MockERC6909} from "test/misc/mocks/MockERC6909.sol";
 import {MockAdapter} from "test/common/mocks/MockAdapter.sol";
 import {MockCentrifugeChain} from "test/spoke/mocks/MockCentrifugeChain.sol";
-import {MockERC6909} from "test/misc/mocks/MockERC6909.sol";
-import {MockSafe} from "test/spoke/mocks/MockSafe.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/spoke/BaseTest.sol
+++ b/test/spoke/BaseTest.sol
@@ -36,14 +36,6 @@ import {MockCentrifugeChain} from "test/spoke/mocks/MockCentrifugeChain.sol";
 
 import "forge-std/Test.sol";
 
-// core contracts
-
-// scripts
-
-// mocks
-
-// test env
-
 contract BaseTest is SpokeDeployer, Test {
     using MessageLib for *;
 

--- a/test/spoke/integration/Admin.t.sol
+++ b/test/spoke/integration/Admin.t.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {CastLib} from "src/misc/libraries/CastLib.sol";
 
-import {IGuardian} from "src/common/interfaces/IGuardian.sol";
-import {IMultiAdapter} from "src/common/interfaces/adapters/IMultiAdapter.sol";
 import {IRoot} from "src/common/interfaces/IRoot.sol";
+import {IGuardian} from "src/common/interfaces/IGuardian.sol";
 import {MessageProofLib} from "src/common/libraries/MessageProofLib.sol";
+import {IMultiAdapter} from "src/common/interfaces/adapters/IMultiAdapter.sol";
 
 import "test/spoke/BaseTest.sol";
 

--- a/test/spoke/integration/Admin.t.sol
+++ b/test/spoke/integration/Admin.t.sol
@@ -4,9 +4,9 @@ pragma solidity 0.8.28;
 import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
 
-import {IRoot} from "src/common/interfaces/IRoot.sol";
 import {IGuardian} from "src/common/interfaces/IGuardian.sol";
 import {IMultiAdapter} from "src/common/interfaces/adapters/IMultiAdapter.sol";
+import {IRoot} from "src/common/interfaces/IRoot.sol";
 import {MessageProofLib} from "src/common/libraries/MessageProofLib.sol";
 
 import "test/spoke/BaseTest.sol";

--- a/test/spoke/integration/AsyncRequestManager.t.sol
+++ b/test/spoke/integration/AsyncRequestManager.t.sol
@@ -2,17 +2,17 @@
 pragma solidity 0.8.28;
 pragma abicoder v2;
 
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
 import {d18, D18} from "src/misc/types/D18.sol";
+import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {MathLib} from "src/misc/libraries/MathLib.sol";
+import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
 
 import {PricingLib} from "src/common/libraries/PricingLib.sol";
 
-import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
-import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
 import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
+import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
+import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
 
 import {VaultDetails} from "src/spoke/interfaces/ISpoke.sol";
 

--- a/test/spoke/integration/AsyncRequestManager.t.sol
+++ b/test/spoke/integration/AsyncRequestManager.t.sol
@@ -2,19 +2,19 @@
 pragma solidity 0.8.28;
 pragma abicoder v2;
 
-import {d18, D18} from "src/misc/types/D18.sol";
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
 import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
+import {MathLib} from "src/misc/libraries/MathLib.sol";
+import {d18, D18} from "src/misc/types/D18.sol";
 
 import {PricingLib} from "src/common/libraries/PricingLib.sol";
 
-import {VaultDetails} from "src/spoke/interfaces/ISpoke.sol";
-
+import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
 import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
 import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
 import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
+
+import {VaultDetails} from "src/spoke/interfaces/ISpoke.sol";
 
 import "test/spoke/BaseTest.sol";
 

--- a/test/spoke/integration/BalanceSheet.t.sol
+++ b/test/spoke/integration/BalanceSheet.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "test/spoke/BaseTest.sol";
-
 import {BalanceSheet} from "src/spoke/BalanceSheet.sol";
+
+import "test/spoke/BaseTest.sol";
 
 contract BalanceSheetTest is BaseTest {
     // Deployment

--- a/test/spoke/integration/Burn.t.sol
+++ b/test/spoke/integration/Burn.t.sol
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "test/spoke/BaseTest.sol";
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
 import {IERC20} from "src/misc/interfaces/IERC20.sol";
+
+import "test/spoke/BaseTest.sol";
 
 contract BurnTest is BaseTest {
     function testBurn(uint256 amount) public {

--- a/test/spoke/integration/Deposit.t.sol
+++ b/test/spoke/integration/Deposit.t.sol
@@ -1,21 +1,22 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
+import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {IERC7751} from "src/misc/interfaces/IERC7751.sol";
 import {MathLib} from "src/misc/libraries/MathLib.sol";
 import {d18, D18} from "src/misc/types/D18.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
 
+import {AssetId} from "src/common/types/AssetId.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
 import {RequestMessageLib} from "src/common/libraries/RequestMessageLib.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
 
-import "test/spoke/BaseTest.sol";
 import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
 import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
 import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
+
+import "test/spoke/BaseTest.sol";
 
 contract DepositTest is BaseTest {
     using MessageLib for *;

--- a/test/spoke/integration/Deposit.t.sol
+++ b/test/spoke/integration/Deposit.t.sol
@@ -1,20 +1,19 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
+import {D18} from "src/misc/types/D18.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {IERC7751} from "src/misc/interfaces/IERC7751.sol";
 import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {d18, D18} from "src/misc/types/D18.sol";
+import {IERC7751} from "src/misc/interfaces/IERC7751.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
-import {RequestMessageLib} from "src/common/libraries/RequestMessageLib.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {RequestMessageLib} from "src/common/libraries/RequestMessageLib.sol";
 
-import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
-import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
 import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
+import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
+import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
 
 import "test/spoke/BaseTest.sol";
 

--- a/test/spoke/integration/Mint.t.sol
+++ b/test/spoke/integration/Mint.t.sol
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "test/spoke/BaseTest.sol";
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
+
 import {ITransferHook} from "src/common/interfaces/ITransferHook.sol";
+
+import "test/spoke/BaseTest.sol";
 
 contract MintTest is BaseTest {
     function testMint(uint256 amount) public {

--- a/test/spoke/integration/Operator.t.sol
+++ b/test/spoke/integration/Operator.t.sol
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "test/spoke/BaseTest.sol";
-
 import {IERC20} from "src/misc/interfaces/IERC20.sol";
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
+
 import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
+import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
+
+import "test/spoke/BaseTest.sol";
 
 contract OperatorTest is BaseTest {
     function testDepositAsOperator(uint256 amount) public {

--- a/test/spoke/integration/Operator.t.sol
+++ b/test/spoke/integration/Operator.t.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.28;
 
 import {IERC20} from "src/misc/interfaces/IERC20.sol";
 
-import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
 import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
+import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
 
 import "test/spoke/BaseTest.sol";
 

--- a/test/spoke/integration/Redeem.t.sol
+++ b/test/spoke/integration/Redeem.t.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {D18} from "src/misc/types/D18.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {IERC20} from "src/misc/interfaces/IERC20.sol";
+import {D18} from "src/misc/types/D18.sol";
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {IERC20} from "src/misc/interfaces/IERC20.sol";
 
+import {AssetId} from "src/common/types/AssetId.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
 import {RequestMessageLib} from "src/common/libraries/RequestMessageLib.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
 
 import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
 import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";

--- a/test/spoke/integration/Redeem.t.sol
+++ b/test/spoke/integration/Redeem.t.sol
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {D18} from "src/misc/types/D18.sol";
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
 import {IERC20} from "src/misc/interfaces/IERC20.sol";
+import {CastLib} from "src/misc/libraries/CastLib.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
-import {RequestMessageLib} from "src/common/libraries/RequestMessageLib.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {RequestMessageLib} from "src/common/libraries/RequestMessageLib.sol";
 
-import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
 import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
+import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
 
 import "test/spoke/BaseTest.sol";
 

--- a/test/spoke/integration/Spoke.t.sol
+++ b/test/spoke/integration/Spoke.t.sol
@@ -1,28 +1,30 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {MockERC6909} from "test/misc/mocks/MockERC6909.sol";
-import {MockHook} from "test/spoke/mocks/MockHook.sol";
-import "test/spoke/BaseTest.sol";
-
-import {IGateway} from "src/common/interfaces/IGateway.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {D18} from "src/misc/types/D18.sol";
+import {IAuth} from "src/misc/interfaces/IAuth.sol";
 
-import {MessageLib} from "src/common/libraries/MessageLib.sol";
-import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {PoolId} from "src/common/types/PoolId.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
+import {IGateway} from "src/common/interfaces/IGateway.sol";
 import {ITransferHook} from "src/common/interfaces/ITransferHook.sol";
+import {MessageLib} from "src/common/libraries/MessageLib.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
+import {ShareClassId} from "src/common/types/ShareClassId.sol";
+
+import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
 
 import {ISpoke, VaultDetails} from "src/spoke/interfaces/ISpoke.sol";
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
 import {IUpdateContract} from "src/spoke/interfaces/IUpdateContract.sol";
-import {IMemberlist} from "src/hooks/interfaces/IMemberlist.sol";
 import {IVault} from "src/spoke/interfaces/IVaultManager.sol";
+
+import {IMemberlist} from "src/hooks/interfaces/IMemberlist.sol";
+import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+
+import "test/spoke/BaseTest.sol";
+import {MockERC6909} from "test/misc/mocks/MockERC6909.sol";
+import {MockHook} from "test/spoke/mocks/MockHook.sol";
 
 contract SpokeTestHelper is BaseTest {
     PoolId poolId;

--- a/test/spoke/integration/Spoke.t.sol
+++ b/test/spoke/integration/Spoke.t.sol
@@ -1,30 +1,30 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {D18} from "src/misc/types/D18.sol";
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 
+import {PoolId} from "src/common/types/PoolId.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
 import {IGateway} from "src/common/interfaces/IGateway.sol";
-import {ITransferHook} from "src/common/interfaces/ITransferHook.sol";
 import {MessageLib} from "src/common/libraries/MessageLib.sol";
-import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {ITransferHook} from "src/common/interfaces/ITransferHook.sol";
 
 import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
 
+import {ShareToken} from "src/spoke/ShareToken.sol";
+import {IVault} from "src/spoke/interfaces/IVaultManager.sol";
 import {ISpoke, VaultDetails} from "src/spoke/interfaces/ISpoke.sol";
 import {IUpdateContract} from "src/spoke/interfaces/IUpdateContract.sol";
-import {IVault} from "src/spoke/interfaces/IVaultManager.sol";
 
 import {IMemberlist} from "src/hooks/interfaces/IMemberlist.sol";
 import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
 import "test/spoke/BaseTest.sol";
-import {MockERC6909} from "test/misc/mocks/MockERC6909.sol";
 import {MockHook} from "test/spoke/mocks/MockHook.sol";
+import {MockERC6909} from "test/misc/mocks/MockERC6909.sol";
 
 contract SpokeTestHelper is BaseTest {
     PoolId poolId;

--- a/test/spoke/integration/SyncDeposit.t.sol
+++ b/test/spoke/integration/SyncDeposit.t.sol
@@ -1,26 +1,26 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {D18, d18} from "src/misc/types/D18.sol";
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {IERC7751} from "src/misc/interfaces/IERC7751.sol";
+import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {MathLib} from "src/misc/libraries/MathLib.sol";
+import {IERC7751} from "src/misc/interfaces/IERC7751.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
-import {ITransferHook} from "src/common/interfaces/ITransferHook.sol";
-import {MessageLib} from "src/common/libraries/MessageLib.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
+import {MessageLib} from "src/common/libraries/MessageLib.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {ITransferHook} from "src/common/interfaces/ITransferHook.sol";
 
-import {IAsyncRedeemVault} from "src/vaults/interfaces/IAsyncVault.sol";
 import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {ISyncManager} from "src/vaults/interfaces/IVaultManagers.sol";
 import {SyncDepositVault} from "src/vaults/SyncDepositVault.sol";
+import {ISyncManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {IAsyncRedeemVault} from "src/vaults/interfaces/IAsyncVault.sol";
 
-import {IBalanceSheet} from "src/spoke/interfaces/IBalanceSheet.sol";
-import {IVault} from "src/spoke/interfaces/IVaultManager.sol";
 import {VaultDetails} from "src/spoke/interfaces/ISpoke.sol";
+import {IVault} from "src/spoke/interfaces/IVaultManager.sol";
+import {IBalanceSheet} from "src/spoke/interfaces/IBalanceSheet.sol";
 
 import "test/spoke/BaseTest.sol";
 

--- a/test/spoke/integration/SyncDeposit.t.sol
+++ b/test/spoke/integration/SyncDeposit.t.sol
@@ -1,27 +1,28 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "test/spoke/BaseTest.sol";
-
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
 import {D18, d18} from "src/misc/types/D18.sol";
+import {IAuth} from "src/misc/interfaces/IAuth.sol";
 import {IERC7751} from "src/misc/interfaces/IERC7751.sol";
+import {MathLib} from "src/misc/libraries/MathLib.sol";
 
+import {AssetId} from "src/common/types/AssetId.sol";
+import {ITransferHook} from "src/common/interfaces/ITransferHook.sol";
 import {MessageLib} from "src/common/libraries/MessageLib.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
 
-import {ITransferHook} from "src/common/interfaces/ITransferHook.sol";
-import {IBalanceSheet} from "src/spoke/interfaces/IBalanceSheet.sol";
-import {SyncDepositVault} from "src/vaults/SyncDepositVault.sol";
-import {VaultDetails} from "src/spoke/interfaces/ISpoke.sol";
+import {IAsyncRedeemVault} from "src/vaults/interfaces/IAsyncVault.sol";
 import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
 import {ISyncManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {IAsyncRedeemVault} from "src/vaults/interfaces/IAsyncVault.sol";
+import {SyncDepositVault} from "src/vaults/SyncDepositVault.sol";
+
+import {IBalanceSheet} from "src/spoke/interfaces/IBalanceSheet.sol";
 import {IVault} from "src/spoke/interfaces/IVaultManager.sol";
+import {VaultDetails} from "src/spoke/interfaces/ISpoke.sol";
+
+import "test/spoke/BaseTest.sol";
 
 contract SyncDepositTestHelper is BaseTest {
     using CastLib for *;

--- a/test/spoke/integration/SyncManager.t.sol
+++ b/test/spoke/integration/SyncManager.t.sol
@@ -7,14 +7,12 @@ import {MathLib} from "src/misc/libraries/MathLib.sol";
 
 import {MessageLib} from "src/common/libraries/MessageLib.sol";
 
-import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {ISyncManager, ISyncDepositValuation} from "src/vaults/interfaces/IVaultManagers.sol";
-import {ISyncManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {SyncDepositVault} from "src/vaults/SyncDepositVault.sol";
 import {SyncManager} from "src/vaults/SyncManager.sol";
-
-import {VaultDetails} from "src/spoke/interfaces/ISpoke.sol";
+import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
+import {SyncDepositVault} from "src/vaults/SyncDepositVault.sol";
+import {ISyncManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
+import {ISyncManager, ISyncDepositValuation} from "src/vaults/interfaces/IVaultManagers.sol";
 
 import "test/spoke/BaseTest.sol";
 

--- a/test/spoke/integration/SyncManager.t.sol
+++ b/test/spoke/integration/SyncManager.t.sol
@@ -1,19 +1,20 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
 import {D18, d18} from "src/misc/types/D18.sol";
+import {IAuth} from "src/misc/interfaces/IAuth.sol";
 import {MathLib} from "src/misc/libraries/MathLib.sol";
 
 import {MessageLib} from "src/common/libraries/MessageLib.sol";
 
-import {ISyncManager, ISyncDepositValuation} from "src/vaults/interfaces/IVaultManagers.sol";
-import {SyncManager} from "src/vaults/SyncManager.sol";
-import {SyncDepositVault} from "src/vaults/SyncDepositVault.sol";
-import {VaultDetails} from "src/spoke/interfaces/ISpoke.sol";
 import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
-import {ISyncManager} from "src/vaults/interfaces/IVaultManagers.sol";
 import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
+import {ISyncManager, ISyncDepositValuation} from "src/vaults/interfaces/IVaultManagers.sol";
+import {ISyncManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {SyncDepositVault} from "src/vaults/SyncDepositVault.sol";
+import {SyncManager} from "src/vaults/SyncManager.sol";
+
+import {VaultDetails} from "src/spoke/interfaces/ISpoke.sol";
 
 import "test/spoke/BaseTest.sol";
 

--- a/test/spoke/integration/VaultRouter.t.sol
+++ b/test/spoke/integration/VaultRouter.t.sol
@@ -1,23 +1,24 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "test/spoke/BaseTest.sol";
-
-import "src/misc/interfaces/IERC7575.sol";
-import "src/misc/interfaces/IERC7540.sol";
 import "src/misc/interfaces/IERC20.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
+import "src/misc/interfaces/IERC7540.sol";
+import "src/misc/interfaces/IERC7575.sol";
 import {IERC7751} from "src/misc/interfaces/IERC7751.sol";
+import {MathLib} from "src/misc/libraries/MathLib.sol";
 
-import {MessageLib} from "src/common/libraries/MessageLib.sol";
 import {IGateway} from "src/common/interfaces/IGateway.sol";
+import {MessageLib} from "src/common/libraries/MessageLib.sol";
 
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
-import {VaultRouter} from "src/vaults/VaultRouter.sol";
-import {IVaultRouter} from "src/vaults/interfaces/IVaultRouter.sol";
-import {ISpoke} from "src/spoke/interfaces/ISpoke.sol";
 import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
+import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
+import {IVaultRouter} from "src/vaults/interfaces/IVaultRouter.sol";
+import {VaultRouter} from "src/vaults/VaultRouter.sol";
+
+import {ISpoke} from "src/spoke/interfaces/ISpoke.sol";
+
+import "test/spoke/BaseTest.sol";
 
 contract VaultRouterTest is BaseTest {
     using MessageLib for *;

--- a/test/spoke/integration/VaultRouter.t.sol
+++ b/test/spoke/integration/VaultRouter.t.sol
@@ -4,17 +4,17 @@ pragma solidity 0.8.28;
 import "src/misc/interfaces/IERC20.sol";
 import "src/misc/interfaces/IERC7540.sol";
 import "src/misc/interfaces/IERC7575.sol";
-import {IERC7751} from "src/misc/interfaces/IERC7751.sol";
 import {MathLib} from "src/misc/libraries/MathLib.sol";
+import {IERC7751} from "src/misc/interfaces/IERC7751.sol";
 
 import {IGateway} from "src/common/interfaces/IGateway.sol";
 import {MessageLib} from "src/common/libraries/MessageLib.sol";
 
-import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IVaultRouter} from "src/vaults/interfaces/IVaultRouter.sol";
 import {VaultRouter} from "src/vaults/VaultRouter.sol";
+import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
+import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
+import {IVaultRouter} from "src/vaults/interfaces/IVaultRouter.sol";
+import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
 
 import {ISpoke} from "src/spoke/interfaces/ISpoke.sol";
 

--- a/test/spoke/mocks/MockCentrifugeChain.sol
+++ b/test/spoke/mocks/MockCentrifugeChain.sol
@@ -1,22 +1,21 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {D18, d18} from "src/misc/types/D18.sol";
+import {CastLib} from "src/misc/libraries/CastLib.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {MessageLib, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
-import {MessageProofLib} from "src/common/libraries/MessageProofLib.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {IAdapter} from "src/common/interfaces/IAdapter.sol";
+import {MessageProofLib} from "src/common/libraries/MessageProofLib.sol";
+import {MessageLib, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
 import {RequestCallbackMessageLib} from "src/common/libraries/RequestCallbackMessageLib.sol";
 
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
 import {SyncManager} from "src/vaults/SyncManager.sol";
+import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
 
 import {Spoke} from "src/spoke/Spoke.sol";
-import {UpdateContractMessageLib} from "src/spoke/libraries/UpdateContractMessageLib.sol";
 import {VaultDetails} from "src/spoke/interfaces/ISpoke.sol";
+import {UpdateContractMessageLib} from "src/spoke/libraries/UpdateContractMessageLib.sol";
 
 import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 

--- a/test/spoke/mocks/MockCentrifugeChain.sol
+++ b/test/spoke/mocks/MockCentrifugeChain.sol
@@ -1,24 +1,26 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "forge-std/Test.sol";
-
 import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {D18, d18} from "src/misc/types/D18.sol";
 
-import {MessageLib, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
-import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
-import {UpdateContractMessageLib} from "src/spoke/libraries/UpdateContractMessageLib.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
 import {IAdapter} from "src/common/interfaces/IAdapter.sol";
+import {MessageLib, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
 import {MessageProofLib} from "src/common/libraries/MessageProofLib.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
 import {RequestCallbackMessageLib} from "src/common/libraries/RequestCallbackMessageLib.sol";
 
-import {Spoke} from "src/spoke/Spoke.sol";
-import {SyncManager} from "src/vaults/SyncManager.sol";
-import {VaultDetails} from "src/spoke/interfaces/ISpoke.sol";
 import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
+import {SyncManager} from "src/vaults/SyncManager.sol";
+
+import {Spoke} from "src/spoke/Spoke.sol";
+import {UpdateContractMessageLib} from "src/spoke/libraries/UpdateContractMessageLib.sol";
+import {VaultDetails} from "src/spoke/interfaces/ISpoke.sol";
+
+import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+
+import "forge-std/Test.sol";
 
 interface AdapterLike {
     function execute(bytes memory _message) external;

--- a/test/spoke/mocks/MockFullRestrictions.sol
+++ b/test/spoke/mocks/MockFullRestrictions.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "test/common/mocks/Mock.sol";
 import "src/hooks/FullRestrictions.sol";
+
+import "test/common/mocks/Mock.sol";
 
 contract MockFullRestrictions is FullRestrictions, Mock {
     constructor(address root_, address deployer) FullRestrictions(root_, deployer) {}

--- a/test/spoke/mocks/MockHook.sol
+++ b/test/spoke/mocks/MockHook.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "test/common/mocks/Mock.sol";
-
 import {IERC165} from "src/misc/interfaces/IERC7575.sol";
 
 import {ITransferHook} from "src/common/interfaces/ITransferHook.sol";
+
+import "test/common/mocks/Mock.sol";
 
 contract MockHook is Mock {
     function supportsInterface(bytes4 interfaceId) external pure returns (bool) {

--- a/test/spoke/mocks/MockSafe.sol
+++ b/test/spoke/mocks/MockSafe.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.28;
 
 import {ISafe} from "src/common/Guardian.sol";
+
 import {Mock} from "test/common/mocks/Mock.sol";
 
 contract MockSafe is Mock, ISafe {

--- a/test/spoke/unit/AsyncVault.t.sol
+++ b/test/spoke/unit/AsyncVault.t.sol
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "test/spoke/BaseTest.sol";
-
-import "src/misc/interfaces/IERC7575.sol";
 import "src/misc/interfaces/IERC7540.sol";
+import "src/misc/interfaces/IERC7575.sol";
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
 import {MathLib} from "src/misc/libraries/MathLib.sol";
 
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
 import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
 import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
+import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
+
+import "test/spoke/BaseTest.sol";
 
 contract AsyncVaultTest is BaseTest {
     // Deployment

--- a/test/spoke/unit/AsyncVault.t.sol
+++ b/test/spoke/unit/AsyncVault.t.sol
@@ -6,10 +6,8 @@ import "src/misc/interfaces/IERC7575.sol";
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
 import {MathLib} from "src/misc/libraries/MathLib.sol";
 
-import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
-import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
 import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
+import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
 
 import "test/spoke/BaseTest.sol";
 

--- a/test/spoke/unit/BalanceSheet.t.sol
+++ b/test/spoke/unit/BalanceSheet.t.sol
@@ -1,26 +1,25 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {D18, d18} from "src/misc/types/D18.sol";
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
 import {IERC20} from "src/misc/interfaces/IERC20.sol";
-import {IERC6909} from "src/misc/interfaces/IERC6909.sol";
-import {IERC7751} from "src/misc/interfaces/IERC7751.sol";
+import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
+import {IERC6909} from "src/misc/interfaces/IERC6909.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
-import {IGateway} from "src/common/interfaces/IGateway.sol";
-import {IPoolEscrowProvider} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
-import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
-import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {ISpokeMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
+import {IRoot} from "src/common/interfaces/IRoot.sol";
+import {IGateway} from "src/common/interfaces/IGateway.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
+import {ISpokeMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
+import {IPoolEscrowProvider} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
 
-import {BalanceSheet, IBalanceSheet} from "src/spoke/BalanceSheet.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
 import {ISpoke} from "src/spoke/interfaces/ISpoke.sol";
+import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+import {BalanceSheet, IBalanceSheet} from "src/spoke/BalanceSheet.sol";
 
 import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 

--- a/test/spoke/unit/BalanceSheet.t.sol
+++ b/test/spoke/unit/BalanceSheet.t.sol
@@ -1,29 +1,30 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "forge-std/Test.sol";
-
-import {IERC7751} from "src/misc/interfaces/IERC7751.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {D18, d18} from "src/misc/types/D18.sol";
-import {IERC6909} from "src/misc/interfaces/IERC6909.sol";
+import {IAuth} from "src/misc/interfaces/IAuth.sol";
 import {IERC20} from "src/misc/interfaces/IERC20.sol";
+import {IERC6909} from "src/misc/interfaces/IERC6909.sol";
+import {IERC7751} from "src/misc/interfaces/IERC7751.sol";
 import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
 
-import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
+import {IGateway} from "src/common/interfaces/IGateway.sol";
+import {IPoolEscrowProvider} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
+import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
 import {IRoot} from "src/common/interfaces/IRoot.sol";
 import {ISpokeMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
-import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
-import {IGateway} from "src/common/interfaces/IGateway.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
+import {ShareClassId} from "src/common/types/ShareClassId.sol";
 
 import {BalanceSheet, IBalanceSheet} from "src/spoke/BalanceSheet.sol";
-import {ISpoke} from "src/spoke/interfaces/ISpoke.sol";
 import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
-import {IPoolEscrowProvider} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
+import {ISpoke} from "src/spoke/interfaces/ISpoke.sol";
+
+import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+
+import "forge-std/Test.sol";
 
 // Need it to overpass a mockCall issue: https://github.com/foundry-rs/foundry/issues/10703
 contract IsContract {}

--- a/test/spoke/unit/RestrictedTransfers.t.sol
+++ b/test/spoke/unit/RestrictedTransfers.t.sol
@@ -1,18 +1,19 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "forge-std/Test.sol";
+import {IERC165} from "src/misc/interfaces/IERC7575.sol";
+
+import {ITransferHook} from "src/common/interfaces/ITransferHook.sol";
+
+import {ShareToken} from "src/spoke/ShareToken.sol";
+
+import {FullRestrictions} from "src/hooks/FullRestrictions.sol";
+import {IFreezable} from "src/hooks/interfaces/IFreezable.sol";
+import {IMemberlist} from "src/hooks/interfaces/IMemberlist.sol";
 
 import {MockRoot} from "test/common/mocks/MockRoot.sol";
 
-import {IERC165} from "src/misc/interfaces/IERC7575.sol";
-
-import {ShareToken} from "src/spoke/ShareToken.sol";
-import {ITransferHook} from "src/common/interfaces/ITransferHook.sol";
-
-import {FullRestrictions} from "src/hooks/FullRestrictions.sol";
-import {IMemberlist} from "src/hooks/interfaces/IMemberlist.sol";
-import {IFreezable} from "src/hooks/interfaces/IFreezable.sol";
+import "forge-std/Test.sol";
 
 contract FullRestrictionsTest is Test {
     MockRoot root;

--- a/test/spoke/unit/RestrictedTransfers.t.sol
+++ b/test/spoke/unit/RestrictedTransfers.t.sol
@@ -7,8 +7,8 @@ import {ITransferHook} from "src/common/interfaces/ITransferHook.sol";
 
 import {ShareToken} from "src/spoke/ShareToken.sol";
 
-import {FullRestrictions} from "src/hooks/FullRestrictions.sol";
 import {IFreezable} from "src/hooks/interfaces/IFreezable.sol";
+import {FullRestrictions} from "src/hooks/FullRestrictions.sol";
 import {IMemberlist} from "src/hooks/interfaces/IMemberlist.sol";
 
 import {MockRoot} from "test/common/mocks/MockRoot.sol";

--- a/test/spoke/unit/ShareToken.t.sol
+++ b/test/spoke/unit/ShareToken.t.sol
@@ -1,19 +1,18 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
+import {ERC20} from "src/misc/ERC20.sol";
 import "src/misc/interfaces/IERC7540.sol";
 import "src/misc/interfaces/IERC7575.sol";
-import {ERC20} from "src/misc/ERC20.sol";
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
 import {IERC20} from "src/misc/interfaces/IERC20.sol";
 
 import {ITransferHook} from "src/common/interfaces/ITransferHook.sol";
 
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
 import {ShareToken} from "src/spoke/ShareToken.sol";
 
-import {MockFullRestrictions} from "test/spoke/mocks/MockFullRestrictions.sol";
 import {MockRoot} from "test/common/mocks/MockRoot.sol";
+import {MockFullRestrictions} from "test/spoke/mocks/MockFullRestrictions.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/spoke/unit/ShareToken.t.sol
+++ b/test/spoke/unit/ShareToken.t.sol
@@ -1,20 +1,21 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {MockRoot} from "test/common/mocks/MockRoot.sol";
-import "forge-std/Test.sol";
-
+import "src/misc/interfaces/IERC7540.sol";
+import "src/misc/interfaces/IERC7575.sol";
+import {ERC20} from "src/misc/ERC20.sol";
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
 import {IERC20} from "src/misc/interfaces/IERC20.sol";
-import {ERC20} from "src/misc/ERC20.sol";
 
-import "src/misc/interfaces/IERC7575.sol";
-import "src/misc/interfaces/IERC7540.sol";
+import {ITransferHook} from "src/common/interfaces/ITransferHook.sol";
+
+import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
 import {ShareToken} from "src/spoke/ShareToken.sol";
 
 import {MockFullRestrictions} from "test/spoke/mocks/MockFullRestrictions.sol";
-import {ITransferHook} from "src/common/interfaces/ITransferHook.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+import {MockRoot} from "test/common/mocks/MockRoot.sol";
+
+import "forge-std/Test.sol";
 
 interface ERC20Like {
     function balanceOf(address) external view returns (uint256);

--- a/test/spoke/unit/VaultRouter.t.sol
+++ b/test/spoke/unit/VaultRouter.t.sol
@@ -1,24 +1,24 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "test/spoke/BaseTest.sol";
-
 import "src/misc/interfaces/IERC20.sol";
-import "src/misc/interfaces/IERC7575.sol";
 import "src/misc/interfaces/IERC7540.sol";
+import "src/misc/interfaces/IERC7575.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {IERC7751} from "src/misc/interfaces/IERC7751.sol";
 
-import {MessageLib} from "src/common/libraries/MessageLib.sol";
 import {IGateway} from "src/common/interfaces/IGateway.sol";
-
-import {VaultRouter} from "src/vaults/VaultRouter.sol";
-import {IVaultRouter} from "src/vaults/interfaces/IVaultRouter.sol";
-import {ISpoke} from "src/spoke/interfaces/ISpoke.sol";
+import {MessageLib} from "src/common/libraries/MessageLib.sol";
 
 import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
 import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
+import {IVaultRouter} from "src/vaults/interfaces/IVaultRouter.sol";
 import {SyncDepositVault} from "src/vaults/SyncDepositVault.sol";
+import {VaultRouter} from "src/vaults/VaultRouter.sol";
+
+import {ISpoke} from "src/spoke/interfaces/ISpoke.sol";
+
+import "test/spoke/BaseTest.sol";
 
 interface Authlike {
     function rely(address) external;

--- a/test/spoke/unit/VaultRouter.t.sol
+++ b/test/spoke/unit/VaultRouter.t.sol
@@ -10,11 +10,11 @@ import {IERC7751} from "src/misc/interfaces/IERC7751.sol";
 import {IGateway} from "src/common/interfaces/IGateway.sol";
 import {MessageLib} from "src/common/libraries/MessageLib.sol";
 
-import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {VaultRouter} from "src/vaults/VaultRouter.sol";
+import {SyncDepositVault} from "src/vaults/SyncDepositVault.sol";
 import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
 import {IVaultRouter} from "src/vaults/interfaces/IVaultRouter.sol";
-import {SyncDepositVault} from "src/vaults/SyncDepositVault.sol";
-import {VaultRouter} from "src/vaults/VaultRouter.sol";
+import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
 
 import {ISpoke} from "src/spoke/interfaces/ISpoke.sol";
 

--- a/test/spoke/unit/factories/TokenFactory.t.sol
+++ b/test/spoke/unit/factories/TokenFactory.t.sol
@@ -1,17 +1,18 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
 import {Escrow} from "src/misc/Escrow.sol";
+import {IAuth} from "src/misc/interfaces/IAuth.sol";
 
 import {Root} from "src/common/Root.sol";
 
-import {TokenFactory} from "src/spoke/factories/TokenFactory.sol";
-import {ShareToken} from "src/spoke/ShareToken.sol";
-import {VaultKind} from "src/spoke/interfaces/IVault.sol";
 import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+import {ShareToken} from "src/spoke/ShareToken.sol";
+import {TokenFactory} from "src/spoke/factories/TokenFactory.sol";
+import {VaultKind} from "src/spoke/interfaces/IVault.sol";
 
 import {BaseTest} from "test/spoke/BaseTest.sol";
+
 import "forge-std/Test.sol";
 
 interface SpokeLike {

--- a/test/spoke/unit/factories/TokenFactory.t.sol
+++ b/test/spoke/unit/factories/TokenFactory.t.sol
@@ -1,15 +1,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Escrow} from "src/misc/Escrow.sol";
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
 
 import {Root} from "src/common/Root.sol";
 
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
 import {ShareToken} from "src/spoke/ShareToken.sol";
-import {TokenFactory} from "src/spoke/factories/TokenFactory.sol";
 import {VaultKind} from "src/spoke/interfaces/IVault.sol";
+import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+import {TokenFactory} from "src/spoke/factories/TokenFactory.sol";
 
 import {BaseTest} from "test/spoke/BaseTest.sol";
 

--- a/test/spoke/unit/libraries/UpdateContractMessageLib.t.sol
+++ b/test/spoke/unit/libraries/UpdateContractMessageLib.t.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {UpdateContractMessageLib} from "src/spoke/libraries/UpdateContractMessageLib.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
+
+import {UpdateContractMessageLib} from "src/spoke/libraries/UpdateContractMessageLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/spoke/unit/libraries/UpdateContractMessageLib.t.sol
+++ b/test/spoke/unit/libraries/UpdateContractMessageLib.t.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {AssetId} from "src/common/types/AssetId.sol";
-
 import {UpdateContractMessageLib} from "src/spoke/libraries/UpdateContractMessageLib.sol";
 
 import "forge-std/Test.sol";


### PR DESCRIPTION
* **Fixes ONLY import order** for all files based on the folllowing priority list

```python
IMPORT_PRIORITY = [
    "src/misc",
    "src/common", 
    "src/vaults",
    "src/hub",
    "src/spoke",
    "src/hooks",
    "src/managers",
    "script",
    "test",
    "forge-std"
]
```

* Adds `script/utils/fix_imports.py` which we could utilize in CI as check in the future
* Within an import block, sorts by ascending line length order

```diff
- import {AccountId} from "src/common/types/AccountId.sol";
- import {AssetId, newAssetId} from "src/common/types/AssetId.sol";
+ import {PoolId} from "src/common/types/PoolId.sol";
+ import {AccountId} from "src/common/types/AccountId.sol";
import {ISafe} from "src/common/interfaces/IGuardian.sol";
- import {PoolId} from "src/common/types/PoolId.sol";
- import {ShareClassId} from "src/common/types/ShareClassId.sol";
+ import {ShareClassId} from "src/common/types/ShareClassId.sol";
+ import {AssetId, newAssetId} from "src/common/types/AssetId.sol";
import {VaultUpdateKind} from "src/common/libraries/MessageLib.sol"
```