### PR TITLE
AdaptersPerPool: Block sending and subsidized repayment

### DIFF
--- a/snapshots/AsyncVault.json
+++ b/snapshots/AsyncVault.json
@@ -1,4 +1,4 @@
 {
-  "fulfillDepositRequest": "944441",
-  "requestDeposit": "542036"
+  "fulfillDepositRequest": "944674",
+  "requestDeposit": "547829"
 }

--- a/snapshots/VaultRouter.json
+++ b/snapshots/VaultRouter.json
@@ -1,7 +1,7 @@
 {
-  "claimDeposit": "1109937",
+  "claimDeposit": "1110170",
   "enable": "60931",
   "lockDepositRequest": "95582",
-  "requestDeposit": "580973",
-  "requestRedeem": "2157629"
+  "requestDeposit": "587121",
+  "requestRedeem": "2170209"
 }

--- a/src/common/Gateway.sol
+++ b/src/common/Gateway.sol
@@ -230,7 +230,7 @@ contract Gateway is Auth, Recoverable, IGateway {
             if (msg.value > 0) subsidizePool(poolId);
         }
 
-        require(_send(centrifugeId, batch, underpaid_.gasLimit), InsufficientFundsForRepayment());
+        require(_send(centrifugeId, batch, underpaid_.gasLimit), CanNotBeRepaid());
 
         if (!underpaid_.isSubsidized) {
             _endTransactionPayment();

--- a/src/common/Gateway.sol
+++ b/src/common/Gateway.sol
@@ -214,20 +214,15 @@ contract Gateway is Auth, Recoverable, IGateway {
     }
 
     /// @inheritdoc IGateway
-    /// @dev note repay will only repay subsized messages, transactional messages fails if not enough gas.
     function repay(uint16 centrifugeId, bytes memory batch) external payable pauseable {
         bytes32 batchHash = keccak256(batch);
         Underpaid storage underpaid_ = underpaid[centrifugeId][batchHash];
         require(underpaid_.counter > 0, NotUnderpaidBatch());
 
-        PoolId poolId = processor.messagePoolIdPayment(batch);
-
         underpaid_.counter--;
 
         if (!underpaid_.isSubsidized) {
             _startTransactionPayment(msg.sender);
-        } else {
-            if (msg.value > 0) subsidizePool(poolId);
         }
 
         require(_send(centrifugeId, batch, underpaid_.gasLimit), CanNotBeRepaid());

--- a/src/common/MessageDispatcher.sol
+++ b/src/common/MessageDispatcher.sol
@@ -414,7 +414,7 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
                 gateway.send(targetCentrifugeId, message);
             } else {
                 // Spoke chain X => Hub chain Y => Spoke chain Z
-                gateway.addUnpaidMessage(targetCentrifugeId, message);
+                gateway.addUnpaidMessage(targetCentrifugeId, message, false);
             }
         }
     }

--- a/src/common/interfaces/IAdapter.sol
+++ b/src/common/interfaces/IAdapter.sol
@@ -3,6 +3,8 @@ pragma solidity >=0.5.0;
 
 import {IAuth} from "../../misc/interfaces/IAuth.sol";
 
+import {PoolId} from "../types/PoolId.sol";
+
 interface IAdapter is IAuth {
     error NotEntrypoint();
     error UnknownChainId();
@@ -15,4 +17,8 @@ interface IAdapter is IAuth {
 
     /// @notice Estimate the total cost in native gas tokens
     function estimate(uint16 centrifugeId, bytes calldata payload, uint256 gasLimit) external view returns (uint256);
+}
+
+interface IAdapterBlockSendingExt is IAdapter {
+    function isSendingBlocked(uint16 centrifugeId, PoolId poolId) external returns (bool);
 }

--- a/src/common/interfaces/IGateway.sol
+++ b/src/common/interfaces/IGateway.sol
@@ -19,14 +19,15 @@ interface IGateway is IMessageHandler, IMessageSender, IRecoverable {
     }
 
     struct Underpaid {
-        uint128 counter;
         uint128 gasLimit;
+        uint64 counter;
+        bool isSubsidized;
     }
 
     event File(bytes32 indexed what, address addr);
 
     event PrepareMessage(uint16 indexed centrifugeId, PoolId poolId, bytes message);
-    event UnderpaidBatch(uint16 indexed centrifugeId, bytes batch);
+    event UnderpaidBatch(uint16 indexed centrifugeId, bytes batch, bytes32 batchHash);
     event RepayBatch(uint16 indexed centrifugeId, bytes batch);
     event ExecuteMessage(uint16 indexed centrifugeId, bytes message);
     event FailMessage(uint16 indexed centrifugeId, bytes message, bytes error);
@@ -97,7 +98,7 @@ interface IGateway is IMessageHandler, IMessageSender, IRecoverable {
 
     /// @notice Add a message to the underpaid storage to be repay and send later.
     /// @dev It only supports one message, not a batch
-    function addUnpaidMessage(uint16 centrifugeId, bytes memory message) external;
+    function addUnpaidMessage(uint16 centrifugeId, bytes memory message, bool isSubsidized) external;
 
     /// @notice Initialize batching message
     function startBatching() external;
@@ -107,4 +108,7 @@ interface IGateway is IMessageHandler, IMessageSender, IRecoverable {
 
     /// @notice Returns the current gateway batching level.
     function isBatching() external view returns (bool);
+
+    /// @notice Returns the current gateway batching level.
+    function subsidizedValue(PoolId poolId) external view returns (uint256);
 }

--- a/src/common/interfaces/IGateway.sol
+++ b/src/common/interfaces/IGateway.sol
@@ -57,8 +57,8 @@ interface IGateway is IMessageHandler, IMessageSender, IRecoverable {
     /// @notice Dispatched when a batch that has not been underpaid is repaid.
     error NotUnderpaidBatch();
 
-    /// @notice Dispatched when a batch is repaid with insufficient funds.
-    error InsufficientFundsForRepayment();
+    /// @notice Dispatched when a batch is repaid with insufficient funds or the sending is blocked.
+    error CanNotBeRepaid();
 
     /// @notice Dispatched when a message is added to a batch that causes it to exceed the max batch size.
     error ExceedsMaxGasLimit();

--- a/src/common/interfaces/IGateway.sol
+++ b/src/common/interfaces/IGateway.sol
@@ -72,7 +72,11 @@ interface IGateway is IMessageHandler, IMessageSender, IRecoverable {
     /// @param  data New address.
     function file(bytes32 what, address data) external;
 
-    /// @notice Repay an underpaid batch. Send unused funds to subsidy pot of the pool.
+    /// @notice Repay an underpaid batch.
+    /// @dev Depending on the repaid message properties the payment vary.
+    ///      Check Underpaid.isSubsidized to know how the message must be repaid.
+    ///      - If !Underpaid.isSubsidized, then the payment is transactional and needs to be paid in `repay{value: ..}()`
+    ///      - If Underpaid.isSubsidized, the funds are taken from the subsidized pool
     function repay(uint16 centrifugeId, bytes memory batch) external payable;
 
     /// @notice Retry a failed message.

--- a/src/common/libraries/MessageLib.sol
+++ b/src/common/libraries/MessageLib.sol
@@ -74,8 +74,8 @@ library MessageLib {
         (33  << uint8(MessageType.CancelUpgrade) * 8) +
         (161 << uint8(MessageType.RecoverTokens) * 8) +
         (18  << uint8(MessageType.RegisterAsset) * 8) +
-        (43   << uint8(MessageType.SetPoolAdapters) * 8) +
-        (41   << uint8(MessageType.SetPoolAdaptersManager) * 8) +
+        (43  << uint8(MessageType.SetPoolAdapters) * 8) +
+        (41  << uint8(MessageType.SetPoolAdaptersManager) * 8) +
         (0   << uint8(MessageType._Placeholder7) * 8) +
         (0   << uint8(MessageType._Placeholder8) * 8) +
         (0   << uint8(MessageType._Placeholder9) * 8) +

--- a/test/common/unit/Gateway.t.sol
+++ b/test/common/unit/Gateway.t.sol
@@ -927,17 +927,18 @@ contract GatewayTestRepay is GatewayTest {
 
         _mockAdapter(REMOTE_CENT_ID, batch, MESSAGE_GAS_LIMIT, address(POOL_REFUND));
         gateway.send(REMOTE_CENT_ID, batch);
-
-        uint256 payment = MESSAGE_GAS_LIMIT + ADAPTER_ESTIMATE;
+        gateway.subsidizePool{value: MESSAGE_GAS_LIMIT + ADAPTER_ESTIMATE + 1234}(POOL_A);
 
         vm.expectEmit();
         emit IGateway.RepayBatch(REMOTE_CENT_ID, batch);
-        gateway.repay{value: payment}(REMOTE_CENT_ID, batch);
+        gateway.repay(REMOTE_CENT_ID, batch);
 
         (uint128 gasLimit, uint64 counter, bool isSubsidized) = gateway.underpaid(REMOTE_CENT_ID, keccak256(batch));
         assertEq(counter, 0);
         assertEq(gasLimit, 0);
         assertEq(isSubsidized, false);
+
+        assertEq(gateway.subsidizedValue(POOL_A), 1234); // 1234 of gas remaining
     }
 
     function testCorrectRepayForBatches() public {
@@ -951,12 +952,11 @@ contract GatewayTestRepay is GatewayTest {
 
         _mockAdapter(REMOTE_CENT_ID, batch, MESSAGE_GAS_LIMIT * 2, address(POOL_REFUND));
         gateway.endBatching();
-
-        uint256 payment = MESSAGE_GAS_LIMIT * 2 + ADAPTER_ESTIMATE;
+        gateway.subsidizePool{value: MESSAGE_GAS_LIMIT * 2 + ADAPTER_ESTIMATE + 1234}(POOL_A);
 
         vm.expectEmit();
         emit IGateway.RepayBatch(REMOTE_CENT_ID, batch);
-        gateway.repay{value: payment}(REMOTE_CENT_ID, batch);
+        gateway.repay(REMOTE_CENT_ID, batch);
     }
 
     function testCorrectRepayWithTransactionalPayment() public {

--- a/test/hub/integration/Cases.t.sol
+++ b/test/hub/integration/Cases.t.sol
@@ -8,7 +8,6 @@ import {CastLib} from "../../../src/misc/libraries/CastLib.sol";
 import {MathLib} from "../../../src/misc/libraries/MathLib.sol";
 
 import {PoolId} from "../../../src/common/types/PoolId.sol";
-
 import {MessageLib} from "../../../src/common/libraries/MessageLib.sol";
 import {PricingLib} from "../../../src/common/libraries/PricingLib.sol";
 import {ShareClassId} from "../../../src/common/types/ShareClassId.sol";

--- a/test/integration/ThreeChainEndToEnd.t.sol
+++ b/test/integration/ThreeChainEndToEnd.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import {EndToEndUseCases} from "./EndToEnd.t.sol";
+import {EndToEndFlows} from "./EndToEnd.t.sol";
 import {LocalAdapter} from "./adapters/LocalAdapter.sol";
 import {IntegrationConstants} from "./utils/IntegrationConstants.sol";
 
@@ -35,7 +35,7 @@ enum CrossChainDirection {
 ///         Hub is on Chain A, with spokes on Chains B and C
 ///         C is considered the source chain, B the destination chain
 ///         Depending on the cross chain direction, the hub is either on A or B or C
-contract ThreeChainEndToEndDeployment is EndToEndUseCases {
+contract ThreeChainEndToEndDeployment is EndToEndFlows {
     using CastLib for *;
     using MessageLib for *;
 
@@ -116,7 +116,7 @@ contract ThreeChainEndToEndDeployment is EndToEndUseCases {
         // If hub is not source, then message will be pending as unpaid on hub until repaid
         if (direction == CrossChainDirection.WithIntermediaryHub) {
             vm.expectEmit(true, false, false, false);
-            emit IGateway.UnderpaidBatch(sC.centrifugeId, bytes(""));
+            emit IGateway.UnderpaidBatch(sC.centrifugeId, bytes(""), bytes32(0));
         } else {
             vm.expectEmit();
             emit ISpoke.ExecuteTransferShares(POOL_A, SC_1, INVESTOR_A, amount);
@@ -146,6 +146,8 @@ contract ThreeChainEndToEndDeployment is EndToEndUseCases {
             emit IMultiAdapter.HandlePayload(h.centrifugeId, bytes32(""), bytes(""), adapterCToA);
             vm.expectEmit();
             emit ISpoke.ExecuteTransferShares(POOL_A, SC_1, INVESTOR_A, amount);
+
+            vm.startPrank(ANY);
             h.gateway.repay{value: GAS}(sC.centrifugeId, message);
         }
 


### PR DESCRIPTION
Based on: https://github.com/centrifuge/protocol-v3/pull/570

- Add a mechanism to block sending messages and be able to repay them when sending is ready again.
- When sending is blocked, a try to send a message will subsidy the subsidized pool, to later the manager be able to recover them.
- Fix a repay bug when the message MUST not be repaid with subsidized funds: [ref](https://kflabs.slack.com/archives/C07PG2EUR9C/p1757331318071439)