### PR TITLE
Avoid manual payment for transfering shares if Hub is in the same chain as origin Spoke and minor fixes.

### DIFF
--- a/snapshots/AsyncVault.json
+++ b/snapshots/AsyncVault.json
@@ -1,4 +1,4 @@
 {
   "fulfillDepositRequest": "925319",
-  "requestDeposit": "530931"
+  "requestDeposit": "530960"
 }

--- a/snapshots/VaultRouter.json
+++ b/snapshots/VaultRouter.json
@@ -2,6 +2,6 @@
   "claimDeposit": "1090815",
   "enable": "60931",
   "lockDepositRequest": "95582",
-  "requestDeposit": "569868",
-  "requestRedeem": "2116297"
+  "requestDeposit": "569897",
+  "requestRedeem": "2116355"
 }

--- a/src/common/GasService.sol
+++ b/src/common/GasService.sol
@@ -57,8 +57,8 @@ contract GasService is IGasService {
         notifyPricePoolPerAsset = BASE_COST + 35759;
         notifyShareMetadata = BASE_COST + 13343;
         updateShareHook = BASE_COST + 6415;
-        initiateTransferShares = BASE_COST + 52195;
-        executeTransferShares = BASE_COST + 70267;
+        initiateTransferShares = BASE_COST + 89689;
+        executeTransferShares = BASE_COST + 70428;
         updateRestriction = BASE_COST + 35992;
         updateContract = BASE_COST + 53345;
         requestCallback = BASE_COST + 186947; // approve deposit case

--- a/src/common/Gateway.sol
+++ b/src/common/Gateway.sol
@@ -187,7 +187,7 @@ contract Gateway is Auth, Recoverable, IGateway {
 
     /// @inheritdoc IGateway
     function addUnpaidMessage(uint16 centrifugeId, bytes memory message) external auth {
-        _addUnpaidBatch(centrifugeId, message, gasService.messageGasLimit(centrifugeId, message));
+        _addUnpaidBatch(centrifugeId, message, gasService.messageGasLimit(centrifugeId, message) + extraGasLimit);
     }
 
     function _addUnpaidBatch(uint16 centrifugeId, bytes memory message, uint128 gasLimit) internal {

--- a/src/common/Gateway.sol
+++ b/src/common/Gateway.sol
@@ -189,6 +189,7 @@ contract Gateway is Auth, Recoverable, IGateway {
     function addUnpaidMessage(uint16 centrifugeId, bytes memory message) external auth {
         uint128 gasLimit = gasService.messageGasLimit(centrifugeId, message) + extraGasLimit;
         extraGasLimit = 0;
+        emit PrepareMessage(centrifugeId, processor.messagePoolId(message), message);
         _addUnpaidBatch(centrifugeId, message, gasLimit);
     }
 

--- a/src/common/Gateway.sol
+++ b/src/common/Gateway.sol
@@ -187,7 +187,9 @@ contract Gateway is Auth, Recoverable, IGateway {
 
     /// @inheritdoc IGateway
     function addUnpaidMessage(uint16 centrifugeId, bytes memory message) external auth {
-        _addUnpaidBatch(centrifugeId, message, gasService.messageGasLimit(centrifugeId, message) + extraGasLimit);
+        uint128 gasLimit = gasService.messageGasLimit(centrifugeId, message) + extraGasLimit;
+        extraGasLimit = 0;
+        _addUnpaidBatch(centrifugeId, message, gasLimit);
     }
 
     function _addUnpaidBatch(uint16 centrifugeId, bytes memory message, uint128 gasLimit) internal {

--- a/src/common/MessageDispatcher.sol
+++ b/src/common/MessageDispatcher.sol
@@ -397,6 +397,7 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
         uint128 extraGasLimit
     ) external auth {
         if (targetCentrifugeId == localCentrifugeId) {
+            // Spoke chain X => Hub chain Y => Spoke chain Y
             spoke.executeTransferShares(poolId, scId, receiver, amount);
         } else {
             bytes memory message = MessageLib.ExecuteTransferShares({

--- a/src/common/MessageProcessor.sol
+++ b/src/common/MessageProcessor.sol
@@ -121,7 +121,13 @@ contract MessageProcessor is Auth, IMessageProcessor {
         } else if (kind == MessageType.InitiateTransferShares) {
             MessageLib.InitiateTransferShares memory m = MessageLib.deserializeInitiateTransferShares(message);
             hub.initiateTransferShares(
-                m.centrifugeId, PoolId.wrap(m.poolId), ShareClassId.wrap(m.scId), m.receiver, m.amount, m.extraGasLimit
+                sourceCentrifugeId,
+                m.centrifugeId,
+                PoolId.wrap(m.poolId),
+                ShareClassId.wrap(m.scId),
+                m.receiver,
+                m.amount,
+                m.extraGasLimit
             );
         } else if (kind == MessageType.ExecuteTransferShares) {
             MessageLib.ExecuteTransferShares memory m = MessageLib.deserializeExecuteTransferShares(message);

--- a/src/common/MessageProcessor.sol
+++ b/src/common/MessageProcessor.sol
@@ -121,7 +121,7 @@ contract MessageProcessor is Auth, IMessageProcessor {
         } else if (kind == MessageType.InitiateTransferShares) {
             MessageLib.InitiateTransferShares memory m = MessageLib.deserializeInitiateTransferShares(message);
             hub.initiateTransferShares(
-                sourceCentrifugeId,
+                centrifugeId,
                 m.centrifugeId,
                 PoolId.wrap(m.poolId),
                 ShareClassId.wrap(m.scId),

--- a/src/common/interfaces/IGatewayHandlers.sol
+++ b/src/common/interfaces/IGatewayHandlers.sol
@@ -41,7 +41,8 @@ interface IHubGatewayHandler {
 
     /// @notice Forward an initiated share transfer to the destination chain.
     function initiateTransferShares(
-        uint16 centrifugeId,
+        uint16 originCentrifugeId,
+        uint16 targetCentrifugeId,
         PoolId poolId,
         ShareClassId scId,
         bytes32 receiver,

--- a/src/common/interfaces/IGatewaySenders.sol
+++ b/src/common/interfaces/IGatewaySenders.sol
@@ -105,7 +105,8 @@ interface IHubMessageSender is ILocalCentrifugeId {
 
     /// @notice Creates and send the message
     function sendExecuteTransferShares(
-        uint16 centrifugeId,
+        uint16 originCentrifugeId,
+        uint16 targetCentrifugeId,
         PoolId poolId,
         ShareClassId scId,
         bytes32 receiver,

--- a/src/hub/Hub.sol
+++ b/src/hub/Hub.sol
@@ -708,7 +708,8 @@ contract Hub is Multicall, Auth, Recoverable, IHub, IHubGatewayHandler, IHubGuar
 
     /// @inheritdoc IHubGatewayHandler
     function initiateTransferShares(
-        uint16 centrifugeId,
+        uint16 originCentrifugeId,
+        uint16 targetCentrifugeId,
         PoolId poolId,
         ShareClassId scId,
         bytes32 receiver,
@@ -717,8 +718,10 @@ contract Hub is Multicall, Auth, Recoverable, IHub, IHubGatewayHandler, IHubGuar
     ) external {
         _auth();
 
-        emit ForwardTransferShares(centrifugeId, poolId, scId, receiver, amount);
-        sender.sendExecuteTransferShares(centrifugeId, poolId, scId, receiver, amount, extraGasLimit);
+        emit ForwardTransferShares(targetCentrifugeId, poolId, scId, receiver, amount);
+        sender.sendExecuteTransferShares(
+            originCentrifugeId, targetCentrifugeId, poolId, scId, receiver, amount, extraGasLimit
+        );
     }
 
     //----------------------------------------------------------------------------------------------

--- a/src/hub/Hub.sol
+++ b/src/hub/Hub.sol
@@ -78,7 +78,6 @@ contract Hub is Multicall, Auth, Recoverable, IHub, IHubGatewayHandler, IHubGuar
 
         if (what == "sender") sender = IHubMessageSender(data);
         else if (what == "holdings") holdings = IHoldings(data);
-        else if (what == "hubHelpers") hubHelpers = IHubHelpers(data);
         else if (what == "shareClassManager") shareClassManager = IShareClassManager(data);
         else if (what == "gateway") gateway = IGateway(data);
         else if (what == "poolEscrowFactory") poolEscrowFactory = IPoolEscrowFactory(data);

--- a/test/common/unit/Gateway.t.sol
+++ b/test/common/unit/Gateway.t.sol
@@ -636,16 +636,23 @@ contract GatewayTestSend is GatewayTest {
 
         gateway.setExtraGasLimit(EXTRA_GAS_LIMIT);
         gateway.send(REMOTE_CENT_ID, message);
+
+        assertEq(gateway.extraGasLimit(), 0);
     }
 
     function testMessageBatchedWithExtraGasLimit() public {
         bytes memory message = MessageKind.WithPoolA1.asBytes();
 
-        gateway.setExtraGasLimit(EXTRA_GAS_LIMIT);
         gateway.startBatching();
+
+        gateway.setExtraGasLimit(EXTRA_GAS_LIMIT);
         gateway.send(REMOTE_CENT_ID, message);
 
-        assertEq(gateway.batchGasLimit(REMOTE_CENT_ID, POOL_A), MESSAGE_GAS_LIMIT + EXTRA_GAS_LIMIT);
+        gateway.setExtraGasLimit(EXTRA_GAS_LIMIT);
+        gateway.send(REMOTE_CENT_ID, message);
+
+        assertEq(gateway.batchGasLimit(REMOTE_CENT_ID, POOL_A), (MESSAGE_GAS_LIMIT + EXTRA_GAS_LIMIT) * 2);
+        assertEq(gateway.extraGasLimit(), 0);
     }
 }
 
@@ -883,5 +890,17 @@ contract GatewayTestAddUnpaidMessage is GatewayTest {
         (uint128 counter, uint128 gasLimit) = gateway.underpaid(REMOTE_CENT_ID, batchHash);
         assertEq(counter, 2);
         assertEq(gasLimit, MESSAGE_GAS_LIMIT);
+    }
+
+    function testCorrectAddUnpaidMessageWithExtraGas() public {
+        bytes memory message = MessageKind.WithPoolA1.asBytes();
+        bytes32 batchHash = keccak256(message);
+
+        gateway.setExtraGasLimit(EXTRA_GAS_LIMIT);
+        gateway.addUnpaidMessage(REMOTE_CENT_ID, message);
+
+        (, uint128 gasLimit) = gateway.underpaid(REMOTE_CENT_ID, batchHash);
+        assertEq(gasLimit, MESSAGE_GAS_LIMIT + EXTRA_GAS_LIMIT);
+        assertEq(gateway.extraGasLimit(), 0);
     }
 }

--- a/test/common/unit/Gateway.t.sol
+++ b/test/common/unit/Gateway.t.sol
@@ -872,6 +872,8 @@ contract GatewayTestAddUnpaidMessage is GatewayTest {
         bytes32 batchHash = keccak256(message);
 
         vm.expectEmit();
+        emit IGateway.PrepareMessage(REMOTE_CENT_ID, POOL_A, message);
+        vm.expectEmit();
         emit IGateway.UnderpaidBatch(REMOTE_CENT_ID, message);
         gateway.addUnpaidMessage(REMOTE_CENT_ID, message);
 

--- a/test/hub/unit/Hub.t.sol
+++ b/test/hub/unit/Hub.t.sol
@@ -24,6 +24,7 @@ import "forge-std/Test.sol";
 
 contract TestCommon is Test {
     uint16 constant CHAIN_A = 23;
+    uint16 constant CHAIN_B = 24;
     PoolId constant POOL_A = PoolId.wrap(1);
     ShareClassId constant SC_A = ShareClassId.wrap(bytes16(uint128(2)));
     AssetId constant ASSET_A = AssetId.wrap(3);
@@ -78,7 +79,7 @@ contract TestMainMethodsChecks is TestCommon {
         hub.updateShares(CHAIN_A, PoolId.wrap(0), ShareClassId.wrap(0), 0, true, true, 0);
 
         vm.expectRevert(IAuth.NotAuthorized.selector);
-        hub.initiateTransferShares(CHAIN_A, PoolId.wrap(0), ShareClassId.wrap(0), bytes32(""), 0, 0);
+        hub.initiateTransferShares(CHAIN_A, CHAIN_B, PoolId.wrap(0), ShareClassId.wrap(0), bytes32(""), 0, 0);
 
         vm.stopPrank();
     }

--- a/test/integration/ThreeChainEndToEnd.t.sol
+++ b/test/integration/ThreeChainEndToEnd.t.sol
@@ -125,7 +125,7 @@ contract ThreeChainEndToEndDeployment is EndToEndUseCases {
         emit IHub.ForwardTransferShares(sC.centrifugeId, POOL_A, SC_1, INVESTOR_A.toBytes32(), amount);
 
         // If hub is not source, then message will be pending as unpaid on hub until repaid
-        if (direction != CrossChainDirection.FromHub) {
+        if (direction == CrossChainDirection.WithIntermediaryHub) {
             vm.expectEmit(true, false, false, false);
             emit IGateway.UnderpaidBatch(sC.centrifugeId, bytes(""));
         } else {
@@ -143,7 +143,7 @@ contract ThreeChainEndToEndDeployment is EndToEndUseCases {
         IShareToken shareTokenC = IShareToken(sC.spoke.shareToken(POOL_A, SC_1));
 
         // If hub is not source, then message will be pending as unpaid on hub until repaid
-        if (direction != CrossChainDirection.FromHub) {
+        if (direction == CrossChainDirection.WithIntermediaryHub) {
             assertEq(shareTokenC.balanceOf(INVESTOR_A), 0, "Share transfer not executed due to unpaid message");
             bytes memory message = MessageLib.ExecuteTransferShares({
                 poolId: PoolId.unwrap(POOL_A),

--- a/test/integration/ThreeChainEndToEnd.t.sol
+++ b/test/integration/ThreeChainEndToEnd.t.sol
@@ -25,8 +25,8 @@ import "forge-std/Test.sol";
 
 enum CrossChainDirection {
     WithIntermediaryHub, // C -> A -> B (Hub is on A)
-    FromHub, // C == A -> B (Hub is on C)
-    ToHub // C -> B == A (Hub is on B)
+    FromHub, // C => A -> B (Hub is on A)
+    ToHub // C -> A => B (Hub is on A)
 
 }
 
@@ -46,7 +46,6 @@ contract ThreeChainEndToEndDeployment is EndToEndUseCases {
     LocalAdapter adapterCToA;
     LocalAdapter adapterAToC;
 
-    CSpoke sA;
     CSpoke sC;
     CSpoke sB;
 
@@ -70,27 +69,20 @@ contract ThreeChainEndToEndDeployment is EndToEndUseCases {
 
     function _setSpokes(CrossChainDirection direction) internal {
         if (direction == CrossChainDirection.WithIntermediaryHub) {
-            _setSpoke(deployA, CENTRIFUGE_ID_A, sA);
             _setSpoke(deployB, CENTRIFUGE_ID_B, sB);
             _setSpoke(deployC, CENTRIFUGE_ID_C, sC);
         } else if (direction == CrossChainDirection.FromHub) {
             _setSpoke(deployB, CENTRIFUGE_ID_B, sB);
             _setSpoke(deployA, CENTRIFUGE_ID_A, sC);
-            sA = sC;
         } else if (direction == CrossChainDirection.ToHub) {
             _setSpoke(deployA, CENTRIFUGE_ID_A, sB);
             _setSpoke(deployC, CENTRIFUGE_ID_C, sC);
-            sA = sB;
         }
     }
 
     /// @notice Configure the third chain (C) with assets
     function _testConfigureAssets(CrossChainDirection direction) internal {
         _setSpokes(direction);
-
-        if (direction == CrossChainDirection.WithIntermediaryHub) {
-            _configureAsset(sA);
-        }
         _configureAsset(sB);
         _configureAsset(sC);
     }
@@ -98,10 +90,6 @@ contract ThreeChainEndToEndDeployment is EndToEndUseCases {
     /// @notice Configure a pool with support for all three chains
     function _testConfigurePool(CrossChainDirection direction) internal {
         _setSpokes(direction);
-
-        if (direction == CrossChainDirection.WithIntermediaryHub) {
-            _configurePool(sA);
-        }
         _configurePool(sB);
         _configurePool(sC);
     }

--- a/test/integration/ThreeChainEndToEnd.t.sol
+++ b/test/integration/ThreeChainEndToEnd.t.sol
@@ -68,6 +68,7 @@ contract ThreeChainEndToEndDeployment is EndToEndUseCases {
     }
 
     function _setSpokes(CrossChainDirection direction) internal {
+        // NOTE: Hub is always in deployA.
         if (direction == CrossChainDirection.WithIntermediaryHub) {
             _setSpoke(deployB, CENTRIFUGE_ID_B, sB);
             _setSpoke(deployC, CENTRIFUGE_ID_C, sC);


### PR DESCRIPTION
Ref: https://kflabs.slack.com/archives/C07PG2EUR9C/p1756245526774999

### Changes
- No need to repay a message if the network topology of the transaction is: 
`Spoke chain X => Hub chain X => Spoke chain Y`
- Fix a bug in the Gateway where the extraGas wasn't taken into account for external unpaid messages (using `addUnpaidMessage()` method)
- Add missing `PrepareMessage` event to `addUnpaidMessage()`
- Fix gas values for the case of: Spoke on chain X => hub on chain Y => spoke on chain Y