### PR TITLE
FuzzTests: Fixing bytes params in handlers

### DIFF
--- a/test/hub/fuzzing/recon-hub/CryticToFoundry.sol
+++ b/test/hub/fuzzing/recon-hub/CryticToFoundry.sol
@@ -70,15 +70,15 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
         hub_createAccount(poolId.raw(), LOSS_ACCOUNT, IS_DEBIT_NORMAL);
         hub_createAccount(poolId.raw(), GAIN_ACCOUNT, IS_DEBIT_NORMAL);
         hub_initializeHolding(
-            poolId.raw(), scId.raw(), identityValuation, ASSET_ACCOUNT, EQUITY_ACCOUNT, LOSS_ACCOUNT, GAIN_ACCOUNT
+            poolId.raw(), uint128(scId.raw()), identityValuation, ASSET_ACCOUNT, EQUITY_ACCOUNT, LOSS_ACCOUNT, GAIN_ACCOUNT
         );
 
         // request deposit
-        hub_depositRequest(poolId.raw(), scId.raw(), INVESTOR_AMOUNT);
+        hub_depositRequest(poolId.raw(), uint128(scId.raw()), INVESTOR_AMOUNT);
 
         uint32 depositEpochId = shareClassManager.nowDepositEpoch(scId, assetId);
-        hub_approveDeposits(poolId.raw(), scId.raw(), assetId.raw(), depositEpochId, APPROVED_INVESTOR_AMOUNT);
-        hub_issueShares(poolId.raw(), scId.raw(), assetId.raw(), depositEpochId, NAV_PER_SHARE);
+        hub_approveDeposits(poolId.raw(), uint128(scId.raw()), assetId.raw(), depositEpochId, APPROVED_INVESTOR_AMOUNT);
+        hub_issueShares(poolId.raw(), uint128(scId.raw()), assetId.raw(), depositEpochId, NAV_PER_SHARE);
 
         // claim deposit
         hub_notifyDeposit(poolId.raw(), scId.raw(), assetId.raw(), MAX_CLAIMS);
@@ -90,12 +90,12 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
         (poolId, scId) = test_request_deposit();
 
         // request redemption
-        hub_redeemRequest(poolId.raw(), scId.raw(), assetId.raw(), SHARE_AMOUNT);
+        hub_redeemRequest(poolId.raw(), uint128(scId.raw()), assetId.raw(), SHARE_AMOUNT);
 
         // executed via the PoolRouter
         uint32 redeemEpochId = shareClassManager.nowRedeemEpoch(scId, assetId);
-        hub_approveRedeems(poolId.raw(), scId.raw(), assetId.raw(), redeemEpochId, APPROVED_SHARE_AMOUNT);
-        hub_revokeShares(poolId.raw(), scId.raw(), redeemEpochId, APPROVED_SHARE_AMOUNT);
+        hub_approveRedeems(poolId.raw(), uint128(scId.raw()), assetId.raw(), redeemEpochId, APPROVED_SHARE_AMOUNT);
+        hub_revokeShares(poolId.raw(), uint128(scId.raw()), redeemEpochId, APPROVED_SHARE_AMOUNT);
 
         // claim redemption
         hub_notifyRedeem(poolId.raw(), scId.raw(), assetId.raw(), MAX_CLAIMS);
@@ -124,7 +124,7 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
             18, ISO_CODE, SC_SALT, true, INVESTOR_AMOUNT, APPROVED_INVESTOR_AMOUNT, NAV_PER_SHARE
         );
 
-        hub_notifyShareClass(poolId.raw(), CENTIFUGE_CHAIN_ID, scId.raw(), SC_HOOK);
+        hub_notifyShareClass(poolId.raw(), CENTIFUGE_CHAIN_ID, uint128(scId.raw()), uint256(SC_HOOK));
     }
 
     function test_shortcut_deposit_claim_and_cancel() public {
@@ -152,9 +152,9 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
             18, ISO_CODE, SC_SALT, true, INVESTOR_AMOUNT, APPROVED_INVESTOR_AMOUNT, NAV_PER_SHARE
         );
 
-        hub_redeemRequest(poolId.raw(), scId.raw(), ISO_CODE, SHARE_AMOUNT);
+        hub_redeemRequest(poolId.raw(), uint128(scId.raw()), ISO_CODE, SHARE_AMOUNT);
 
-        hub_cancelRedeemRequest(poolId.raw(), scId.raw());
+        hub_cancelRedeemRequest(poolId.raw(), uint128(scId.raw()));
     }
 
     function test_shortcut_notify_share_class() public {

--- a/test/hub/fuzzing/recon-hub/TargetFunctions.sol
+++ b/test/hub/fuzzing/recon-hub/TargetFunctions.sol
@@ -66,7 +66,7 @@ abstract contract TargetFunctions is AdminTargets, ManagerTargets, HubTargets, T
         (poolId, scId) = shortcut_create_pool_and_holding(decimals, isoCode, salt, isIdentityValuation);
 
         // request deposit
-        hub_depositRequest(PoolId.unwrap(poolId), ShareClassId.unwrap(scId), amount);
+        hub_depositRequest(PoolId.unwrap(poolId), uint128(ShareClassId.unwrap(scId)), amount);
 
         // approve and issue shares as the pool admin
         shortcut_approve_and_issue_shares(
@@ -118,7 +118,7 @@ abstract contract TargetFunctions is AdminTargets, ManagerTargets, HubTargets, T
         hub_notifyDeposit(PoolId.unwrap(poolId), ShareClassId.unwrap(scId), assetId.raw(), MAX_CLAIMS);
 
         // cancel deposit
-        hub_cancelDepositRequest(PoolId.unwrap(poolId), ShareClassId.unwrap(scId));
+        hub_cancelDepositRequest(PoolId.unwrap(poolId), uint128(ShareClassId.unwrap(scId)));
 
         return (poolId, scId);
     }
@@ -139,7 +139,7 @@ abstract contract TargetFunctions is AdminTargets, ManagerTargets, HubTargets, T
             shortcut_deposit(decimals, isoCode, salt, isIdentityValuation, amount, maxApproval, navPerShare);
 
         // cancel deposit
-        hub_cancelDepositRequest(PoolId.unwrap(poolId), ShareClassId.unwrap(scId));
+        hub_cancelDepositRequest(PoolId.unwrap(poolId), uint128(ShareClassId.unwrap(scId)));
 
         return (poolId, scId);
     }
@@ -164,7 +164,7 @@ abstract contract TargetFunctions is AdminTargets, ManagerTargets, HubTargets, T
         hub_notifyDeposit(PoolId.unwrap(poolId), ShareClassId.unwrap(scId), assetId.raw(), MAX_CLAIMS);
 
         // cancel deposit
-        hub_cancelDepositRequest(PoolId.unwrap(poolId), ShareClassId.unwrap(scId));
+        hub_cancelDepositRequest(PoolId.unwrap(poolId), uint128(ShareClassId.unwrap(scId)));
 
         return (poolId, scId);
     }
@@ -179,7 +179,7 @@ abstract contract TargetFunctions is AdminTargets, ManagerTargets, HubTargets, T
         bool isIdentityValuation
     ) public clearQueuedCalls {
         // request redemption
-        hub_redeemRequest(poolId, scId, isoCode, shareAmount);
+        hub_redeemRequest(poolId, uint128(scId), isoCode, shareAmount);
 
         // approve and revoke shares as the pool admin
         shortcut_approve_and_revoke_shares(poolId, scId, isoCode, maxApproval, navPerShare, isIdentityValuation);
@@ -227,7 +227,7 @@ abstract contract TargetFunctions is AdminTargets, ManagerTargets, HubTargets, T
         );
 
         // request redemption
-        hub_redeemRequest(PoolId.unwrap(poolId), ShareClassId.unwrap(scId), isoCode, shareAmount);
+        hub_redeemRequest(PoolId.unwrap(poolId), uint128(ShareClassId.unwrap(scId)), isoCode, shareAmount);
 
         // approve and revoke shares as the pool admin
         // revokes the shares that were issued in the deposit
@@ -262,10 +262,10 @@ abstract contract TargetFunctions is AdminTargets, ManagerTargets, HubTargets, T
         );
 
         // request redemption
-        hub_redeemRequest(PoolId.unwrap(poolId), ShareClassId.unwrap(scId), isoCode, shareAmount);
+        hub_redeemRequest(PoolId.unwrap(poolId), uint128(ShareClassId.unwrap(scId)), isoCode, shareAmount);
 
         // cancel redemption
-        hub_cancelRedeemRequest(PoolId.unwrap(poolId), ShareClassId.unwrap(scId));
+        hub_cancelRedeemRequest(PoolId.unwrap(poolId), uint128(ShareClassId.unwrap(scId)));
     }
 
     function shortcut_create_pool_and_update_holding(
@@ -309,7 +309,7 @@ abstract contract TargetFunctions is AdminTargets, ManagerTargets, HubTargets, T
 
             hub_updateHoldingAmount(
                 PoolId.unwrap(poolId),
-                ShareClassId.unwrap(scId),
+                uint128(ShareClassId.unwrap(scId)),
                 assetId.raw(),
                 amount,
                 pricePoolPerAsset,
@@ -336,7 +336,7 @@ abstract contract TargetFunctions is AdminTargets, ManagerTargets, HubTargets, T
             transientValuation_setPrice(assetId, assetId, INITIAL_PRICE.raw());
         }
 
-        hub_updateHoldingValue(PoolId.unwrap(poolId), ShareClassId.unwrap(scId), assetId.raw());
+        hub_updateHoldingValue(PoolId.unwrap(poolId), uint128(ShareClassId.unwrap(scId)), assetId.raw());
     }
 
     function shortcut_create_pool_and_update_journal(
@@ -377,7 +377,7 @@ abstract contract TargetFunctions is AdminTargets, ManagerTargets, HubTargets, T
         AssetId assetId = newAssetId(isoCode);
         hub_updateHoldingValuation(
             poolId.raw(),
-            ShareClassId.unwrap(scId),
+            uint128(ShareClassId.unwrap(scId)),
             assetId.raw(),
             isIdentityValuation ? IValuation(address(identityValuation)) : IValuation(address(transientValuation))
         );
@@ -400,7 +400,7 @@ abstract contract TargetFunctions is AdminTargets, ManagerTargets, HubTargets, T
         );
 
         // set chainId and hook to constants because we're mocking Gateway so they're not needed
-        hub_notifyShareClass(poolId.raw(), CENTIFUGE_CHAIN_ID, ShareClassId.unwrap(scId), bytes32("ExampleHookData"));
+        hub_notifyShareClass(poolId.raw(), CENTIFUGE_CHAIN_ID, uint128(ShareClassId.unwrap(scId)), uint256(bytes32("ExampleHookData")));
     }
 
     /// === POOL ADMIN SHORTCUTS === ///
@@ -420,7 +420,7 @@ abstract contract TargetFunctions is AdminTargets, ManagerTargets, HubTargets, T
         hub_createAccount(poolId, LOSS_ACCOUNT, IS_DEBIT_NORMAL);
         hub_createAccount(poolId, GAIN_ACCOUNT, IS_DEBIT_NORMAL);
 
-        hub_initializeHolding(poolId, scId, valuation, ASSET_ACCOUNT, EQUITY_ACCOUNT, LOSS_ACCOUNT, GAIN_ACCOUNT);
+        hub_initializeHolding(poolId, uint128(scId), valuation, ASSET_ACCOUNT, EQUITY_ACCOUNT, LOSS_ACCOUNT, GAIN_ACCOUNT);
     }
 
     function shortcut_approve_and_issue_shares(
@@ -439,8 +439,8 @@ abstract contract TargetFunctions is AdminTargets, ManagerTargets, HubTargets, T
         transientValuation_setPrice(assetId, assetId, INITIAL_PRICE.raw());
 
         uint32 depositEpochId = shareClassManager.nowDepositEpoch(ShareClassId.wrap(scId), assetId);
-        hub_approveDeposits(poolId, scId, assetId.raw(), depositEpochId, maxApproval);
-        hub_issueShares(poolId, scId, assetId.raw(), depositEpochId, navPerShare);
+        hub_approveDeposits(poolId, uint128(scId), assetId.raw(), depositEpochId, maxApproval);
+        hub_issueShares(poolId, uint128(scId), assetId.raw(), depositEpochId, navPerShare);
     }
 
     function shortcut_approve_and_revoke_shares(
@@ -457,11 +457,11 @@ abstract contract TargetFunctions is AdminTargets, ManagerTargets, HubTargets, T
         AssetId assetId = newAssetId(isoCode);
 
         uint32 redeemEpochId = shareClassManager.nowRedeemEpoch(ShareClassId.wrap(scId), assetId);
-        hub_approveRedeems(poolId, scId, assetId.raw(), redeemEpochId, maxApproval);
-        hub_revokeShares(poolId, scId, redeemEpochId, navPerShare);
+        hub_approveRedeems(poolId, uint128(scId), assetId.raw(), redeemEpochId, maxApproval);
+        hub_revokeShares(poolId, uint128(scId), redeemEpochId, navPerShare);
     }
 
-    function shortcut_update_restriction(uint16 poolIdEntropy, uint16 shareClassEntropy, bytes calldata payload)
+    function shortcut_update_restriction(uint16 poolIdEntropy, uint16 shareClassEntropy, uint256 payloadAsUint)
         public
     {
         if (createdPools.length > 0) {
@@ -471,7 +471,7 @@ abstract contract TargetFunctions is AdminTargets, ManagerTargets, HubTargets, T
 
             // get a random share class id
             ShareClassId scId = shareClassManager.previewShareClassId(poolId, shareClassEntropy % shareClassCount);
-            hub_updateRestriction(poolId.raw(), scId.raw(), CENTIFUGE_CHAIN_ID, payload);
+            hub_updateRestriction(poolId.raw(), uint128(scId.raw()), CENTIFUGE_CHAIN_ID, payloadAsUint);
         }
     }
 

--- a/test/hub/fuzzing/recon-hub/targets/AdminTargets.sol
+++ b/test/hub/fuzzing/recon-hub/targets/AdminTargets.sol
@@ -56,13 +56,13 @@ abstract contract AdminTargets is BaseTargetFunctions, Properties {
 
     function hub_approveDeposits(
         uint64 poolIdAsUint,
-        bytes16 scIdAsBytes,
+        uint128 scIdAsUint,
         uint128 paymentAssetIdAsUint,
         uint32 nowDepositEpochId,
         uint128 maxApproval
     ) public {
         PoolId poolId = PoolId.wrap(poolIdAsUint);
-        ShareClassId scId = ShareClassId.wrap(scIdAsBytes);
+        ShareClassId scId = ShareClassId.wrap(bytes16(uint128(scIdAsUint)));
         AssetId paymentAssetId = AssetId.wrap(paymentAssetIdAsUint);
         uint128 pendingDepositBefore = shareClassManager.pendingDeposit(scId, paymentAssetId);
 
@@ -78,18 +78,18 @@ abstract contract AdminTargets is BaseTargetFunctions, Properties {
         PoolId poolId = Helpers.getRandomPoolId(createdPools, poolIdEntropy);
         ShareClassId scId = Helpers.getRandomShareClassIdForPool(shareClassManager, poolId, scEntropy);
         AssetId paymentAssetId = hubRegistry.currency(poolId);
-        hub_approveDeposits(poolId.raw(), scId.raw(), paymentAssetId.raw(), nowDepositEpochId, maxApproval);
+        hub_approveDeposits(poolId.raw(), uint128(scId.raw()), paymentAssetId.raw(), nowDepositEpochId, maxApproval);
     }
 
     function hub_approveRedeems(
         uint64 poolIdAsUint,
-        bytes16 scIdAsBytes,
+        uint128 scIdAsUint,
         uint128 assetIdAsUint,
         uint32 nowRedeemEpochId,
         uint128 maxApproval
     ) public {
         PoolId poolId = PoolId.wrap(poolIdAsUint);
-        ShareClassId scId = ShareClassId.wrap(scIdAsBytes);
+        ShareClassId scId = ShareClassId.wrap(bytes16(uint128(scIdAsUint)));
         AssetId payoutAssetId = AssetId.wrap(assetIdAsUint);
         uint128 pendingRedeemBefore = shareClassManager.pendingRedeem(scId, payoutAssetId);
 
@@ -105,7 +105,7 @@ abstract contract AdminTargets is BaseTargetFunctions, Properties {
         PoolId poolId = Helpers.getRandomPoolId(createdPools, poolIdEntropy);
         ShareClassId scId = Helpers.getRandomShareClassIdForPool(shareClassManager, poolId, scEntropy);
         AssetId payoutAssetId = hubRegistry.currency(poolId);
-        hub_approveRedeems(poolId.raw(), scId.raw(), payoutAssetId.raw(), nowRedeemEpochId, maxApproval);
+        hub_approveRedeems(poolId.raw(), uint128(scId.raw()), payoutAssetId.raw(), nowRedeemEpochId, maxApproval);
     }
 
     function hub_createAccount(uint64 poolIdAsUint, uint32 accountAsInt, bool isDebitNormal) public {
@@ -116,7 +116,7 @@ abstract contract AdminTargets is BaseTargetFunctions, Properties {
 
     function hub_initializeHolding(
         uint64 poolIdAsUint,
-        bytes16 scIdAsBytes,
+        uint128 scIdAsUint,
         IValuation valuation,
         uint32 assetAccountAsUint,
         uint32 equityAccountAsUint,
@@ -124,7 +124,7 @@ abstract contract AdminTargets is BaseTargetFunctions, Properties {
         uint32 gainAccountAsUint
     ) public {
         PoolId poolId = PoolId.wrap(poolIdAsUint);
-        ShareClassId scId = ShareClassId.wrap(scIdAsBytes);
+        ShareClassId scId = ShareClassId.wrap(bytes16(uint128(scIdAsUint)));
         AssetId assetId = hubRegistry.currency(poolId);
 
         hub.initializeHolding(
@@ -161,7 +161,7 @@ abstract contract AdminTargets is BaseTargetFunctions, Properties {
 
         hub_initializeHolding(
             poolId.raw(),
-            scId.raw(),
+            uint128(scId.raw()),
             valuation,
             assetAccountAsUint,
             equityAccountAsUint,
@@ -172,13 +172,13 @@ abstract contract AdminTargets is BaseTargetFunctions, Properties {
 
     function hub_issueShares(
         uint64 poolIdAsUint,
-        bytes16 scIdAsBytes,
+        uint128 scIdAsUint,
         uint128 assetIdAsUint,
         uint32 nowIssueEpochId,
         uint128 navPerShare
     ) public {
         PoolId poolId = PoolId.wrap(poolIdAsUint);
-        ShareClassId scId = ShareClassId.wrap(scIdAsBytes);
+        ShareClassId scId = ShareClassId.wrap(bytes16(uint128(scIdAsUint)));
         AssetId assetId = AssetId.wrap(assetIdAsUint);
         hub.issueShares(poolId, scId, assetId, nowIssueEpochId, D18.wrap(navPerShare));
     }
@@ -192,7 +192,7 @@ abstract contract AdminTargets is BaseTargetFunctions, Properties {
         PoolId poolId = Helpers.getRandomPoolId(createdPools, poolIdEntropy);
         ShareClassId scId = Helpers.getRandomShareClassIdForPool(shareClassManager, poolId, scEntropy);
         AssetId assetId = hubRegistry.currency(poolId);
-        hub_issueShares(poolId.raw(), scId.raw(), assetId.raw(), nowIssueEpochId, navPerShare);
+        hub_issueShares(poolId.raw(), uint128(scId.raw()), assetId.raw(), nowIssueEpochId, navPerShare);
     }
 
     function hub_notifyPool(uint64 poolIdAsUint, uint16 centrifugeId) public {
@@ -200,23 +200,23 @@ abstract contract AdminTargets is BaseTargetFunctions, Properties {
         hub.notifyPool(poolId, centrifugeId);
     }
 
-    function hub_notifyShareClass(uint64 poolIdAsUint, uint16 centrifugeId, bytes16 scIdAsBytes, bytes32 hook) public {
+    function hub_notifyShareClass(uint64 poolIdAsUint, uint16 centrifugeId, uint128 scIdAsUint, uint256 hook) public {
         PoolId poolId = PoolId.wrap(poolIdAsUint);
-        ShareClassId scId = ShareClassId.wrap(scIdAsBytes);
-        hub.notifyShareClass(poolId, scId, centrifugeId, hook);
+        ShareClassId scId = ShareClassId.wrap(bytes16(uint128(scIdAsUint)));
+        hub.notifyShareClass(poolId, scId, centrifugeId, bytes32(hook));
     }
 
-    function hub_notifyShareClass_clamped(uint64 poolIdEntropy, uint32 scEntropy, bytes32 hook) public {
+    function hub_notifyShareClass_clamped(uint64 poolIdEntropy, uint32 scEntropy, uint256 hook) public {
         PoolId poolId = Helpers.getRandomPoolId(createdPools, poolIdEntropy);
         ShareClassId scId = Helpers.getRandomShareClassIdForPool(shareClassManager, poolId, scEntropy);
-        hub_notifyShareClass(poolId.raw(), CENTIFUGE_CHAIN_ID, scId.raw(), hook);
+        hub_notifyShareClass(poolId.raw(), CENTIFUGE_CHAIN_ID, uint128(scId.raw()), hook);
     }
 
-    function hub_revokeShares(uint64 poolIdAsUint, bytes16 scIdAsBytes, uint32 nowRevokeEpochId, uint128 navPerShare)
+    function hub_revokeShares(uint64 poolIdAsUint, uint128 scIdAsUint, uint32 nowRevokeEpochId, uint128 navPerShare)
         public
     {
         PoolId poolId = PoolId.wrap(poolIdAsUint);
-        ShareClassId scId = ShareClassId.wrap(scIdAsBytes);
+        ShareClassId scId = ShareClassId.wrap(bytes16(uint128(scIdAsUint)));
         AssetId payoutAssetId = hubRegistry.currency(poolId);
         hub.revokeShares(poolId, scId, payoutAssetId, nowRevokeEpochId, D18.wrap(navPerShare));
     }
@@ -229,51 +229,54 @@ abstract contract AdminTargets is BaseTargetFunctions, Properties {
     ) public {
         PoolId poolId = Helpers.getRandomPoolId(createdPools, poolIdEntropy);
         ShareClassId scId = Helpers.getRandomShareClassIdForPool(shareClassManager, poolId, scEntropy);
-        hub_revokeShares(poolId.raw(), scId.raw(), nowRevokeEpochId, navPerShare);
+        hub_revokeShares(poolId.raw(), uint128(scId.raw()), nowRevokeEpochId, navPerShare);
     }
 
-    function hub_setAccountMetadata(uint64 poolIdAsUint, uint32 accountAsInt, bytes memory metadata) public {
+    function hub_setAccountMetadata(uint64 poolIdAsUint, uint32 accountAsInt, uint256 metadataAsUint) public {
         PoolId poolId = PoolId.wrap(poolIdAsUint);
         AccountId account = AccountId.wrap(accountAsInt);
+        bytes memory metadata = abi.encodePacked(metadataAsUint);
         hub.setAccountMetadata(poolId, account, metadata);
     }
 
     function hub_setHoldingAccountId(
         uint64 poolIdAsUint,
-        bytes16 scIdAsBytes,
+        uint128 scIdAsUint,
         uint128 assetIdAsUint,
         uint8 kind,
         uint32 accountIdAsInt
     ) public {
         PoolId poolId = PoolId.wrap(poolIdAsUint);
-        ShareClassId scId = ShareClassId.wrap(scIdAsBytes);
+        ShareClassId scId = ShareClassId.wrap(bytes16(uint128(scIdAsUint)));
         AssetId assetId = AssetId.wrap(assetIdAsUint);
         AccountId accountId = AccountId.wrap(accountIdAsInt);
         hub.setHoldingAccountId(poolId, scId, assetId, kind, accountId);
     }
 
-    function hub_setPoolMetadata(uint64 poolIdAsUint, bytes memory metadata) public {
+    function hub_setPoolMetadata(uint64 poolIdAsUint, uint256 metadataAsUint) public {
         PoolId poolId = PoolId.wrap(poolIdAsUint);
+        bytes memory metadata = abi.encodePacked(metadataAsUint);
         hub.setPoolMetadata(poolId, metadata);
     }
 
     function hub_updateHoldingValuation(
         uint64 poolIdAsUint,
-        bytes16 scIdAsBytes,
+        uint128 scIdAsUint,
         uint128 assetIdAsUint,
         IValuation valuation
     ) public {
         PoolId poolId = PoolId.wrap(poolIdAsUint);
-        ShareClassId scId = ShareClassId.wrap(scIdAsBytes);
+        ShareClassId scId = ShareClassId.wrap(bytes16(uint128(scIdAsUint)));
         AssetId assetId = AssetId.wrap(assetIdAsUint);
         hub.updateHoldingValuation(poolId, scId, assetId, valuation);
     }
 
-    function hub_updateRestriction(uint64 poolIdAsUint, bytes16 scIdAsBytes, uint16 chainId, bytes calldata payload)
+    function hub_updateRestriction(uint64 poolIdAsUint, uint128 scIdAsUint, uint16 chainId, uint256 payloadAsUint)
         public
     {
         PoolId poolId = PoolId.wrap(poolIdAsUint);
-        ShareClassId scId = ShareClassId.wrap(scIdAsBytes);
+        ShareClassId scId = ShareClassId.wrap(bytes16(uint128(scIdAsUint)));
+        bytes memory payload = abi.encodePacked(payloadAsUint);
         hub.updateRestriction(poolId, scId, chainId, payload, 0);
     }
 
@@ -298,9 +301,9 @@ abstract contract AdminTargets is BaseTargetFunctions, Properties {
     /// @dev Property: after successfully calling requestDeposit for an investor, their depositRequest[..].lastUpdate
     /// equals the current epoch id epochId[poolId]
     /// @dev Property: _updateDepositRequest should never revert due to underflow
-    function hub_depositRequest(uint64 poolIdAsUint, bytes16 scIdAsBytes, uint128 amount) public updateGhosts {
+    function hub_depositRequest(uint64 poolIdAsUint, uint128 scIdAsUint, uint128 amount) public updateGhosts {
         PoolId poolId = PoolId.wrap(poolIdAsUint);
-        ShareClassId scId = ShareClassId.wrap(scIdAsBytes);
+        ShareClassId scId = ShareClassId.wrap(bytes16(uint128(scIdAsUint)));
         AssetId depositAssetId = hubRegistry.currency(poolId);
         bytes32 investor = _getActor().toBytes32();
 
@@ -327,17 +330,17 @@ abstract contract AdminTargets is BaseTargetFunctions, Properties {
     function hub_depositRequest_clamped(uint64 poolIdEntropy, uint32 scEntropy, uint128 amount) public updateGhosts {
         PoolId poolId = _getRandomPoolId(poolIdEntropy);
         ShareClassId scId = _getRandomShareClassIdForPool(poolId, scEntropy);
-        hub_depositRequest(poolId.raw(), scId.raw(), amount);
+        hub_depositRequest(poolId.raw(), uint128(scId.raw()), amount);
     }
 
     /// @dev Property: After successfully calling redeemRequest for an investor, their redeemRequest[..].lastUpdate
     /// equals the current epoch id epochId[poolId]
-    function hub_redeemRequest(uint64 poolIdAsUint, bytes16 scIdAsBytes, uint128 assetIdAsUint, uint128 amount)
+    function hub_redeemRequest(uint64 poolIdAsUint, uint128 scIdAsUint, uint128 assetIdAsUint, uint128 amount)
         public
         updateGhosts
     {
         PoolId poolId = PoolId.wrap(poolIdAsUint);
-        ShareClassId scId = ShareClassId.wrap(scIdAsBytes);
+        ShareClassId scId = ShareClassId.wrap(bytes16(uint128(scIdAsUint)));
         AssetId payoutAssetId = AssetId.wrap(assetIdAsUint);
         bytes32 investor = CastLib.toBytes32(_getActor());
 
@@ -359,7 +362,7 @@ abstract contract AdminTargets is BaseTargetFunctions, Properties {
         PoolId poolId = _getRandomPoolId(poolIdEntropy);
         ShareClassId scId = _getRandomShareClassIdForPool(poolId, scEntropy);
         AssetId payoutAssetId = hubRegistry.currency(poolId);
-        hub_redeemRequest(poolId.raw(), scId.raw(), payoutAssetId.raw(), amount);
+        hub_redeemRequest(poolId.raw(), uint128(scId.raw()), payoutAssetId.raw(), amount);
     }
 
     /// @dev The investor is explicitly clamped to one of the actors to make checking properties over all actors easier
@@ -369,9 +372,9 @@ abstract contract AdminTargets is BaseTargetFunctions, Properties {
     /// is zero
     /// @dev Property: cancelDepositRequest absolute value should never be higher than pendingDeposit (would result in
     /// underflow revert)
-    function hub_cancelDepositRequest(uint64 poolIdAsUint, bytes16 scIdAsBytes) public updateGhosts {
+    function hub_cancelDepositRequest(uint64 poolIdAsUint, uint128 scIdAsUint) public updateGhosts {
         PoolId poolId = PoolId.wrap(poolIdAsUint);
-        ShareClassId scId = ShareClassId.wrap(scIdAsBytes);
+        ShareClassId scId = ShareClassId.wrap(bytes16(uint128(scIdAsUint)));
         AssetId depositAssetId = hubRegistry.currency(poolId);
         bytes32 investor = _getActor().toBytes32();
 
@@ -411,7 +414,7 @@ abstract contract AdminTargets is BaseTargetFunctions, Properties {
     function hub_cancelDepositRequest_clamped(uint64 poolIdEntropy, uint32 scEntropy) public updateGhosts {
         PoolId poolId = Helpers.getRandomPoolId(createdPools, poolIdEntropy);
         ShareClassId scId = Helpers.getRandomShareClassIdForPool(shareClassManager, poolId, scEntropy);
-        hub_cancelDepositRequest(poolId.raw(), scId.raw());
+        hub_cancelDepositRequest(poolId.raw(), uint128(scId.raw()));
     }
 
     /// @dev Property: After successfully calling cancelRedeemRequest for an investor, their
@@ -420,9 +423,9 @@ abstract contract AdminTargets is BaseTargetFunctions, Properties {
     /// is zero
     /// @dev Property: cancelRedeemRequest absolute value should never be higher than pendingRedeem (would result in
     /// underflow revert)
-    function hub_cancelRedeemRequest(uint64 poolIdAsUint, bytes16 scIdAsBytes) public updateGhosts {
+    function hub_cancelRedeemRequest(uint64 poolIdAsUint, uint128 scIdAsUint) public updateGhosts {
         PoolId poolId = PoolId.wrap(poolIdAsUint);
-        ShareClassId scId = ShareClassId.wrap(scIdAsBytes);
+        ShareClassId scId = ShareClassId.wrap(bytes16(uint128(scIdAsUint)));
         AssetId payoutAssetId = hubRegistry.currency(poolId);
         bytes32 investor = _getActor().toBytes32();
 
@@ -463,12 +466,12 @@ abstract contract AdminTargets is BaseTargetFunctions, Properties {
     function hub_cancelRedeemRequest_clamped(uint64 poolIdEntropy, uint32 scEntropy) public updateGhosts {
         PoolId poolId = Helpers.getRandomPoolId(createdPools, poolIdEntropy);
         ShareClassId scId = Helpers.getRandomShareClassIdForPool(shareClassManager, poolId, scEntropy);
-        hub_cancelRedeemRequest(poolId.raw(), scId.raw());
+        hub_cancelRedeemRequest(poolId.raw(), uint128(scId.raw()));
     }
 
     function hub_updateHoldingAmount(
         uint64 poolIdAsUint,
-        bytes16 scIdAsBytes,
+        uint128 scIdAsUint,
         uint128 assetIdAsUint,
         uint128 amount,
         uint128 pricePoolPerAsset,
@@ -477,7 +480,7 @@ abstract contract AdminTargets is BaseTargetFunctions, Properties {
         uint64 nonce
     ) public updateGhosts {
         PoolId poolId = PoolId.wrap(poolIdAsUint);
-        ShareClassId scId = ShareClassId.wrap(scIdAsBytes);
+        ShareClassId scId = ShareClassId.wrap(bytes16(uint128(scIdAsUint)));
         AssetId assetId = AssetId.wrap(assetIdAsUint);
 
         hub.updateHoldingAmount(
@@ -511,16 +514,16 @@ abstract contract AdminTargets is BaseTargetFunctions, Properties {
             JournalEntry({value: amount, accountId: _getRandomAccountId(poolId, scId, assetId, accountEntropy)});
 
         hub_updateHoldingAmount(
-            poolId.raw(), scId.raw(), assetId.raw(), amount, pricePerUnit, IS_INCREASE, IS_SNAPSHOT, NONCE
+            poolId.raw(), uint128(scId.raw()), assetId.raw(), amount, pricePerUnit, IS_INCREASE, IS_SNAPSHOT, NONCE
         );
     }
 
-    function hub_updateHoldingValue(uint64 poolIdAsUint, bytes16 scIdAsBytes, uint128 assetIdAsUint)
+    function hub_updateHoldingValue(uint64 poolIdAsUint, uint128 scIdAsUint, uint128 assetIdAsUint)
         public
         updateGhosts
     {
         PoolId poolId = PoolId.wrap(poolIdAsUint);
-        ShareClassId scId = ShareClassId.wrap(scIdAsBytes);
+        ShareClassId scId = ShareClassId.wrap(bytes16(uint128(scIdAsUint)));
         AssetId assetId = AssetId.wrap(assetIdAsUint);
         hub.updateHoldingValue(poolId, scId, assetId);
     }
@@ -529,7 +532,7 @@ abstract contract AdminTargets is BaseTargetFunctions, Properties {
         PoolId poolId = _getRandomPoolId(poolEntropy);
         ShareClassId scId = _getRandomShareClassIdForPool(poolId, scEntropy);
         AssetId assetId = hubRegistry.currency(poolId);
-        hub_updateHoldingValue(poolId.raw(), scId.raw(), assetId.raw());
+        hub_updateHoldingValue(poolId.raw(), uint128(scId.raw()), assetId.raw());
     }
 
     function hub_updateJournal(uint64 poolIdAsUint, JournalEntry[] memory debits, JournalEntry[] memory credits)

--- a/test/integration/recon-end-to-end/CryticSanity.sol
+++ b/test/integration/recon-end-to-end/CryticSanity.sol
@@ -62,7 +62,7 @@ contract CryticSanity is Test, TargetFunctions, FoundryAsserts {
 
         // price needs to be set in valuation before calling updatePricePoolPerShare
         transientValuation_setPrice_clamped(1e18);
-        hub_updateSharePrice(vault.poolId().raw(), vault.scId().raw(), 1e18);
+        hub_updateSharePrice(vault.poolId().raw(), uint128(vault.scId().raw()), 1e18);
 
         hub_notifyAssetPrice();
         hub_notifySharePrice_clamped();

--- a/test/integration/recon-end-to-end/CryticToFoundry.sol
+++ b/test/integration/recon-end-to-end/CryticToFoundry.sol
@@ -247,7 +247,7 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
 
         hub_setHoldingAccountId(4370001, 255, 1524785992);
 
-        hub_notifyShareClass_clamped(bytes32(0));
+        hub_notifyShareClass_clamped(uint256(bytes32(0)));
 
         hub_createHolding_clamped(true, 42, 255, 200, 255);
 

--- a/test/integration/recon-end-to-end/TargetFunctions.sol
+++ b/test/integration/recon-end-to-end/TargetFunctions.sol
@@ -127,7 +127,7 @@ abstract contract TargetFunctions is
 
             hub_addShareClass(salt);
 
-            spoke_addShareClass(_scId, 18, address(fullRestrictions));
+            spoke_addShareClass(uint128(_scId), 18, address(fullRestrictions));
             ShareToken(_getShareToken()).rely(address(spoke));
             ShareToken(_getShareToken()).rely(address(balanceSheet));
         }
@@ -200,7 +200,7 @@ abstract contract TargetFunctions is
         IBaseVault vault = IBaseVault(_getVault());
 
         transientValuation_setPrice_clamped(navPerShare);
-        hub_updateSharePrice(vault.poolId().raw(), vault.scId().raw(), navPerShare);
+        hub_updateSharePrice(vault.poolId().raw(), uint128(vault.scId().raw()), navPerShare);
 
         hub_notifyAssetPrice();
         hub_notifySharePrice(CENTRIFUGE_CHAIN_ID);
@@ -214,7 +214,7 @@ abstract contract TargetFunctions is
         IBaseVault vault = IBaseVault(_getVault());
 
         transientValuation_setPrice_clamped(navPerShare);
-        hub_updateSharePrice(vault.poolId().raw(), vault.scId().raw(), navPerShare);
+        hub_updateSharePrice(vault.poolId().raw(), uint128(vault.scId().raw()), navPerShare);
 
         hub_notifyAssetPrice();
         hub_notifySharePrice(CENTRIFUGE_CHAIN_ID);

--- a/test/integration/recon-end-to-end/targets/AdminTargets.sol
+++ b/test/integration/recon-end-to-end/targets/AdminTargets.sol
@@ -195,14 +195,14 @@ abstract contract AdminTargets is BaseTargetFunctions, Properties {
         hub_notifyPool(CENTRIFUGE_CHAIN_ID);
     }
 
-    function hub_notifyShareClass(uint16 centrifugeId, bytes32 hook) public updateGhosts {
+    function hub_notifyShareClass(uint16 centrifugeId, uint256 hookAsUint) public updateGhosts {
         PoolId poolId = PoolId.wrap(_getPool());
         ShareClassId scId = ShareClassId.wrap(_getShareClassId());
-        hub.notifyShareClass(poolId, scId, centrifugeId, hook);
+        hub.notifyShareClass(poolId, scId, centrifugeId, bytes32(hookAsUint));
     }
 
-    function hub_notifyShareClass_clamped(bytes32 hook) public {
-        hub_notifyShareClass(CENTRIFUGE_CHAIN_ID, hook);
+    function hub_notifyShareClass_clamped(uint256 hookAsUint) public {
+        hub_notifyShareClass(CENTRIFUGE_CHAIN_ID, hookAsUint);
     }
 
     function hub_notifySharePrice(uint16 centrifugeId) public updateGhostsWithType(OpType.UPDATE) {
@@ -254,9 +254,10 @@ abstract contract AdminTargets is BaseTargetFunctions, Properties {
         // }
     }
 
-    function hub_setAccountMetadata(uint32 accountAsInt, bytes memory metadata) public updateGhosts {
+    function hub_setAccountMetadata(uint32 accountAsInt, uint256 metadataAsUint) public updateGhosts {
         PoolId poolId = PoolId.wrap(_getPool());
         AccountId account = AccountId.wrap(accountAsInt);
+        bytes memory metadata = abi.encodePacked(metadataAsUint);
         hub.setAccountMetadata(poolId, account, metadata);
     }
 
@@ -268,8 +269,9 @@ abstract contract AdminTargets is BaseTargetFunctions, Properties {
         hub.setHoldingAccountId(poolId, scId, assetId, kind, accountId);
     }
 
-    function hub_setPoolMetadata(bytes memory metadata) public updateGhosts {
+    function hub_setPoolMetadata(uint256 metadataAsUint) public updateGhosts {
         PoolId poolId = PoolId.wrap(_getPool());
+        bytes memory metadata = abi.encodePacked(metadataAsUint);
         hub.setPoolMetadata(poolId, metadata);
     }
 
@@ -288,14 +290,15 @@ abstract contract AdminTargets is BaseTargetFunctions, Properties {
         hub_updateHoldingValuation(assetId.raw(), valuation);
     }
 
-    function hub_updateRestriction(uint16 chainId, bytes calldata payload) public updateGhosts {
+    function hub_updateRestriction(uint16 chainId, uint256 payloadAsUint) public updateGhosts {
         PoolId poolId = PoolId.wrap(_getPool());
         ShareClassId scId = ShareClassId.wrap(_getShareClassId());
+        bytes memory payload = abi.encodePacked(payloadAsUint);
         hub.updateRestriction(poolId, scId, chainId, payload, 0);
     }
 
-    function hub_updateRestriction_clamped(bytes calldata payload) public {
-        hub_updateRestriction(CENTRIFUGE_CHAIN_ID, payload);
+    function hub_updateRestriction_clamped(uint256 payloadAsUint) public {
+        hub_updateRestriction(CENTRIFUGE_CHAIN_ID, payloadAsUint);
     }
 
     function syncManager_setValuation(address valuation) public updateGhosts {
@@ -309,7 +312,7 @@ abstract contract AdminTargets is BaseTargetFunctions, Properties {
         syncManager_setValuation(valuation);
     }
 
-    function hub_updateSharePrice(uint64 poolIdAsUint, bytes16 scIdAsBytes, uint128 navPoolPerShare)
+    function hub_updateSharePrice(uint64 poolIdAsUint, uint128 scIdAsUint, uint128 navPoolPerShare)
         public
         updateGhosts
     {

--- a/test/integration/recon-end-to-end/targets/BalanceSheetTargets.sol
+++ b/test/integration/recon-end-to-end/targets/BalanceSheetTargets.sol
@@ -35,9 +35,10 @@ abstract contract BalanceSheetTargets is BaseTargetFunctions, Properties {
         sumOfManagerDeposits[vault.asset()] += amount;
     }
 
-    function balanceSheet_file(bytes32 what, address data) public updateGhosts asActor {
-        balanceSheet.file(what, data);
-    }
+    // NOTE: removed because not useful for fuzzing
+    // function balanceSheet_file(bytes32 what, address data) public updateGhosts asActor {
+    //     balanceSheet.file(what, data);
+    // }
 
     function balanceSheet_issue(uint128 shares) public updateGhosts asActor {
         IBaseVault vault = IBaseVault(_getVault());

--- a/test/integration/recon-end-to-end/targets/SpokeTargets.sol
+++ b/test/integration/recon-end-to-end/targets/SpokeTargets.sol
@@ -88,13 +88,14 @@ abstract contract SpokeTargets is BaseTargetFunctions, Properties {
     }
 
     // Step 3
-    function spoke_addShareClass(bytes16 scId, uint8 decimals, address hook)
+    function spoke_addShareClass(uint128 scIdAsUint, uint8 decimals, address hook)
         public
         asAdmin
         returns (address, bytes16)
     {
         string memory name = "Test ShareClass";
         string memory symbol = "TSC";
+        bytes16 scId = bytes16(scIdAsUint);
 
         spoke.addShareClass(
             PoolId.wrap(_getPool()),


### PR DESCRIPTION
This PR replaces all byte values in handler inputs with uints to resolve the issue we're having with Echidna not generating valid reproducers for optimization mode tests. 