### PR TITLE
Deploy: input config & fix end-to-end issues

### DIFF
--- a/script/CommonDeployer.s.sol
+++ b/script/CommonDeployer.s.sol
@@ -16,14 +16,17 @@ import {CreateXScript} from "createx-forge/script/CreateXScript.sol";
 
 import "forge-std/Script.sol";
 
-string constant MESSAGE_COST_ENV = "MESSAGE_COST";
-string constant MAX_BATCH_SIZE_ENV = "MAX_BATCH_SIZE";
+struct CommonInput {
+    uint16 centrifugeId;
+    ISafe adminSafe;
+    uint128 messageGasLimit;
+    uint128 maxBatchSize;
+    bool isTests;
+}
 
 abstract contract CommonDeployer is Script, JsonRegistry, CreateXScript {
     uint256 constant DELAY = 48 hours;
     bytes32 immutable SALT;
-    uint128 constant FALLBACK_MSG_COST = uint128(1_000_000); // in GAS
-    uint128 constant FALLBACK_MAX_BATCH_SIZE = uint128(10_000_000); // 10M in Weight
 
     string version;
     ISafe public adminSafe;
@@ -56,34 +59,30 @@ abstract contract CommonDeployer is Script, JsonRegistry, CreateXScript {
         return keccak256(abi.encodePacked(contractName));
     }
 
-    function deployCommon(uint16 centrifugeId_, ISafe adminSafe_, address deployer, bool isTests) public virtual {
+    function deployCommon(CommonInput memory input, address deployer) public {
         if (address(root) != address(0)) {
             return; // Already deployed. Make this method idempotent.
         }
 
-        if (isTests) {
+        if (input.isTests) {
             // For tests we want to have different contract addreses per chain
-            version = string(abi.encodePacked(version, centrifugeId_));
+            version = string(abi.encodePacked(version, input.centrifugeId));
         }
 
         setUpCreateXFactory();
-
-        startDeploymentOutput(isTests);
-
-        uint128 messageGasLimit = uint128(vm.envOr(MESSAGE_COST_ENV, FALLBACK_MSG_COST));
-        uint128 maxBatchSize = uint128(vm.envOr(MAX_BATCH_SIZE_ENV, FALLBACK_MAX_BATCH_SIZE));
+        startDeploymentOutput(input.isTests);
 
         // Note: This function was split into smaller helper functions to avoid
         // "stack too deep" compilation errors that occur when too many local
         // variables are used in a single function scope.
 
         // Deploy basic contracts first
-        _deployBasicContracts(deployer, messageGasLimit, maxBatchSize);
+        _deployBasicContracts(deployer, input.messageGasLimit, input.maxBatchSize);
 
         // Deploy more complex contracts
-        _deployComplexContracts(centrifugeId_, deployer);
+        _deployComplexContracts(input.centrifugeId, deployer);
 
-        adminSafe = adminSafe_;
+        adminSafe = input.adminSafe;
 
         _commonRegister();
         _commonRely();

--- a/script/CommonDeployer.s.sol
+++ b/script/CommonDeployer.s.sol
@@ -12,9 +12,9 @@ import {MessageDispatcher} from "src/common/MessageDispatcher.sol";
 import {PoolEscrowFactory} from "src/common/factories/PoolEscrowFactory.sol";
 
 import {JsonRegistry} from "script/utils/JsonRegistry.s.sol";
-import {CreateXScript} from "createx-forge/script/CreateXScript.sol";
 
 import "forge-std/Script.sol";
+import {CreateXScript} from "createx-forge/script/CreateXScript.sol";
 
 struct CommonInput {
     uint16 centrifugeId;

--- a/script/FullDeployer.s.sol
+++ b/script/FullDeployer.s.sol
@@ -54,12 +54,13 @@ contract FullDeployer is HubDeployer, SpokeDeployer {
         // Since `wire()` is not called, separately adding the safe here
         guardian.file("safe", address(adminSafe));
         saveDeploymentOutput();
-        vm.stopBroadcast();
 
         bool isNotMainnet = keccak256(abi.encodePacked(environment)) != keccak256(abi.encodePacked("mainnet"));
 
         if (!isNotMainnet) {
             removeFullDeployerAccess(msg.sender);
         }
+
+        vm.stopBroadcast();
     }
 }

--- a/script/FullDeployer.s.sol
+++ b/script/FullDeployer.s.sol
@@ -4,8 +4,8 @@ pragma solidity 0.8.28;
 import {ISafe} from "src/common/Guardian.sol";
 
 import {HubDeployer} from "script/HubDeployer.s.sol";
-import {SpokeDeployer} from "script/SpokeDeployer.s.sol";
 import {CommonInput} from "script/CommonDeployer.s.sol";
+import {SpokeDeployer} from "script/SpokeDeployer.s.sol";
 
 import "forge-std/Script.sol";
 

--- a/script/FullDeployer.s.sol
+++ b/script/FullDeployer.s.sol
@@ -15,6 +15,11 @@ contract FullDeployer is HubDeployer, SpokeDeployer {
         deploySpoke(input, deployer);
     }
 
+    function removeFullDeployerAccess(address deployer) public {
+        removeHubDeployerAccess(deployer);
+        removeSpokeDeployerAccess(deployer);
+    }
+
     function run() public virtual {
         vm.startBroadcast();
         uint16 centrifugeId;
@@ -51,15 +56,10 @@ contract FullDeployer is HubDeployer, SpokeDeployer {
         saveDeploymentOutput();
         vm.stopBroadcast();
 
-        removeFullDeployerAccess(msg.sender, environment);
-    }
-
-    function removeFullDeployerAccess(address deployer, string memory environment) public {
         bool isNotMainnet = keccak256(abi.encodePacked(environment)) != keccak256(abi.encodePacked("mainnet"));
 
         if (!isNotMainnet) {
-            removeHubDeployerAccess(deployer);
-            removeSpokeDeployerAccess(deployer);
+            removeFullDeployerAccess(msg.sender);
         }
     }
 }

--- a/script/FullDeployer.s.sol
+++ b/script/FullDeployer.s.sol
@@ -5,13 +5,14 @@ import {ISafe} from "src/common/Guardian.sol";
 
 import {HubDeployer} from "script/HubDeployer.s.sol";
 import {SpokeDeployer} from "script/SpokeDeployer.s.sol";
+import {CommonInput} from "script/CommonDeployer.s.sol";
 
 import "forge-std/Script.sol";
 
 contract FullDeployer is HubDeployer, SpokeDeployer {
-    function deployFull(uint16 centrifugeId_, ISafe adminSafe_, address deployer, bool isTests) public {
-        deployHub(centrifugeId_, adminSafe_, deployer, isTests);
-        deploySpoke(centrifugeId_, adminSafe_, deployer, isTests);
+    function deployFull(CommonInput memory input, address deployer) public {
+        deployHub(input, deployer);
+        deploySpoke(input, deployer);
     }
 
     function run() public virtual {
@@ -34,8 +35,16 @@ contract FullDeployer is HubDeployer, SpokeDeployer {
         console.log("Network:", network);
         console.log("Environment:", environment);
 
+        CommonInput memory input = CommonInput({
+            centrifugeId: centrifugeId,
+            adminSafe: ISafe(vm.envAddress("ADMIN")),
+            messageGasLimit: uint128(vm.envUint("MESSAGE_COST")),
+            maxBatchSize: uint128(vm.envUint("MAX_BATCH_SIZE")),
+            isTests: false
+        });
+
         // Use the regular deployment functions - they now use CreateX internally
-        deployFull(centrifugeId, ISafe(vm.envAddress("ADMIN")), msg.sender, false);
+        deployFull(input, msg.sender);
 
         // Since `wire()` is not called, separately adding the safe here
         guardian.file("safe", address(adminSafe));

--- a/script/HubDeployer.s.sol
+++ b/script/HubDeployer.s.sol
@@ -13,7 +13,7 @@ import {HubHelpers} from "src/hub/HubHelpers.sol";
 import {HubRegistry} from "src/hub/HubRegistry.sol";
 import {ShareClassManager} from "src/hub/ShareClassManager.sol";
 
-import {CommonDeployer} from "script/CommonDeployer.s.sol";
+import {CommonDeployer, CommonInput} from "script/CommonDeployer.s.sol";
 
 import "forge-std/Script.sol";
 
@@ -34,8 +34,8 @@ contract HubDeployer is CommonDeployer {
     AssetId public immutable USD_ID = newAssetId(840);
     AssetId public immutable EUR_ID = newAssetId(978);
 
-    function deployHub(uint16 centrifugeId_, ISafe adminSafe_, address deployer, bool isTests) public virtual {
-        deployCommon(centrifugeId_, adminSafe_, deployer, isTests);
+    function deployHub(CommonInput memory input, address deployer) public {
+        deployCommon(input, deployer);
 
         // HubRegistry
         bytes32 hubRegistrySalt = generateSalt("hubRegistry");

--- a/script/HubDeployer.s.sol
+++ b/script/HubDeployer.s.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.28;
 
 import {IdentityValuation} from "src/misc/IdentityValuation.sol";
 
-import {ISafe} from "src/common/Guardian.sol";
 import {AssetId, newAssetId} from "src/common/types/AssetId.sol";
 
 import {Hub} from "src/hub/Hub.sol";

--- a/script/SpokeDeployer.s.sol
+++ b/script/SpokeDeployer.s.sol
@@ -21,7 +21,7 @@ import {FreezeOnly} from "src/hooks/FreezeOnly.sol";
 import {FullRestrictions} from "src/hooks/FullRestrictions.sol";
 import {RedemptionRestrictions} from "src/hooks/RedemptionRestrictions.sol";
 
-import {CommonDeployer} from "script/CommonDeployer.s.sol";
+import {CommonDeployer, CommonInput} from "script/CommonDeployer.s.sol";
 
 import "forge-std/Script.sol";
 
@@ -42,8 +42,8 @@ contract SpokeDeployer is CommonDeployer {
     address public redemptionRestrictionsHook;
     address public fullRestrictionsHook;
 
-    function deploySpoke(uint16 centrifugeId_, ISafe adminSafe_, address deployer, bool isTests) public virtual {
-        deployCommon(centrifugeId_, adminSafe_, deployer, isTests);
+    function deploySpoke(CommonInput memory input, address deployer) public {
+        deployCommon(input, deployer);
 
         // Note: This function was split into smaller helper functions to avoid
         // "stack too deep" compilation errors that occur when too many local

--- a/script/SpokeDeployer.s.sol
+++ b/script/SpokeDeployer.s.sol
@@ -5,8 +5,6 @@ import {Escrow} from "src/misc/Escrow.sol";
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
 import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
 
-import {ISafe} from "src/common/Guardian.sol";
-
 import {SyncManager} from "src/vaults/SyncManager.sol";
 import {VaultRouter} from "src/vaults/VaultRouter.sol";
 import {AsyncRequestManager} from "src/vaults/AsyncRequestManager.sol";

--- a/test/common/Deployment.t.sol
+++ b/test/common/Deployment.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.28;
 
 import {ISafe} from "src/common/interfaces/IGuardian.sol";
 
-import {CommonDeployer} from "script/CommonDeployer.s.sol";
+import {CommonDeployer, CommonInput} from "script/CommonDeployer.s.sol";
 
 import "forge-std/Test.sol";
 
@@ -12,7 +12,15 @@ contract CommonDeploymentTest is CommonDeployer, Test {
     ISafe immutable ADMIN_SAFE = ISafe(makeAddr("AdminSafe"));
 
     function setUp() public virtual {
-        deployCommon(CENTRIFUGE_ID, ADMIN_SAFE, address(this), true);
+        CommonInput memory input = CommonInput({
+            centrifugeId: CENTRIFUGE_ID,
+            adminSafe: ADMIN_SAFE,
+            messageGasLimit: 0,
+            maxBatchSize: 0,
+            isTests: true
+        });
+
+        deployCommon(input, address(this));
         removeCommonDeployerAccess(address(this));
     }
 

--- a/test/hub/Deployment.t.sol
+++ b/test/hub/Deployment.t.sol
@@ -3,13 +3,21 @@ pragma solidity 0.8.28;
 
 import {HubDeployer} from "script/HubDeployer.s.sol";
 
-import {CommonDeploymentTest} from "test/common/Deployment.t.sol";
+import {CommonDeploymentTest, CommonInput} from "test/common/Deployment.t.sol";
 
 import "forge-std/Test.sol";
 
 contract HubDeploymentTest is HubDeployer, CommonDeploymentTest {
     function setUp() public virtual override {
-        deployHub(CENTRIFUGE_ID, ADMIN_SAFE, address(this), true);
+        CommonInput memory input = CommonInput({
+            centrifugeId: CENTRIFUGE_ID,
+            adminSafe: ADMIN_SAFE,
+            messageGasLimit: 0,
+            maxBatchSize: 0,
+            isTests: true
+        });
+
+        deployHub(input, address(this));
         removeHubDeployerAccess(address(this));
     }
 

--- a/test/hub/integration/BaseTest.sol
+++ b/test/hub/integration/BaseTest.sol
@@ -9,8 +9,7 @@ import {AccountId} from "src/common/types/AccountId.sol";
 import {IAdapter} from "src/common/interfaces/IAdapter.sol";
 import {AssetId, newAssetId} from "src/common/types/AssetId.sol";
 
-import {HubDeployer, ISafe} from "script/HubDeployer.s.sol";
-import {MESSAGE_COST_ENV} from "script/CommonDeployer.s.sol";
+import {HubDeployer, ISafe, CommonInput} from "script/HubDeployer.s.sol";
 
 import {MockVaults} from "test/hub/mocks/MockVaults.sol";
 import {MockValuation} from "test/common/mocks/MockValuation.sol";
@@ -72,11 +71,16 @@ contract BaseTest is HubDeployer, Test {
     }
 
     function setUp() public virtual {
-        // Pre deployment
-        vm.setEnv(MESSAGE_COST_ENV, vm.toString(GAS));
-
         // Deployment
-        deployHub(CHAIN_CP, ISafe(ADMIN), address(this), true);
+        CommonInput memory input = CommonInput({
+            centrifugeId: CHAIN_CP,
+            adminSafe: adminSafe,
+            messageGasLimit: uint128(GAS),
+            maxBatchSize: uint128(GAS) * 100,
+            isTests: true
+        });
+
+        deployHub(input, address(this));
         _mockStuff();
         removeHubDeployerAccess(address(this));
 

--- a/test/hub/integration/BaseTest.sol
+++ b/test/hub/integration/BaseTest.sol
@@ -9,7 +9,7 @@ import {AccountId} from "src/common/types/AccountId.sol";
 import {IAdapter} from "src/common/interfaces/IAdapter.sol";
 import {AssetId, newAssetId} from "src/common/types/AssetId.sol";
 
-import {HubDeployer, ISafe, CommonInput} from "script/HubDeployer.s.sol";
+import {HubDeployer, CommonInput} from "script/HubDeployer.s.sol";
 
 import {MockVaults} from "test/hub/mocks/MockVaults.sol";
 import {MockValuation} from "test/common/mocks/MockValuation.sol";

--- a/test/integration/EndToEnd.t.sol
+++ b/test/integration/EndToEnd.t.sol
@@ -199,15 +199,16 @@ contract EndToEndDeployment is Test {
     }
 
     function _wire(FullDeployer deploy, uint16 remoteCentrifugeId, IAdapter adapter) internal {
-        vm.startPrank(address(deploy.guardian().safe()));
+        vm.startPrank(address(deploy));
         IAuth(address(adapter)).rely(address(deploy.root()));
         IAuth(address(adapter)).rely(address(deploy.guardian()));
         IAuth(address(adapter)).deny(address(deploy));
+        vm.stopPrank();
 
+        vm.startPrank(address(deploy.guardian().safe()));
         IAdapter[] memory adapters = new IAdapter[](1);
         adapters[0] = adapter;
         deploy.guardian().wireAdapters(remoteCentrifugeId, adapters);
-
         vm.stopPrank();
     }
 
@@ -228,7 +229,7 @@ contract EndToEndDeployment is Test {
         adapter = new LocalAdapter(localCentrifugeId, deploy.multiAdapter(), address(deploy));
         _wire(deploy, remoteCentrifugeId, adapter);
 
-        deploy.removeFullDeployerAccess(address(deploy), "testnet");
+        deploy.removeFullDeployerAccess(address(deploy));
     }
 
     function _setSpoke(FullDeployer deploy, uint16 centrifugeId, CSpoke storage s_) internal {
@@ -406,7 +407,6 @@ contract EndToEndFlows is EndToEndUtils {
     }
 
     function _testAsyncDeposit(bool sameChain, bool nonZeroPrices) public {
-        _setSpoke(sameChain);
         _configurePool(sameChain);
         nonZeroPrices ? _configurePrices(ASSET_PRICE, SHARE_PRICE) : _configurePrices(ZERO_PRICE, ZERO_PRICE);
 
@@ -442,7 +442,6 @@ contract EndToEndFlows is EndToEndUtils {
     }
 
     function _testSyncDeposit(bool sameChain, bool nonZeroPrices) public {
-        _setSpoke(sameChain);
         _configurePool(sameChain);
         nonZeroPrices ? _configurePrices(ASSET_PRICE, SHARE_PRICE) : _configurePrices(ZERO_PRICE, ZERO_PRICE);
 
@@ -625,7 +624,6 @@ contract EndToEndUseCases is EndToEndFlows {
 
     /// forge-config: default.isolate = true
     function testAsyncDepositCancel(bool sameChain, bool nonZeroPrices) public {
-        _setSpoke(sameChain);
         _configurePool(sameChain);
         nonZeroPrices ? _configurePrices(ASSET_PRICE, SHARE_PRICE) : _configurePrices(ZERO_PRICE, ZERO_PRICE);
 

--- a/test/spoke/BaseTest.sol
+++ b/test/spoke/BaseTest.sol
@@ -27,8 +27,7 @@ import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
 import {TokenFactory} from "src/spoke/factories/TokenFactory.sol";
 import {IVaultFactory} from "src/spoke/factories/interfaces/IVaultFactory.sol";
 
-import {SpokeDeployer} from "script/SpokeDeployer.s.sol";
-import {MESSAGE_COST_ENV} from "script/CommonDeployer.s.sol";
+import {SpokeDeployer, CommonInput} from "script/SpokeDeployer.s.sol";
 
 import {MockSafe} from "test/spoke/mocks/MockSafe.sol";
 import {MockERC6909} from "test/misc/mocks/MockERC6909.sol";
@@ -92,8 +91,16 @@ contract BaseTest is SpokeDeployer, Test {
         pausers[0] = self;
         ISafe adminSafe = new MockSafe(pausers, 1);
 
-        vm.setEnv(MESSAGE_COST_ENV, vm.toString(GAS_COST_LIMIT));
-        deploySpoke(THIS_CHAIN_ID, adminSafe, address(this), true);
+        // deploy core contracts
+        CommonInput memory input = CommonInput({
+            centrifugeId: THIS_CHAIN_ID,
+            adminSafe: adminSafe,
+            messageGasLimit: uint128(GAS_COST_LIMIT),
+            maxBatchSize: uint128(GAS_COST_LIMIT) * 100,
+            isTests: true
+        });
+
+        deploySpoke(input, address(this));
         guardian.file("safe", address(adminSafe));
 
         // deploy mock adapters

--- a/test/spoke/Deployment.t.sol
+++ b/test/spoke/Deployment.t.sol
@@ -3,13 +3,21 @@ pragma solidity 0.8.28;
 
 import {SpokeDeployer} from "script/SpokeDeployer.s.sol";
 
-import {CommonDeploymentTest} from "test/common/Deployment.t.sol";
+import {CommonDeploymentTest, CommonInput} from "test/common/Deployment.t.sol";
 
 import "forge-std/Test.sol";
 
 contract SpokeDeploymentTest is SpokeDeployer, CommonDeploymentTest {
     function setUp() public virtual override {
-        deploySpoke(CENTRIFUGE_ID, ADMIN_SAFE, address(this), true);
+        CommonInput memory input = CommonInput({
+            centrifugeId: CENTRIFUGE_ID,
+            adminSafe: ADMIN_SAFE,
+            messageGasLimit: 0,
+            maxBatchSize: 0,
+            isTests: true
+        });
+
+        deploySpoke(input, address(this));
         removeSpokeDeployerAccess(address(this));
     }
 


### PR DESCRIPTION
- Add Input struct to the deploy script to easy adapt to new parameters.
- Fix the write/read env value concurrence issue in EndToEnd tests
- Deploy access correctly removed in EndToEnd tests

Next incoming PRs: CBD & spliting deployments