### PR TITLE
Test: Improve EndToEnd coverage & accurate gas values

### DIFF
--- a/script/CommonDeployer.s.sol
+++ b/script/CommonDeployer.s.sol
@@ -95,7 +95,7 @@ contract CommonActionBatcher {
 }
 
 abstract contract CommonDeployer is Script, JsonRegistry, CreateXScript {
-    uint256 constant DELAY = 48 hours;
+    uint256 public constant DELAY = 48 hours;
 
     bytes32 version;
     ISafe public adminSafe;

--- a/src/common/GasService.sol
+++ b/src/common/GasService.sol
@@ -71,8 +71,8 @@ contract GasService is IGasService {
         updateBalanceSheetManager = BASE_COST + 35241;
         updateHoldingAmount = BASE_COST + 220866;
         updateShares = BASE_COST + 49968;
-        maxAssetPriceAge = BASE_COST + SMALL_COST;
-        maxSharePriceAge = BASE_COST + SMALL_COST;
+        maxAssetPriceAge = BASE_COST + 27260;
+        maxSharePriceAge = BASE_COST + 26032;
     }
 
     /// @inheritdoc IGasService

--- a/src/common/GasService.sol
+++ b/src/common/GasService.sol
@@ -10,7 +10,7 @@ import {MessageLib, MessageType, VaultUpdateKind} from "src/common/libraries/Mes
 contract GasService is IGasService {
     using MessageLib for *;
 
-    /// @dev Takes into account Adapter + Gateway processing + some mismatch happened regarding the reference
+    /// @dev Takes into account Adapter + Gateway processing + some mismatch happened regarding the input values
     uint128 public constant BASE_COST = 200_000;
     /// @dev Assumess a relatively small computation for unknown/non-measured code paths
     uint128 public constant SMALL_COST = 100_000;
@@ -48,8 +48,8 @@ contract GasService is IGasService {
 
         // NOTE: The hardcoded values are take from the EndToEnd tests. This should be automated in the future.
 
-        scheduleUpgrade = BASE_COST + SMALL_COST;
-        cancelUpgrade = BASE_COST + SMALL_COST;
+        scheduleUpgrade = BASE_COST + 28514;
+        cancelUpgrade = BASE_COST + 8861;
         recoverTokens = BASE_COST + SMALL_COST;
         registerAsset = BASE_COST + 34329;
         request = BASE_COST + 86084; // request deposit case

--- a/src/common/GasService.sol
+++ b/src/common/GasService.sol
@@ -12,8 +12,6 @@ contract GasService is IGasService {
 
     /// @dev Takes into account Adapter + Gateway processing + some mismatch happened regarding the input values
     uint128 public constant BASE_COST = 200_000;
-    /// @dev Assumess a relatively small computation for unknown/non-measured code paths
-    uint128 public constant SMALL_COST = 100_000;
 
     uint128 internal immutable _batchGasLimit;
 
@@ -50,7 +48,7 @@ contract GasService is IGasService {
 
         scheduleUpgrade = BASE_COST + 28514;
         cancelUpgrade = BASE_COST + 8861;
-        recoverTokens = BASE_COST + SMALL_COST;
+        recoverTokens = BASE_COST + 82906;
         registerAsset = BASE_COST + 34329;
         request = BASE_COST + 86084; // request deposit case
         notifyPool = BASE_COST + 38190;

--- a/src/common/interfaces/IGasService.sol
+++ b/src/common/interfaces/IGasService.sol
@@ -36,7 +36,9 @@ interface IGasService {
     function updateRestriction() external view returns (uint128);
     function updateContract() external view returns (uint128);
     function requestCallback() external view returns (uint128);
-    function updateVault() external view returns (uint128);
+    function updateVaultDeployAndLink() external view returns (uint128);
+    function updateVaultLink() external view returns (uint128);
+    function updateVaultUnlink() external view returns (uint128);
     function setRequestManager() external view returns (uint128);
     function updateBalanceSheetManager() external view returns (uint128);
     function updateHoldingAmount() external view returns (uint128);

--- a/test/common/unit/GasService.t.sol
+++ b/test/common/unit/GasService.t.sol
@@ -28,7 +28,7 @@ contract GasServiceTest is Test {
         vm.assume(message.messageCode() <= uint8(type(MessageType).max));
 
         if (message.messageCode() == uint8(MessageType.UpdateVault)) {
-            vm.assume(message.length >= 73);
+            vm.assume(message.length > 73);
             uint8 vaultKind = message.toUint8(73);
             vm.assume(vaultKind >= 0);
             vm.assume(vaultKind <= uint8(type(VaultUpdateKind).max));

--- a/test/common/unit/GasService.t.sol
+++ b/test/common/unit/GasService.t.sol
@@ -1,14 +1,17 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
+import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+
 import {GasService} from "src/common/GasService.sol";
 import {MAX_MESSAGE_COST} from "src/common/interfaces/IGasService.sol";
-import {MessageLib, MessageType} from "src/common/libraries/MessageLib.sol";
+import {MessageLib, MessageType, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
 
 import "forge-std/Test.sol";
 
 contract GasServiceTest is Test {
     using MessageLib for *;
+    using BytesLib for *;
 
     uint128 constant BATCH_GAS_LIMIT = 10_000_000 ether;
     uint16 constant CENTRIFUGE_ID = 1;
@@ -22,7 +25,14 @@ contract GasServiceTest is Test {
             message.messageCode() < uint8(MessageType._Placeholder5)
                 || message.messageCode() > uint8(MessageType._Placeholder15)
         );
-        vm.assume(message.messageCode() < uint8(type(MessageType).max));
+        vm.assume(message.messageCode() <= uint8(type(MessageType).max));
+
+        if (message.messageCode() == uint8(MessageType.UpdateVault)) {
+            vm.assume(message.length >= 73);
+            uint8 vaultKind = message.toUint8(73);
+            vm.assume(vaultKind >= 0);
+            vm.assume(vaultKind <= uint8(type(VaultUpdateKind).max));
+        }
 
         uint256 messageGasLimit = service.messageGasLimit(CENTRIFUGE_ID, message);
         assert(messageGasLimit > service.BASE_COST());

--- a/test/integration/EndToEnd.t.sol
+++ b/test/integration/EndToEnd.t.sol
@@ -608,6 +608,21 @@ contract EndToEndUseCases is EndToEndFlows {
         assertEq(s.spoke.shareToken(POOL_A, SC_1).hook(), address(s.fullRestrictionsHook));
     }
 
+    function testUpdatePriceAge(bool sameChain) public {
+        _configurePool(sameChain);
+
+        vm.startPrank(FM);
+
+        h.hub.setMaxAssetPriceAge{value: GAS}(POOL_A, SC_1, s.usdcId, uint64(block.timestamp));
+        h.hub.setMaxSharePriceAge{value: GAS}(s.centrifugeId, POOL_A, SC_1, uint64(block.timestamp));
+
+        (,, uint64 validUntil) = s.spoke.markersPricePoolPerAsset(POOL_A, SC_1, s.usdcId);
+        assertEq(validUntil, uint64(block.timestamp));
+
+        (,, validUntil) = s.spoke.markersPricePoolPerShare(POOL_A, SC_1);
+        assertEq(validUntil, uint64(block.timestamp));
+    }
+
     /// forge-config: default.isolate = true
     function testFundManagement(bool sameChain) public {
         _configurePool(sameChain);

--- a/test/integration/EndToEnd.t.sol
+++ b/test/integration/EndToEnd.t.sol
@@ -6,8 +6,8 @@ import {D18, d18} from "src/misc/types/D18.sol";
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {IdentityValuation} from "src/misc/IdentityValuation.sol";
 import {ETH_ADDRESS} from "src/misc/interfaces/IRecoverable.sol";
+import {IdentityValuation} from "src/misc/IdentityValuation.sol";
 
 import {Gateway} from "src/common/Gateway.sol";
 import {Root, IRoot} from "src/common/Root.sol";
@@ -29,9 +29,9 @@ import {HubRegistry} from "src/hub/HubRegistry.sol";
 import {ShareClassManager} from "src/hub/ShareClassManager.sol";
 
 import {Spoke} from "src/spoke/Spoke.sol";
+import {IVault} from "src/spoke/interfaces/IVault.sol";
 import {BalanceSheet} from "src/spoke/BalanceSheet.sol";
 import {UpdateContractMessageLib} from "src/spoke/libraries/UpdateContractMessageLib.sol";
-import {IVault} from "src/spoke/interfaces/IVault.sol";
 
 import {SyncManager} from "src/vaults/SyncManager.sol";
 import {VaultRouter} from "src/vaults/VaultRouter.sol";


### PR DESCRIPTION
- Test under EndToEnd all supported messages in the MessageLib
- Use real values for all messages
- Split `UpdateVault` gas value in three values depending on the `UpdateVaultKind` message value