### PR TITLE
Ref remove extraGasLimit transient storage

### DIFF
--- a/snapshots/AsyncVault.json
+++ b/snapshots/AsyncVault.json
@@ -1,4 +1,4 @@
 {
-  "fulfillDepositRequest": "794356",
-  "requestDeposit": "668325"
+  "fulfillDepositRequest": "794362",
+  "requestDeposit": "668270"
 }

--- a/snapshots/VaultRouter.json
+++ b/snapshots/VaultRouter.json
@@ -1,7 +1,7 @@
 {
-  "claimDeposit": "959831",
+  "claimDeposit": "959837",
   "enable": "60955",
   "lockDepositRequest": "95562",
-  "requestDeposit": "677730",
-  "requestRedeem": "2067030"
+  "requestDeposit": "677675",
+  "requestRedeem": "2066926"
 }

--- a/src/common/Gateway.sol
+++ b/src/common/Gateway.sol
@@ -6,7 +6,6 @@ import {IRoot} from "./interfaces/IRoot.sol";
 import {IAdapter} from "./interfaces/IAdapter.sol";
 import {IGateway} from "./interfaces/IGateway.sol";
 import {IGasService} from "./interfaces/IGasService.sol";
-import {IMessageSender} from "./interfaces/IMessageSender.sol";
 import {IMessageHandler} from "./interfaces/IMessageHandler.sol";
 import {IMessageProcessor} from "./interfaces/IMessageProcessor.sol";
 
@@ -47,7 +46,6 @@ contract Gateway is Auth, Recoverable, IGateway {
 
     // Outbound & payments
     bool public transient isBatching;
-    uint128 public transient extraGasLimit;
     mapping(PoolId => Funds) public subsidy;
     mapping(uint16 centrifugeId => mapping(PoolId => bool)) public isOutgoingBlocked;
     mapping(uint16 centrifugeId => mapping(bytes32 batchHash => Underpaid)) public underpaid;
@@ -142,8 +140,13 @@ contract Gateway is Auth, Recoverable, IGateway {
     // Outgoing
     //----------------------------------------------------------------------------------------------
 
-    /// @inheritdoc IMessageSender
-    function send(uint16 centrifugeId, bytes calldata message) external pauseable auth returns (uint256) {
+    /// @inheritdoc IGateway
+    function send(uint16 centrifugeId, bytes calldata message, uint128 extraGasLimit)
+        external
+        pauseable
+        auth
+        returns (uint256)
+    {
         require(message.length > 0, EmptyMessage());
 
         PoolId poolId = processor.messagePoolId(message);
@@ -151,7 +154,6 @@ contract Gateway is Auth, Recoverable, IGateway {
         emit PrepareMessage(centrifugeId, poolId, message);
 
         uint128 gasLimit = gasService.messageGasLimit(centrifugeId, message) + extraGasLimit;
-        extraGasLimit = 0;
 
         if (isBatching) {
             bytes32 batchSlot = _outboundBatchSlot(centrifugeId, poolId);
@@ -195,9 +197,8 @@ contract Gateway is Auth, Recoverable, IGateway {
     }
 
     /// @inheritdoc IGateway
-    function addUnpaidMessage(uint16 centrifugeId, bytes memory message) external auth {
+    function addUnpaidMessage(uint16 centrifugeId, bytes memory message, uint128 extraGasLimit) external auth {
         uint128 gasLimit = gasService.messageGasLimit(centrifugeId, message) + extraGasLimit;
-        extraGasLimit = 0;
         emit PrepareMessage(centrifugeId, processor.messagePoolId(message), message);
         _addUnpaidBatch(centrifugeId, message, gasLimit);
     }
@@ -244,11 +245,6 @@ contract Gateway is Auth, Recoverable, IGateway {
             subsidy[GLOBAL_POT].value -= refundBalance.toUint96();
             _depositSubsidy(poolId, address(refund), refundBalance);
         }
-    }
-
-    /// @inheritdoc IGateway
-    function setExtraGasLimit(uint128 gas) public auth {
-        extraGasLimit = gas;
     }
 
     /// @inheritdoc IGateway

--- a/src/common/Gateway.sol
+++ b/src/common/Gateway.sol
@@ -150,11 +150,9 @@ contract Gateway is Auth, Recoverable, IGateway {
         require(message.length > 0, EmptyMessage());
 
         PoolId poolId = processor.messagePoolId(message);
-
         emit PrepareMessage(centrifugeId, poolId, message);
 
         uint128 gasLimit = gasService.messageGasLimit(centrifugeId, message) + extraGasLimit;
-
         if (isBatching) {
             bytes32 batchSlot = _outboundBatchSlot(centrifugeId, poolId);
             bytes memory previousMessage = TransientBytesLib.get(batchSlot);

--- a/src/common/MessageDispatcher.sol
+++ b/src/common/MessageDispatcher.sol
@@ -84,7 +84,7 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
         if (centrifugeId == localCentrifugeId) {
             spoke.addPool(poolId);
         } else {
-            return gateway.send(centrifugeId, MessageLib.NotifyPool({poolId: poolId.raw()}).serialize());
+            return gateway.send(centrifugeId, MessageLib.NotifyPool({poolId: poolId.raw()}).serialize(), 0);
         }
     }
 
@@ -112,7 +112,8 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
                     decimals: decimals,
                     salt: salt,
                     hook: hook
-                }).serialize()
+                }).serialize(),
+                0
             );
         }
     }
@@ -135,7 +136,8 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
                     scId: scId.raw(),
                     name: name,
                     symbol: symbol.toBytes32()
-                }).serialize()
+                }).serialize(),
+                0
             );
         }
     }
@@ -151,7 +153,8 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
         } else {
             return gateway.send(
                 centrifugeId,
-                MessageLib.UpdateShareHook({poolId: poolId.raw(), scId: scId.raw(), hook: hook}).serialize()
+                MessageLib.UpdateShareHook({poolId: poolId.raw(), scId: scId.raw(), hook: hook}).serialize(),
+                0
             );
         }
     }
@@ -173,7 +176,8 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
                     scId: scId.raw(),
                     price: price.raw(),
                     timestamp: timestamp
-                }).serialize()
+                }).serialize(),
+                0
             );
         }
     }
@@ -196,7 +200,8 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
                     assetId: assetId.raw(),
                     price: price.raw(),
                     timestamp: timestamp
-                }).serialize()
+                }).serialize(),
+                0
             );
         }
     }
@@ -212,10 +217,10 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
         if (centrifugeId == localCentrifugeId) {
             spoke.updateRestriction(poolId, scId, payload);
         } else {
-            gateway.setExtraGasLimit(extraGasLimit);
             return gateway.send(
                 centrifugeId,
-                MessageLib.UpdateRestriction({poolId: poolId.raw(), scId: scId.raw(), payload: payload}).serialize()
+                MessageLib.UpdateRestriction({poolId: poolId.raw(), scId: scId.raw(), payload: payload}).serialize(),
+                extraGasLimit
             );
         }
     }
@@ -232,11 +237,11 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
         if (centrifugeId == localCentrifugeId) {
             contractUpdater.execute(poolId, scId, target.toAddress(), payload);
         } else {
-            gateway.setExtraGasLimit(extraGasLimit);
             return gateway.send(
                 centrifugeId,
                 MessageLib.UpdateContract({poolId: poolId.raw(), scId: scId.raw(), target: target, payload: payload})
-                    .serialize()
+                    .serialize(),
+                extraGasLimit
             );
         }
     }
@@ -253,7 +258,6 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
         if (assetId.centrifugeId() == localCentrifugeId) {
             spoke.updateVault(poolId, scId, assetId, vaultOrFactory.toAddress(), kind);
         } else {
-            gateway.setExtraGasLimit(extraGasLimit);
             return gateway.send(
                 assetId.centrifugeId(),
                 MessageLib.UpdateVault({
@@ -262,7 +266,8 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
                     assetId: assetId.raw(),
                     vaultOrFactory: vaultOrFactory,
                     kind: uint8(kind)
-                }).serialize()
+                }).serialize(),
+                extraGasLimit
             );
         }
     }
@@ -277,7 +282,7 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
             spoke.setRequestManager(poolId, IRequestManager(manager.toAddress()));
         } else {
             return gateway.send(
-                centrifugeId, MessageLib.SetRequestManager({poolId: poolId.raw(), manager: manager}).serialize()
+                centrifugeId, MessageLib.SetRequestManager({poolId: poolId.raw(), manager: manager}).serialize(), 0
             );
         }
     }
@@ -293,7 +298,8 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
         } else {
             return gateway.send(
                 centrifugeId,
-                MessageLib.UpdateBalanceSheetManager({poolId: poolId.raw(), who: who, canManage: canManage}).serialize()
+                MessageLib.UpdateBalanceSheetManager({poolId: poolId.raw(), who: who, canManage: canManage}).serialize(),
+                0
             );
         }
     }
@@ -314,7 +320,8 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
                     scId: scId.raw(),
                     assetId: assetId.raw(),
                     maxPriceAge: maxPriceAge
-                }).serialize()
+                }).serialize(),
+                0
             );
         }
     }
@@ -331,7 +338,8 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
             return gateway.send(
                 centrifugeId,
                 MessageLib.MaxSharePriceAge({poolId: poolId.raw(), scId: scId.raw(), maxPriceAge: maxPriceAge})
-                    .serialize()
+                    .serialize(),
+                0
             );
         }
     }
@@ -341,7 +349,7 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
         if (centrifugeId == localCentrifugeId) {
             root.scheduleRely(target.toAddress());
         } else {
-            return gateway.send(centrifugeId, MessageLib.ScheduleUpgrade({target: target}).serialize());
+            return gateway.send(centrifugeId, MessageLib.ScheduleUpgrade({target: target}).serialize(), 0);
         }
     }
 
@@ -350,7 +358,7 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
         if (centrifugeId == localCentrifugeId) {
             root.cancelRely(target.toAddress());
         } else {
-            return gateway.send(centrifugeId, MessageLib.CancelUpgrade({target: target}).serialize());
+            return gateway.send(centrifugeId, MessageLib.CancelUpgrade({target: target}).serialize(), 0);
         }
     }
 
@@ -371,7 +379,8 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
             return gateway.send(
                 centrifugeId,
                 MessageLib.RecoverTokens({target: target, token: token, tokenId: tokenId, to: to, amount: amount})
-                    .serialize()
+                    .serialize(),
+                0
             );
         }
     }
@@ -391,7 +400,6 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
                 localCentrifugeId, targetCentrifugeId, poolId, scId, receiver, amount, remoteExtraGasLimit
             );
         } else {
-            gateway.setExtraGasLimit(extraGasLimit);
             return gateway.send(
                 poolId.centrifugeId(),
                 MessageLib.InitiateTransferShares({
@@ -401,7 +409,8 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
                     receiver: receiver,
                     amount: amount,
                     extraGasLimit: remoteExtraGasLimit
-                }).serialize()
+                }).serialize(),
+                extraGasLimit
             );
         }
     }
@@ -427,14 +436,12 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
                 amount: amount
             }).serialize();
 
-            gateway.setExtraGasLimit(extraGasLimit);
-
             if (originCentrifugeId == localCentrifugeId) {
                 // Spoke chain X => Hub chain X => Spoke chain Y: payment done directly on X
-                return gateway.send(targetCentrifugeId, message);
+                return gateway.send(targetCentrifugeId, message, extraGasLimit);
             } else {
                 // Spoke chain X => Hub chain Y => Spoke chain Z
-                gateway.addUnpaidMessage(targetCentrifugeId, message);
+                gateway.addUnpaidMessage(targetCentrifugeId, message, extraGasLimit);
             }
         }
     }
@@ -461,7 +468,6 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
                 data.nonce
             );
         } else {
-            gateway.setExtraGasLimit(extraGasLimit);
             return gateway.send(
                 poolId.centrifugeId(),
                 MessageLib.UpdateHoldingAmount({
@@ -474,7 +480,8 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
                     isIncrease: data.isIncrease,
                     isSnapshot: data.isSnapshot,
                     nonce: data.nonce
-                }).serialize()
+                }).serialize(),
+                extraGasLimit
             );
         }
     }
@@ -490,7 +497,6 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
                 localCentrifugeId, poolId, scId, data.netAmount, data.isIncrease, data.isSnapshot, data.nonce
             );
         } else {
-            gateway.setExtraGasLimit(extraGasLimit);
             return gateway.send(
                 poolId.centrifugeId(),
                 MessageLib.UpdateShares({
@@ -501,7 +507,8 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
                     isIssuance: data.isIncrease,
                     isSnapshot: data.isSnapshot,
                     nonce: data.nonce
-                }).serialize()
+                }).serialize(),
+                extraGasLimit
             );
         }
     }
@@ -516,7 +523,7 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
             hub.registerAsset(assetId, decimals);
         } else {
             return gateway.send(
-                centrifugeId, MessageLib.RegisterAsset({assetId: assetId.raw(), decimals: decimals}).serialize()
+                centrifugeId, MessageLib.RegisterAsset({assetId: assetId.raw(), decimals: decimals}).serialize(), 0
             );
         }
     }
@@ -533,7 +540,8 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
             return gateway.send(
                 poolId.centrifugeId(),
                 MessageLib.Request({poolId: poolId.raw(), scId: scId.raw(), assetId: assetId.raw(), payload: payload})
-                    .serialize()
+                    .serialize(),
+                0
             );
         }
     }
@@ -549,7 +557,6 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
         if (assetId.centrifugeId() == localCentrifugeId) {
             spoke.requestCallback(poolId, scId, assetId, payload);
         } else {
-            gateway.setExtraGasLimit(extraGasLimit);
             return gateway.send(
                 assetId.centrifugeId(),
                 MessageLib.RequestCallback({
@@ -557,7 +564,8 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
                     scId: scId.raw(),
                     assetId: assetId.raw(),
                     payload: payload
-                }).serialize()
+                }).serialize(),
+                extraGasLimit
             );
         }
     }
@@ -580,7 +588,8 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
                     threshold: threshold,
                     recoveryIndex: recoveryIndex,
                     adapterList: adapters
-                }).serialize()
+                }).serialize(),
+                0
             );
         }
     }
@@ -595,7 +604,8 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
         } else {
             return gateway.send(
                 centrifugeId,
-                MessageLib.UpdateGatewayManager({poolId: poolId.raw(), who: who, canManage: canManage}).serialize()
+                MessageLib.UpdateGatewayManager({poolId: poolId.raw(), who: who, canManage: canManage}).serialize(),
+                0
             );
         }
     }

--- a/src/common/interfaces/IGateway.sol
+++ b/src/common/interfaces/IGateway.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {IMessageSender} from "./IMessageSender.sol";
 import {IMessageHandler} from "./IMessageHandler.sol";
 
 import {IRecoverable} from "../../misc/interfaces/IRecoverable.sol";
@@ -9,7 +8,7 @@ import {IRecoverable} from "../../misc/interfaces/IRecoverable.sol";
 import {PoolId} from "../types/PoolId.sol";
 
 /// @notice Interface for dispatch-only gateway
-interface IGateway is IMessageHandler, IMessageSender, IRecoverable {
+interface IGateway is IMessageHandler, IRecoverable {
     struct Funds {
         /// @notice Funds associated to pay for sending messages
         /// @dev    Overflows with type(uint64).max / 10**18 = 7.923 × 10^10 ETH
@@ -101,9 +100,6 @@ interface IGateway is IMessageHandler, IMessageSender, IRecoverable {
     /// @notice Retry a failed message.
     function retry(uint16 centrifugeId, bytes memory message) external;
 
-    /// @notice Set an extra gas to the gas limit of the message
-    function setExtraGasLimit(uint128 gas) external;
-
     /// @notice Set the refund address for message associated to a poolId
     function setRefundAddress(PoolId poolId, IRecoverable refund) external;
 
@@ -113,9 +109,14 @@ interface IGateway is IMessageHandler, IMessageSender, IRecoverable {
     /// @notice Withdraw the funds associated to the pool
     function withdrawSubsidy(PoolId poolId, address to, uint256 amount) external;
 
+    /// @notice Handling outgoing messages.
+    /// @param centrifugeId Destination chain
+    function send(uint16 centrifugeId, bytes calldata message, uint128 extraGasLimit) external returns (uint256 cost);
+
     /// @notice Add a message to the underpaid storage to be repay and send later.
     /// @dev It only supports one message, not a batch
-    function addUnpaidMessage(uint16 centrifugeId, bytes memory message) external;
+    /// @param extraGasLimit Adds an extra cost for the message
+    function addUnpaidMessage(uint16 centrifugeId, bytes memory message, uint128 extraGasLimit) external;
 
     /// @notice Initialize batching message
     function startBatching() external;

--- a/src/common/interfaces/IMessageSender.sol
+++ b/src/common/interfaces/IMessageSender.sol
@@ -1,9 +1,0 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity >=0.5.0;
-
-/// @notice Generic interface for entities that handles outgoing messages
-interface IMessageSender {
-    /// @notice Handling outgoing messages.
-    /// @param centrifugeId Destination chain
-    function send(uint16 centrifugeId, bytes calldata message) external returns (uint256 cost);
-}


### PR DESCRIPTION
Minor refactor to get rid of `extraGasLimit` transient storage in the Gateway. 

This was annoying because it created an invisible side effect between the `Gateway` and `MessageDispatcher` . It's very easy to forget the call to `gateway.setExtraGasLimit` or from the gateway forgot to assume the caller has called `setExtraGasLimit` in some scenarios, and clean the state after reading.

Now this relation is clearly established using a parameter in `send()`, and the compiler forces  it