### PR TITLE
root messages only from mainnet

### DIFF
--- a/snapshots/AsyncVault.json
+++ b/snapshots/AsyncVault.json
@@ -1,4 +1,4 @@
 {
-  "fulfillDepositRequest": "789122",
-  "requestDeposit": "667599"
+  "fulfillDepositRequest": "789452",
+  "requestDeposit": "667709"
 }

--- a/snapshots/AsyncVault.json
+++ b/snapshots/AsyncVault.json
@@ -1,4 +1,4 @@
 {
-  "fulfillDepositRequest": "789123",
+  "fulfillDepositRequest": "789122",
   "requestDeposit": "667599"
 }

--- a/snapshots/VaultRouter.json
+++ b/snapshots/VaultRouter.json
@@ -1,7 +1,7 @@
 {
-  "claimDeposit": "954529",
+  "claimDeposit": "954859",
   "enable": "60931",
   "lockDepositRequest": "95538",
-  "requestDeposit": "706935",
-  "requestRedeem": "2140829"
+  "requestDeposit": "707045",
+  "requestRedeem": "2141379"
 }

--- a/src/common/MessageProcessor.sol
+++ b/src/common/MessageProcessor.sol
@@ -26,6 +26,8 @@ import {CastLib} from "../misc/libraries/CastLib.sol";
 import {BytesLib} from "../misc/libraries/BytesLib.sol";
 import {IRecoverable} from "../misc/interfaces/IRecoverable.sol";
 
+uint16 constant MAINNET_CENTRIFUGE_ID = 1;
+
 contract MessageProcessor is Auth, IMessageProcessor {
     using CastLib for *;
     using MessageLib for *;
@@ -68,11 +70,12 @@ contract MessageProcessor is Auth, IMessageProcessor {
     /// @inheritdoc IMessageHandler
     function handle(uint16 centrifugeId, bytes calldata message) external auth {
         MessageType kind = message.messageType();
-        uint16 sourceCentrifugeId = message.messageSourceCentrifugeId();
 
+        uint16 sourceCentrifugeId = message.messageSourceCentrifugeId();
         require(sourceCentrifugeId == 0 || sourceCentrifugeId == centrifugeId, InvalidSourceChain());
 
         if (kind == MessageType.ScheduleUpgrade) {
+            require(centrifugeId == MAINNET_CENTRIFUGE_ID, OnlyFromMainnet());
             MessageLib.ScheduleUpgrade memory m = message.deserializeScheduleUpgrade();
             root.scheduleRely(m.target.toAddress());
         } else if (kind == MessageType.CancelUpgrade) {

--- a/src/common/MessageProcessor.sol
+++ b/src/common/MessageProcessor.sol
@@ -26,12 +26,12 @@ import {CastLib} from "../misc/libraries/CastLib.sol";
 import {BytesLib} from "../misc/libraries/BytesLib.sol";
 import {IRecoverable} from "../misc/interfaces/IRecoverable.sol";
 
-uint16 constant MAINNET_CENTRIFUGE_ID = 1;
-
 contract MessageProcessor is Auth, IMessageProcessor {
     using CastLib for *;
     using MessageLib for *;
     using BytesLib for bytes;
+
+    uint16 public constant MAINNET_CENTRIFUGE_ID = 1;
 
     IRoot public immutable root;
     ITokenRecoverer public immutable tokenRecoverer;

--- a/src/common/MessageProcessor.sol
+++ b/src/common/MessageProcessor.sol
@@ -79,9 +79,11 @@ contract MessageProcessor is Auth, IMessageProcessor {
             MessageLib.ScheduleUpgrade memory m = message.deserializeScheduleUpgrade();
             root.scheduleRely(m.target.toAddress());
         } else if (kind == MessageType.CancelUpgrade) {
+            require(centrifugeId == MAINNET_CENTRIFUGE_ID, OnlyFromMainnet());
             MessageLib.CancelUpgrade memory m = message.deserializeCancelUpgrade();
             root.cancelRely(m.target.toAddress());
         } else if (kind == MessageType.RecoverTokens) {
+            require(centrifugeId == MAINNET_CENTRIFUGE_ID, OnlyFromMainnet());
             MessageLib.RecoverTokens memory m = message.deserializeRecoverTokens();
             tokenRecoverer.recoverTokens(
                 IRecoverable(m.target.toAddress()), m.token.toAddress(), m.tokenId, m.to.toAddress(), m.amount

--- a/src/common/interfaces/IMessageProcessor.sol
+++ b/src/common/interfaces/IMessageProcessor.sol
@@ -13,6 +13,9 @@ interface IMessageProcessor is IMessageHandler, IMessageProperties {
     /// @notice Dispatched when the `what` parameter of `file()` is not supported by the implementation.
     error FileUnrecognizedParam();
 
+    /// @notice Dispatched when a message is tried to send from a different chain than mainnet
+    error OnlyFromMainnet();
+
     /// @notice Updates a contract parameter.
     /// @param what Name of the parameter to update.
     /// Accepts a `bytes32` representation of 'hubRegistry' string value.

--- a/test/integration/utils/IntegrationConstants.sol
+++ b/test/integration/utils/IntegrationConstants.sol
@@ -10,10 +10,10 @@ import {MAX_MESSAGE_COST} from "../../../src/common/interfaces/IGasService.sol";
 /// @notice Centralized constants for integration tests
 library IntegrationConstants {
     // ======== Network IDs ========
-    uint16 constant CENTRIFUGE_ID_A = 5;
-    uint16 constant CENTRIFUGE_ID_B = 6;
-    uint16 constant CENTRIFUGE_ID_C = 7;
-    uint16 constant LOCAL_CENTRIFUGE_ID = 1;
+    uint16 constant CENTRIFUGE_ID_A = 1;
+    uint16 constant CENTRIFUGE_ID_B = 2;
+    uint16 constant CENTRIFUGE_ID_C = 3;
+    uint16 constant LOCAL_CENTRIFUGE_ID = 4;
 
     // ======== Amounts ========
     uint128 constant DEFAULT_USDC_AMOUNT = 1e12; // 1M USDC


### PR DESCRIPTION
Task: https://www.notion.so/Allow-ScheduleRely-message-only-from-Ethereum-mainnet-22d2eac24e1780059962d2d606af4df8?source=copy_link

Protect the `scheduleRely` from being used by chains that could be vulnerable.