### PR TITLE
Rename: batchGasLimit name

### DIFF
--- a/env/example.json
+++ b/env/example.json
@@ -3,7 +3,7 @@
         "chainId": 12345,
         "environment": "testnet OR mainnet",
         "centrifugeId": 2,
-        "maxGasLimit": "25000000 (max gas limit for batched messages)",
+        "maxBatchGasLimit": "25000000 (max gas limit for batched messages)",
         "connectsTo": [
             "sepolia",
             "base-sepolia",
@@ -31,7 +31,7 @@
             "environment": "The environment type - can be 'testnet' or 'mainnet'",
             "centrifugeId": "Unique identifier for this network in the Centrifuge ecosystem. Sequence 1,2,3,4 etc.",
             "root": "Address of existing root contract. Set to null or omit to deploy a new root. If provided, must be a valid contract address.",
-            "maxGasLimit": "Maximum gas limit for batched messages in gas units. Default: 25,000,000 gas.",
+            "maxBatchGasLimit": "Maximum gas limit for batched messages in gas units. Default: 25,000,000 gas.",
             "etherscanUrl": "The Etherscan API URL for contract verification. Examples: https://api.etherscan.io/api (mainnet), https://api-sepolia.etherscan.io/api (sepolia), https://api.basescan.org/api (base)",
             "connectsTo": "Only used by Wireadapters.s.sol - List of networks this network can connect to. Use the same name as the env/$chainName.json files"
         },

--- a/env/example.json
+++ b/env/example.json
@@ -3,7 +3,7 @@
         "chainId": 12345,
         "environment": "testnet OR mainnet",
         "centrifugeId": 2,
-        "batchGasLimit": "25000000 (max gas limit for batched messages)",
+        "maxGasLimit": "25000000 (max gas limit for batched messages)",
         "connectsTo": [
             "sepolia",
             "base-sepolia",
@@ -31,7 +31,7 @@
             "environment": "The environment type - can be 'testnet' or 'mainnet'",
             "centrifugeId": "Unique identifier for this network in the Centrifuge ecosystem. Sequence 1,2,3,4 etc.",
             "root": "Address of existing root contract. Set to null or omit to deploy a new root. If provided, must be a valid contract address.",
-            "batchGasLimit": "Maximum gas limit for batched messages in gas units. Default: 25,000,000 gas.",
+            "maxGasLimit": "Maximum gas limit for batched messages in gas units. Default: 25,000,000 gas.",
             "etherscanUrl": "The Etherscan API URL for contract verification. Examples: https://api.etherscan.io/api (mainnet), https://api-sepolia.etherscan.io/api (sepolia), https://api.basescan.org/api (base)",
             "connectsTo": "Only used by Wireadapters.s.sol - List of networks this network can connect to. Use the same name as the env/$chainName.json files"
         },

--- a/script/CommonDeployer.s.sol
+++ b/script/CommonDeployer.s.sol
@@ -20,7 +20,7 @@ import "forge-std/Script.sol";
 struct CommonInput {
     uint16 centrifugeId;
     ISafe adminSafe;
-    uint128 batchGasLimit;
+    uint128 maxGasLimit;
     bytes32 version;
 }
 
@@ -163,7 +163,7 @@ abstract contract CommonDeployer is Script, JsonRegistry, CreateXScript {
         gasService = GasService(
             create3(
                 generateSalt("gasService-2"),
-                abi.encodePacked(type(GasService).creationCode, abi.encode(input.batchGasLimit))
+                abi.encodePacked(type(GasService).creationCode, abi.encode(input.maxGasLimit))
             )
         );
 

--- a/script/CommonDeployer.s.sol
+++ b/script/CommonDeployer.s.sol
@@ -20,7 +20,7 @@ import "forge-std/Script.sol";
 struct CommonInput {
     uint16 centrifugeId;
     ISafe adminSafe;
-    uint128 maxGasLimit;
+    uint128 maxBatchGasLimit;
     bytes32 version;
 }
 
@@ -163,7 +163,7 @@ abstract contract CommonDeployer is Script, JsonRegistry, CreateXScript {
         gasService = GasService(
             create3(
                 generateSalt("gasService-2"),
-                abi.encodePacked(type(GasService).creationCode, abi.encode(input.maxGasLimit))
+                abi.encodePacked(type(GasService).creationCode, abi.encode(input.maxBatchGasLimit))
             )
         );
 

--- a/script/FullDeployer.s.sol
+++ b/script/FullDeployer.s.sol
@@ -23,9 +23,6 @@ contract FullActionBatcher is HubActionBatcher, ExtendedSpokeActionBatcher, Adap
  * @notice Deploys the complete Centrifuge protocol stack (Hub + Spoke + Adapters)
  */
 contract FullDeployer is HubDeployer, ExtendedSpokeDeployer, AdaptersDeployer {
-    // Config variables
-    uint256 public maxGasLimit;
-
     function deployFull(CommonInput memory commonInput, AdaptersInput memory adaptersInput, FullActionBatcher batcher)
         public
     {
@@ -124,11 +121,12 @@ contract FullDeployer is HubDeployer, ExtendedSpokeDeployer, AdaptersDeployer {
         uint16 centrifugeId = uint16(vm.parseJsonUint(config, "$.network.centrifugeId"));
         string memory environment = vm.parseJsonString(config, "$.network.environment");
 
-        // Parse maxGasLimit with defaults
-        try vm.parseJsonUint(config, "$.network.maxGasLimit") returns (uint256 _batchGasLimit) {
-            maxGasLimit = _batchGasLimit;
+        // Parse maxBatchGasLimit with defaults
+        uint256 maxBatchGasLimit;
+        try vm.parseJsonUint(config, "$.network.maxBatchGasLimit") returns (uint256 _batchGasLimit) {
+            maxBatchGasLimit = _batchGasLimit;
         } catch {
-            maxGasLimit = 25_000_000; // 25M gas
+            maxBatchGasLimit = 25_000_000; // 25M gas
         }
 
         console.log("Network:", network);
@@ -141,7 +139,7 @@ contract FullDeployer is HubDeployer, ExtendedSpokeDeployer, AdaptersDeployer {
         CommonInput memory commonInput = CommonInput({
             centrifugeId: centrifugeId,
             adminSafe: ISafe(vm.envAddress("ADMIN")),
-            maxGasLimit: uint128(maxGasLimit),
+            maxBatchGasLimit: uint128(maxBatchGasLimit),
             version: keccak256(abi.encodePacked(vm.envOr("VERSION", string(""))))
         });
 

--- a/script/FullDeployer.s.sol
+++ b/script/FullDeployer.s.sol
@@ -24,7 +24,7 @@ contract FullActionBatcher is HubActionBatcher, ExtendedSpokeActionBatcher, Adap
  */
 contract FullDeployer is HubDeployer, ExtendedSpokeDeployer, AdaptersDeployer {
     // Config variables
-    uint256 public batchGasLimit;
+    uint256 public maxGasLimit;
 
     function deployFull(CommonInput memory commonInput, AdaptersInput memory adaptersInput, FullActionBatcher batcher)
         public
@@ -124,11 +124,11 @@ contract FullDeployer is HubDeployer, ExtendedSpokeDeployer, AdaptersDeployer {
         uint16 centrifugeId = uint16(vm.parseJsonUint(config, "$.network.centrifugeId"));
         string memory environment = vm.parseJsonString(config, "$.network.environment");
 
-        // Parse batchGasLimit with defaults
-        try vm.parseJsonUint(config, "$.network.batchGasLimit") returns (uint256 _batchGasLimit) {
-            batchGasLimit = _batchGasLimit;
+        // Parse maxGasLimit with defaults
+        try vm.parseJsonUint(config, "$.network.maxGasLimit") returns (uint256 _batchGasLimit) {
+            maxGasLimit = _batchGasLimit;
         } catch {
-            batchGasLimit = 25_000_000; // 25M gas
+            maxGasLimit = 25_000_000; // 25M gas
         }
 
         console.log("Network:", network);
@@ -141,7 +141,7 @@ contract FullDeployer is HubDeployer, ExtendedSpokeDeployer, AdaptersDeployer {
         CommonInput memory commonInput = CommonInput({
             centrifugeId: centrifugeId,
             adminSafe: ISafe(vm.envAddress("ADMIN")),
-            batchGasLimit: uint128(batchGasLimit),
+            maxGasLimit: uint128(maxGasLimit),
             version: keccak256(abi.encodePacked(vm.envOr("VERSION", string(""))))
         });
 

--- a/src/common/GasService.sol
+++ b/src/common/GasService.sol
@@ -14,7 +14,7 @@ contract GasService is IGasService {
     /// @dev Takes into account Adapter + Gateway processing + some mismatch happened regarding the input values
     uint128 public constant BASE_COST = 200_000;
 
-    uint128 internal immutable _batchGasLimit;
+    uint128 internal immutable _maxGasLimit;
 
     uint128 public immutable scheduleUpgrade;
     uint128 public immutable cancelUpgrade;
@@ -42,8 +42,8 @@ contract GasService is IGasService {
     uint128 public immutable maxAssetPriceAge;
     uint128 public immutable maxSharePriceAge;
 
-    constructor(uint128 batchGasLimit_) {
-        _batchGasLimit = batchGasLimit_;
+    constructor(uint128 maxGasLimit_) {
+        _maxGasLimit = maxGasLimit_;
 
         // NOTE: The hardcoded values are take from the EndToEnd tests. This should be automated in the future.
         scheduleUpgrade = BASE_COST + 28514;
@@ -74,8 +74,8 @@ contract GasService is IGasService {
     }
 
     /// @inheritdoc IGasService
-    function batchGasLimit(uint16) public view returns (uint128) {
-        return _batchGasLimit;
+    function maxGasLimit(uint16) public view returns (uint128) {
+        return _maxGasLimit;
     }
 
     /// @inheritdoc IGasService

--- a/src/common/GasService.sol
+++ b/src/common/GasService.sol
@@ -14,7 +14,7 @@ contract GasService is IGasService {
     /// @dev Takes into account Adapter + Gateway processing + some mismatch happened regarding the input values
     uint128 public constant BASE_COST = 200_000;
 
-    uint128 internal immutable _maxGasLimit;
+    uint128 internal immutable _maxBatchGasLimit;
 
     uint128 public immutable scheduleUpgrade;
     uint128 public immutable cancelUpgrade;
@@ -42,8 +42,8 @@ contract GasService is IGasService {
     uint128 public immutable maxAssetPriceAge;
     uint128 public immutable maxSharePriceAge;
 
-    constructor(uint128 maxGasLimit_) {
-        _maxGasLimit = maxGasLimit_;
+    constructor(uint128 maxBatchGasLimit_) {
+        _maxBatchGasLimit = maxBatchGasLimit_;
 
         // NOTE: The hardcoded values are take from the EndToEnd tests. This should be automated in the future.
         scheduleUpgrade = BASE_COST + 28514;
@@ -74,8 +74,8 @@ contract GasService is IGasService {
     }
 
     /// @inheritdoc IGasService
-    function maxGasLimit(uint16) public view returns (uint128) {
-        return _maxGasLimit;
+    function maxBatchGasLimit(uint16) public view returns (uint128) {
+        return _maxBatchGasLimit;
     }
 
     /// @inheritdoc IGasService

--- a/src/common/Gateway.sol
+++ b/src/common/Gateway.sol
@@ -136,7 +136,7 @@ contract Gateway is Auth, Recoverable, IGateway {
 
             bytes32 gasLimitSlot = _gasLimitSlot(centrifugeId, poolId);
             uint128 newGasLimit = gasLimitSlot.tloadUint128() + gasLimit;
-            require(newGasLimit <= gasService.maxGasLimit(centrifugeId), ExceedsMaxGasLimit());
+            require(newGasLimit <= gasService.maxBatchGasLimit(centrifugeId), ExceedsMaxGasLimit());
             gasLimitSlot.tstore(uint256(newGasLimit));
 
             if (previousMessage.length == 0) {

--- a/src/common/Gateway.sol
+++ b/src/common/Gateway.sol
@@ -136,7 +136,7 @@ contract Gateway is Auth, Recoverable, IGateway {
 
             bytes32 gasLimitSlot = _gasLimitSlot(centrifugeId, poolId);
             uint128 newGasLimit = gasLimitSlot.tloadUint128() + gasLimit;
-            require(newGasLimit <= gasService.batchGasLimit(centrifugeId), ExceedsBatchGasLimit());
+            require(newGasLimit <= gasService.maxGasLimit(centrifugeId), ExceedsMaxGasLimit());
             gasLimitSlot.tstore(uint256(newGasLimit));
 
             if (previousMessage.length == 0) {

--- a/src/common/interfaces/IGasService.sol
+++ b/src/common/interfaces/IGasService.sol
@@ -20,7 +20,7 @@ interface IGasService {
     /// @notice Gas limit for the execution cost of a batch in a remote chain.
     /// @param centrifugeId Where to the cost is defined
     /// @return Max cost in WEI units
-    function batchGasLimit(uint16 centrifugeId) external view returns (uint128);
+    function maxGasLimit(uint16 centrifugeId) external view returns (uint128);
 
     function scheduleUpgrade() external view returns (uint128);
     function cancelUpgrade() external view returns (uint128);

--- a/src/common/interfaces/IGasService.sol
+++ b/src/common/interfaces/IGasService.sol
@@ -20,7 +20,7 @@ interface IGasService {
     /// @notice Gas limit for the execution cost of a batch in a remote chain.
     /// @param centrifugeId Where to the cost is defined
     /// @return Max cost in WEI units
-    function maxGasLimit(uint16 centrifugeId) external view returns (uint128);
+    function maxBatchGasLimit(uint16 centrifugeId) external view returns (uint128);
 
     function scheduleUpgrade() external view returns (uint128);
     function cancelUpgrade() external view returns (uint128);

--- a/src/common/interfaces/IGateway.sol
+++ b/src/common/interfaces/IGateway.sol
@@ -60,7 +60,7 @@ interface IGateway is IMessageHandler, IMessageSender, IRecoverable {
     error InsufficientFundsForRepayment();
 
     /// @notice Dispatched when a message is added to a batch that causes it to exceed the max batch size.
-    error ExceedsBatchGasLimit();
+    error ExceedsMaxGasLimit();
 
     /// @notice Dispatched when a refund address is not set.
     error RefundAddressNotSet();

--- a/test/common/Deployment.t.sol
+++ b/test/common/Deployment.t.sol
@@ -12,7 +12,7 @@ contract CommonDeploymentInputTest is Test {
     ISafe immutable ADMIN_SAFE = ISafe(makeAddr("AdminSafe"));
 
     function _commonInput() internal view returns (CommonInput memory) {
-        return CommonInput({centrifugeId: CENTRIFUGE_ID, adminSafe: ADMIN_SAFE, batchGasLimit: 0, version: bytes32(0)});
+        return CommonInput({centrifugeId: CENTRIFUGE_ID, adminSafe: ADMIN_SAFE, maxGasLimit: 0, version: bytes32(0)});
     }
 }
 

--- a/test/common/Deployment.t.sol
+++ b/test/common/Deployment.t.sol
@@ -12,7 +12,8 @@ contract CommonDeploymentInputTest is Test {
     ISafe immutable ADMIN_SAFE = ISafe(makeAddr("AdminSafe"));
 
     function _commonInput() internal view returns (CommonInput memory) {
-        return CommonInput({centrifugeId: CENTRIFUGE_ID, adminSafe: ADMIN_SAFE, maxGasLimit: 0, version: bytes32(0)});
+        return
+            CommonInput({centrifugeId: CENTRIFUGE_ID, adminSafe: ADMIN_SAFE, maxBatchGasLimit: 0, version: bytes32(0)});
     }
 }
 

--- a/test/common/unit/GasService.t.sol
+++ b/test/common/unit/GasService.t.sol
@@ -13,10 +13,10 @@ contract GasServiceTest is Test {
     using MessageLib for *;
     using BytesLib for *;
 
-    uint128 constant MAX_GAS_LIMIT = 25_000_000; // 25M gas units
+    uint128 constant MAX_BATCH_GAS_LIMIT = 25_000_000; // 25M gas units
     uint16 constant CENTRIFUGE_ID = 1;
 
-    GasService service = new GasService(MAX_GAS_LIMIT);
+    GasService service = new GasService(MAX_BATCH_GAS_LIMIT);
 
     function testGasLimit(bytes calldata message) public view {
         vm.assume(message.length > 0);
@@ -40,7 +40,7 @@ contract GasServiceTest is Test {
     }
 
     function testMaxGasLimit(bytes calldata) public view {
-        uint256 maxGasLimit = service.maxGasLimit(CENTRIFUGE_ID);
-        assertEq(maxGasLimit, MAX_GAS_LIMIT);
+        uint256 maxBatchGasLimit = service.maxBatchGasLimit(CENTRIFUGE_ID);
+        assertEq(maxBatchGasLimit, MAX_BATCH_GAS_LIMIT);
     }
 }

--- a/test/common/unit/GasService.t.sol
+++ b/test/common/unit/GasService.t.sol
@@ -13,10 +13,10 @@ contract GasServiceTest is Test {
     using MessageLib for *;
     using BytesLib for *;
 
-    uint128 constant BATCH_GAS_LIMIT = 25_000_000; // 25M gas units
+    uint128 constant MAX_GAS_LIMIT = 25_000_000; // 25M gas units
     uint16 constant CENTRIFUGE_ID = 1;
 
-    GasService service = new GasService(BATCH_GAS_LIMIT);
+    GasService service = new GasService(MAX_GAS_LIMIT);
 
     function testGasLimit(bytes calldata message) public view {
         vm.assume(message.length > 0);
@@ -39,8 +39,8 @@ contract GasServiceTest is Test {
         assert(messageGasLimit <= MAX_MESSAGE_COST);
     }
 
-    function testBatchGasLimit(bytes calldata) public view {
-        uint256 batchGasLimit = service.batchGasLimit(CENTRIFUGE_ID);
-        assertEq(batchGasLimit, BATCH_GAS_LIMIT);
+    function testMaxGasLimit(bytes calldata) public view {
+        uint256 maxGasLimit = service.maxGasLimit(CENTRIFUGE_ID);
+        assertEq(maxGasLimit, MAX_GAS_LIMIT);
     }
 }

--- a/test/common/unit/Gateway.t.sol
+++ b/test/common/unit/Gateway.t.sol
@@ -124,7 +124,7 @@ contract GatewayTest is Test {
     bytes32 constant ADAPTER_DATA = bytes32("adapter data");
 
     uint256 constant MESSAGE_GAS_LIMIT = 10.0 gwei;
-    uint256 constant MAX_GAS_LIMIT = 50.0 gwei;
+    uint256 constant MAX_BATCH_GAS_LIMIT = 50.0 gwei;
     uint128 constant EXTRA_GAS_LIMIT = 1.0 gwei;
 
     IGasService gasService = IGasService(makeAddr("GasService"));
@@ -160,7 +160,9 @@ contract GatewayTest is Test {
             abi.encode(MESSAGE_GAS_LIMIT)
         );
         vm.mockCall(
-            address(gasService), abi.encodeWithSelector(IGasService.maxGasLimit.selector), abi.encode(MAX_GAS_LIMIT)
+            address(gasService),
+            abi.encodeWithSelector(IGasService.maxBatchGasLimit.selector),
+            abi.encode(MAX_BATCH_GAS_LIMIT)
         );
     }
 
@@ -462,7 +464,7 @@ contract GatewayTestSend is GatewayTest {
 
     function testErrExceedsMaxBatching() public {
         gateway.startBatching();
-        uint256 maxMessages = MAX_GAS_LIMIT / MESSAGE_GAS_LIMIT;
+        uint256 maxMessages = MAX_BATCH_GAS_LIMIT / MESSAGE_GAS_LIMIT;
 
         for (uint256 i; i < maxMessages; i++) {
             gateway.send(REMOTE_CENT_ID, MessageKind.WithPoolA1.asBytes());

--- a/test/common/unit/Gateway.t.sol
+++ b/test/common/unit/Gateway.t.sol
@@ -124,7 +124,7 @@ contract GatewayTest is Test {
     bytes32 constant ADAPTER_DATA = bytes32("adapter data");
 
     uint256 constant MESSAGE_GAS_LIMIT = 10.0 gwei;
-    uint256 constant BATCH_GAS_LIMIT = 50.0 gwei;
+    uint256 constant MAX_GAS_LIMIT = 50.0 gwei;
     uint128 constant EXTRA_GAS_LIMIT = 1.0 gwei;
 
     IGasService gasService = IGasService(makeAddr("GasService"));
@@ -160,7 +160,7 @@ contract GatewayTest is Test {
             abi.encode(MESSAGE_GAS_LIMIT)
         );
         vm.mockCall(
-            address(gasService), abi.encodeWithSelector(IGasService.batchGasLimit.selector), abi.encode(BATCH_GAS_LIMIT)
+            address(gasService), abi.encodeWithSelector(IGasService.maxGasLimit.selector), abi.encode(MAX_GAS_LIMIT)
         );
     }
 
@@ -462,13 +462,13 @@ contract GatewayTestSend is GatewayTest {
 
     function testErrExceedsMaxBatching() public {
         gateway.startBatching();
-        uint256 maxMessages = BATCH_GAS_LIMIT / MESSAGE_GAS_LIMIT;
+        uint256 maxMessages = MAX_GAS_LIMIT / MESSAGE_GAS_LIMIT;
 
         for (uint256 i; i < maxMessages; i++) {
             gateway.send(REMOTE_CENT_ID, MessageKind.WithPoolA1.asBytes());
         }
 
-        vm.expectRevert(IGateway.ExceedsBatchGasLimit.selector);
+        vm.expectRevert(IGateway.ExceedsMaxGasLimit.selector);
         gateway.send(REMOTE_CENT_ID, MessageKind.WithPoolA1.asBytes());
     }
 

--- a/test/hub/integration/BaseTest.sol
+++ b/test/hub/integration/BaseTest.sol
@@ -82,7 +82,7 @@ contract BaseTest is HubDeployer, Test {
         CommonInput memory input = CommonInput({
             centrifugeId: CHAIN_CP,
             adminSafe: adminSafe,
-            batchGasLimit: uint128(GAS) * 100,
+            maxGasLimit: uint128(GAS) * 100,
             version: bytes32(0)
         });
 

--- a/test/hub/integration/BaseTest.sol
+++ b/test/hub/integration/BaseTest.sol
@@ -82,7 +82,7 @@ contract BaseTest is HubDeployer, Test {
         CommonInput memory input = CommonInput({
             centrifugeId: CHAIN_CP,
             adminSafe: adminSafe,
-            maxGasLimit: uint128(GAS) * 100,
+            maxBatchGasLimit: uint128(GAS) * 100,
             version: bytes32(0)
         });
 

--- a/test/integration/EndToEnd.t.sol
+++ b/test/integration/EndToEnd.t.sol
@@ -231,7 +231,7 @@ contract EndToEndDeployment is Test {
         CommonInput memory commonInput = CommonInput({
             centrifugeId: localCentrifugeId,
             adminSafe: adminSafe,
-            maxGasLimit: uint128(GAS) * 100,
+            maxBatchGasLimit: uint128(GAS) * 100,
             version: bytes32(abi.encodePacked(localCentrifugeId))
         });
 

--- a/test/integration/EndToEnd.t.sol
+++ b/test/integration/EndToEnd.t.sol
@@ -231,7 +231,7 @@ contract EndToEndDeployment is Test {
         CommonInput memory commonInput = CommonInput({
             centrifugeId: localCentrifugeId,
             adminSafe: adminSafe,
-            batchGasLimit: uint128(GAS) * 100,
+            maxGasLimit: uint128(GAS) * 100,
             version: bytes32(abi.encodePacked(localCentrifugeId))
         });
 

--- a/test/integration/Integration.t.sol
+++ b/test/integration/Integration.t.sol
@@ -33,7 +33,7 @@ contract CentrifugeIntegrationTest is FullDeployer, Test {
         CommonInput memory input = CommonInput({
             centrifugeId: LOCAL_CENTRIFUGE_ID,
             adminSafe: adminSafe,
-            batchGasLimit: uint128(GAS) * 100,
+            maxGasLimit: uint128(GAS) * 100,
             version: bytes32(0)
         });
 

--- a/test/integration/Integration.t.sol
+++ b/test/integration/Integration.t.sol
@@ -33,7 +33,7 @@ contract CentrifugeIntegrationTest is FullDeployer, Test {
         CommonInput memory input = CommonInput({
             centrifugeId: LOCAL_CENTRIFUGE_ID,
             adminSafe: adminSafe,
-            maxGasLimit: uint128(GAS) * 100,
+            maxBatchGasLimit: uint128(GAS) * 100,
             version: bytes32(0)
         });
 

--- a/test/spoke/BaseTest.sol
+++ b/test/spoke/BaseTest.sol
@@ -83,7 +83,7 @@ contract BaseTest is ExtendedSpokeDeployer, Test, ExtendedSpokeActionBatcher {
         CommonInput memory input = CommonInput({
             centrifugeId: THIS_CHAIN_ID,
             adminSafe: adminSafe,
-            batchGasLimit: uint128(GAS_COST_LIMIT) * 100,
+            maxGasLimit: uint128(GAS_COST_LIMIT) * 100,
             version: bytes32(0)
         });
 

--- a/test/spoke/BaseTest.sol
+++ b/test/spoke/BaseTest.sol
@@ -83,7 +83,7 @@ contract BaseTest is ExtendedSpokeDeployer, Test, ExtendedSpokeActionBatcher {
         CommonInput memory input = CommonInput({
             centrifugeId: THIS_CHAIN_ID,
             adminSafe: adminSafe,
-            maxGasLimit: uint128(GAS_COST_LIMIT) * 100,
+            maxBatchGasLimit: uint128(GAS_COST_LIMIT) * 100,
             version: bytes32(0)
         });
 


### PR DESCRIPTION
The new name for describing the maximum gas a batch can take collides with a name already used in the Gateway, making things super confused when reading the Gateway.

To recap, there are 3 concept of gas limit:
- `messageGasLimit` => the gas limit for a message
- `batchGasLimit` => the gas limit of a batch of messages
- `maxBatchGasLimit` => the maximum gas a batch can take