### PR TITLE
Tests: decouple fork tests

### DIFF
--- a/test/integration/fork/ForkTestBase.sol
+++ b/test/integration/fork/ForkTestBase.sol
@@ -2,8 +2,8 @@
 pragma solidity 0.8.28;
 
 import {ERC20} from "../../../src/misc/ERC20.sol";
-import {D18} from "../../../src/misc/types/D18.sol";
 import {CastLib} from "../../../src/misc/libraries/CastLib.sol";
+import {IERC7575Share, IERC165} from "../../../src/misc/interfaces/IERC7575.sol";
 
 import {Root} from "../../../src/common/Root.sol";
 import {Gateway} from "../../../src/common/Gateway.sol";
@@ -22,6 +22,8 @@ import {ShareClassManager} from "../../../src/hub/ShareClassManager.sol";
 
 import {Spoke} from "../../../src/spoke/Spoke.sol";
 import {BalanceSheet} from "../../../src/spoke/BalanceSheet.sol";
+import {UpdateContractMessageLib} from "../../../src/spoke/libraries/UpdateContractMessageLib.sol";
+import {IVaultManager, REQUEST_MANAGER_V3_0} from "../../../src/spoke/interfaces/legacy/IVaultManager.sol";
 
 import {SyncManager} from "../../../src/vaults/SyncManager.sol";
 import {VaultRouter} from "../../../src/vaults/VaultRouter.sol";
@@ -33,38 +35,75 @@ import {MockSnapshotHook} from "../../hooks/mocks/MockSnapshotHook.sol";
 import {FreezeOnly} from "../../../src/hooks/FreezeOnly.sol";
 import {FullRestrictions} from "../../../src/hooks/FullRestrictions.sol";
 import {RedemptionRestrictions} from "../../../src/hooks/RedemptionRestrictions.sol";
+import {UpdateRestrictionMessageLib} from "../../../src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
 import {OracleValuation} from "../../../src/valuations/OracleValuation.sol";
 import {IdentityValuation} from "../../../src/valuations/IdentityValuation.sol";
 
 import "forge-std/Test.sol";
 
-import {EndToEndFlows} from "../EndToEnd.t.sol";
 import {IntegrationConstants} from "../utils/IntegrationConstants.sol";
 
-interface HubLike {
-    function updateRestriction(
-        PoolId poolId,
-        ShareClassId scId,
-        uint16 centrifugeId,
-        bytes calldata payload,
-        uint128 extraGasLimit
-    ) external payable;
+struct CHub {
+    uint16 centrifugeId;
+    // Common
+    Root root;
+    Guardian guardian;
+    Gateway gateway;
+    MultiAdapter multiAdapter;
+    GasService gasService;
+    // Hub
+    HubRegistry hubRegistry;
+    Accounting accounting;
+    Holdings holdings;
+    ShareClassManager shareClassManager;
+    Hub hub;
+    // Others
+    IdentityValuation identityValuation;
+    OracleValuation oracleValuation;
+    MockSnapshotHook snapshotHook;
+}
 
-    function notifySharePrice(PoolId poolId, ShareClassId scId, uint16 centrifugeId) external payable;
-
-    function notifyAssetPrice(PoolId poolId, ShareClassId scId, AssetId assetId) external payable;
+struct CSpoke {
+    uint16 centrifugeId;
+    // Common
+    Root root;
+    Guardian guardian;
+    Gateway gateway;
+    MultiAdapter multiAdapter;
+    // Vaults
+    BalanceSheet balanceSheet;
+    Spoke spoke;
+    VaultRouter router;
+    bytes32 asyncVaultFactory;
+    bytes32 syncDepositVaultFactory;
+    AsyncRequestManager asyncRequestManager;
+    SyncManager syncManager;
+    // Hooks
+    FreezeOnly freezeOnlyHook;
+    FullRestrictions fullRestrictionsHook;
+    RedemptionRestrictions redemptionRestrictionsHook;
+    // Others
+    ERC20 usdc;
+    AssetId usdcId;
 }
 
 /// @title ForkTestBase
 /// @notice Base contract for all fork tests, providing common setup and utilities
-contract ForkTestBase is EndToEndFlows {
+contract ForkTestBase is Test {
     using CastLib for *;
+    using UpdateContractMessageLib for *;
+    using UpdateRestrictionMessageLib for *;
+
+    uint128 constant GAS = IntegrationConstants.GAS;
+    uint128 constant EXTRA_GAS = IntegrationConstants.EXTRA_GAS;
+
+    address immutable ANY = makeAddr("ANY");
 
     CHub forkHub;
     CSpoke forkSpoke;
 
-    function setUp() public virtual override {
+    function setUp() public virtual {
         vm.createSelectFork(_rpcEndpoint());
         _loadContracts();
     }
@@ -115,12 +154,15 @@ contract ForkTestBase is EndToEndFlows {
             usdcId: newAssetId(0) // NOTE: Unused in fork tests in order to be chain agnostic
         });
 
-        // Initialize pricing state
-        currentAssetPrice = IntegrationConstants.identityPrice();
-        currentSharePrice = IntegrationConstants.identityPrice();
-
         // Fund pool admin
         vm.deal(_poolAdmin(), 10 ether);
+    }
+
+    function _updateRestrictionMemberMsg(address addr) internal pure returns (bytes memory) {
+        return UpdateRestrictionMessageLib.UpdateRestrictionMember({
+            user: addr.toBytes32(),
+            validUntil: type(uint64).max
+        }).serialize();
     }
 
     function _addPoolMember(IBaseVault vault, address user) internal virtual {
@@ -139,17 +181,46 @@ contract ForkTestBase is EndToEndFlows {
         PoolId poolId,
         ShareClassId shareClassId,
         AssetId assetId,
-        address poolManager,
-        D18 assetPrice,
-        D18 sharePrice
-    ) internal virtual override {
-        currentAssetPrice = assetPrice;
-        currentSharePrice = sharePrice;
-
+        address poolManager
+    ) internal virtual {
         vm.startPrank(poolManager);
-        hub.hub.updateSharePrice(poolId, shareClassId, sharePrice);
+        hub.hub.updateSharePrice(poolId, shareClassId, IntegrationConstants.identityPrice());
         hub.hub.notifySharePrice(poolId, shareClassId, spoke.centrifugeId);
         hub.hub.notifyAssetPrice(poolId, shareClassId, assetId);
         vm.stopPrank();
+    }
+
+    function _isShareToken(address token) internal view returns (bool) {
+        try IERC165(token).supportsInterface(type(IERC7575Share).interfaceId) returns (bool supported) {
+            return supported;
+        } catch {
+            return false;
+        }
+    }
+
+    function _getAsyncVault(CSpoke memory spoke, PoolId poolId, ShareClassId shareClassId, AssetId assetId)
+        internal
+        view
+        returns (address vaultAddr)
+    {
+        if (spoke.asyncRequestManager == REQUEST_MANAGER_V3_0) {
+            // Fallback to legacy V3.0 lookup if not found in new system
+            return
+                address(IVaultManager(address(spoke.asyncRequestManager)).vaultByAssetId(poolId, shareClassId, assetId));
+        } else {
+            // Try new system first
+            return address(spoke.spoke.vault(poolId, shareClassId, assetId, spoke.asyncRequestManager));
+        }
+    }
+
+    function _updateContractSyncDepositMaxReserveMsg(AssetId assetId, uint128 maxReserve)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return UpdateContractMessageLib.UpdateContractSyncDepositMaxReserve({
+            assetId: assetId.raw(),
+            maxReserve: maxReserve
+        }).serialize();
     }
 }

--- a/test/integration/fork/ForkTestInvestments.sol
+++ b/test/integration/fork/ForkTestInvestments.sol
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {ForkTestBase} from "./ForkTestBase.sol";
+import {CHub, CSpoke, ForkTestBase} from "./ForkTestBase.sol";
 
 import {ERC20} from "../../../src/misc/ERC20.sol";
 import {D18} from "../../../src/misc/types/D18.sol";
+import {IERC20} from "../../../src/misc/interfaces/IERC20.sol";
 import {CastLib} from "../../../src/misc/libraries/CastLib.sol";
 
 import {Root} from "../../../src/common/Root.sol";
@@ -14,9 +15,9 @@ import {PoolId} from "../../../src/common/types/PoolId.sol";
 import {AssetId} from "../../../src/common/types/AssetId.sol";
 import {GasService} from "../../../src/common/GasService.sol";
 import {MultiAdapter} from "../../../src/common/MultiAdapter.sol";
-import {MessageLib} from "../../../src/common/libraries/MessageLib.sol";
 import {ShareClassId} from "../../../src/common/types/ShareClassId.sol";
 import {MessageProcessor} from "../../../src/common/MessageProcessor.sol";
+import {MessageLib, VaultUpdateKind} from "../../../src/common/libraries/MessageLib.sol";
 import {RequestCallbackMessageLib} from "../../../src/common/libraries/RequestCallbackMessageLib.sol";
 
 import {Hub} from "../../../src/hub/Hub.sol";
@@ -33,6 +34,7 @@ import {VaultRouter} from "../../../src/vaults/VaultRouter.sol";
 import {IBaseVault} from "../../../src/vaults/interfaces/IBaseVault.sol";
 import {IAsyncVault} from "../../../src/vaults/interfaces/IAsyncVault.sol";
 import {AsyncRequestManager} from "../../../src/vaults/AsyncRequestManager.sol";
+import {IAsyncRedeemVault} from "../../../src/vaults/interfaces/IAsyncVault.sol";
 
 import {MockSnapshotHook} from "../../hooks/mocks/MockSnapshotHook.sol";
 
@@ -48,33 +50,166 @@ import "forge-std/Test.sol";
 import {VMLabeling} from "../utils/VMLabeling.sol";
 import {IntegrationConstants} from "../utils/IntegrationConstants.sol";
 
-/// @title ForkTestAsyncInvestments
-/// @notice Fork tests for async investment flows on Ethereum mainnet
-contract ForkTestAsyncInvestments is ForkTestBase, VMLabeling {
+contract ForkTestInvestmentFlows is ForkTestBase, VMLabeling {
     using CastLib for *;
     using RequestCallbackMessageLib for *;
     using MessageLib for *;
-
-    // TODO(later): After v2 disable, switch to JAAA
-    IBaseVault constant VAULT = IBaseVault(IntegrationConstants.ETH_DEJAA_USDC_VAULT);
-
-    uint128 constant depositAmount = IntegrationConstants.DEFAULT_USDC_AMOUNT;
 
     function setUp() public virtual override {
         super.setUp();
         _setupVMLabels();
     }
 
-    function test_completeAsyncDepositLocalFlow() public virtual {
-        completeAsyncDepositLocal(VAULT, makeAddr("INVESTOR_A"), depositAmount);
+    //----------------------------------------------------------------------------------------------
+    // Async Deposit Flows
+    //----------------------------------------------------------------------------------------------
+
+    function _asyncDepositFlow(
+        CHub memory hub,
+        CSpoke memory spoke,
+        PoolId poolId,
+        ShareClassId shareClassId,
+        AssetId assetId,
+        address poolManager,
+        address investor,
+        uint128 amount,
+        address existingVault
+    ) internal {
+        _baseConfigurePrices(hub, spoke, poolId, shareClassId, assetId, poolManager);
+
+        // Deploy or get existing vault (with fallback for fork tests)
+        IAsyncVault vault =
+            _ensureAsyncVaultExists(hub, spoke, poolId, shareClassId, assetId, poolManager, existingVault);
+
+        // Execute deposit request
+        _executeAsyncDepositRequest(vault, investor, amount);
+
+        // Ensure deposit/issue epochs are aligned before proceeding (handles live chain state)
+        _ensureDepositEpochsAligned(hub, poolId, shareClassId, assetId, poolManager);
+
+        // Process deposit approval and share issuance
+        _processAsyncDepositApproval(hub, poolId, shareClassId, assetId, poolManager, amount);
+
+        // Claim shares
+        _processAsyncDepositClaim(hub, spoke, poolId, shareClassId, assetId, investor, vault);
     }
 
-    function test_completeAsyncRedeemLocalFlow() public virtual {
-        completeAsyncRedeemLocal(VAULT, makeAddr("INVESTOR_A"), depositAmount);
+    function _ensureAsyncVaultExists(
+        CHub memory hub,
+        CSpoke memory spoke,
+        PoolId poolId,
+        ShareClassId shareClassId,
+        AssetId assetId,
+        address poolManager,
+        address fallbackVault
+    ) internal returns (IAsyncVault vault) {
+        vm.startPrank(poolManager);
+
+        // Check if vault already exists (for fork tests)
+        vault = IAsyncVault(_getAsyncVault(spoke, poolId, shareClassId, assetId));
+        if (address(vault) == address(0)) {
+            // If we have a fallback vault (for fork tests), use it
+            if (fallbackVault != address(0)) {
+                vault = IAsyncVault(fallbackVault);
+                vm.stopPrank();
+                return vault;
+            }
+
+            // Otherwise try to create new vault
+            hub.hub.updateVault(
+                poolId, shareClassId, assetId, spoke.asyncVaultFactory, VaultUpdateKind.DeployAndLink, EXTRA_GAS
+            );
+            vault = IAsyncVault(_getAsyncVault(spoke, poolId, shareClassId, assetId));
+        }
+
+        vm.stopPrank();
+        assertNotEq(address(vault), address(0));
+    }
+
+    function _executeAsyncDepositRequest(IAsyncVault vault, address investor, uint128 amount) internal {
+        vm.startPrank(investor);
+        ERC20(vault.asset()).approve(address(vault), amount);
+        vault.requestDeposit(amount, investor, investor);
+    }
+
+    function _ensureDepositEpochsAligned(
+        CHub memory hub,
+        PoolId poolId,
+        ShareClassId shareClassId,
+        AssetId assetId,
+        address poolManager
+    ) internal {
+        uint32 nowDepositEpoch = hub.shareClassManager.nowDepositEpoch(shareClassId, assetId);
+        uint32 nowIssueEpoch = hub.shareClassManager.nowIssueEpoch(shareClassId, assetId);
+
+        // Handle live chain state: if deposits have been approved but not yet issued,
+        // we need to issue outstanding epochs before we can approve new ones
+        if (nowDepositEpoch != nowIssueEpoch) {
+            vm.startPrank(poolManager);
+            while (nowIssueEpoch < nowDepositEpoch) {
+                (, D18 sharePrice) = hub.shareClassManager.metrics(shareClassId);
+                hub.hub.issueShares(
+                    poolId, shareClassId, assetId, nowIssueEpoch, sharePrice, IntegrationConstants.SHARE_HOOK_GAS
+                );
+                nowIssueEpoch = hub.shareClassManager.nowIssueEpoch(shareClassId, assetId);
+            }
+            vm.stopPrank();
+        }
+    }
+
+    function _processAsyncDepositApproval(
+        CHub memory hub,
+        PoolId poolId,
+        ShareClassId shareClassId,
+        AssetId assetId,
+        address poolManager,
+        uint128 amount
+    ) internal {
+        vm.startPrank(poolManager);
+        uint32 depositEpochId = hub.shareClassManager.nowDepositEpoch(shareClassId, assetId);
+        hub.hub.approveDeposits(poolId, shareClassId, assetId, depositEpochId, amount);
+
+        uint32 issueEpochId = hub.shareClassManager.nowIssueEpoch(shareClassId, assetId);
+        (, D18 sharePrice) = hub.shareClassManager.metrics(shareClassId);
+        hub.hub.issueShares(
+            poolId, shareClassId, assetId, issueEpochId, sharePrice, IntegrationConstants.SHARE_HOOK_GAS
+        );
+    }
+
+    function _processAsyncDepositClaim(
+        CHub memory hub,
+        CSpoke memory spoke,
+        PoolId poolId,
+        ShareClassId shareClassId,
+        AssetId assetId,
+        address investor,
+        IAsyncVault vault
+    ) internal {
+        vm.startPrank(ANY);
+        vm.deal(ANY, GAS);
+        hub.hub.notifyDeposit(
+            poolId,
+            shareClassId,
+            assetId,
+            investor.toBytes32(),
+            hub.shareClassManager.maxDepositClaims(shareClassId, investor.toBytes32(), assetId)
+        );
+
+        // Store initial share balance for fork tests
+        uint256 initialShares = spoke.spoke.shareToken(poolId, shareClassId).balanceOf(investor);
+
+        vm.startPrank(investor);
+        vault.mint(vault.maxMint(investor), investor);
+
+        // For fork tests just verify shares increased
+        assertTrue(
+            spoke.spoke.shareToken(poolId, shareClassId).balanceOf(investor) > initialShares,
+            "Investor should have received shares"
+        );
     }
 
     function completeAsyncDepositLocal(IBaseVault vault, address investor, uint128 amount) public {
-        if (isShareToken(vault.asset())) {
+        if (_isShareToken(vault.asset())) {
             vm.startPrank(IntegrationConstants.V2_ROOT);
             ERC20(vault.asset()).mint(investor, amount);
             vm.stopPrank();
@@ -93,9 +228,128 @@ contract ForkTestAsyncInvestments is ForkTestBase, VMLabeling {
             _poolAdmin(),
             investor,
             amount,
-            true,
-            true,
             address(vault)
+        );
+    }
+
+    //----------------------------------------------------------------------------------------------
+    // Async Redeem Flows
+    //----------------------------------------------------------------------------------------------
+
+    function _asyncRedeemFlow(
+        CHub memory hub,
+        CSpoke memory spoke,
+        PoolId poolId,
+        ShareClassId shareClassId,
+        AssetId assetId,
+        address poolManager,
+        address investor,
+        address existingVault
+    ) internal {
+        _configureAsyncRedeemRestriction(hub, spoke, poolId, shareClassId, investor, poolManager);
+
+        // Resolve vault - use existing if provided, otherwise get from manager
+        IAsyncRedeemVault vault = existingVault != address(0)
+            ? IAsyncRedeemVault(existingVault)
+            : IAsyncRedeemVault(_getAsyncVault(spoke, poolId, shareClassId, assetId));
+
+        vm.startPrank(investor);
+        uint128 shares = uint128(spoke.spoke.shareToken(poolId, shareClassId).balanceOf(investor));
+
+        vault.requestRedeem(shares, investor, investor);
+
+        // Ensure epochs are aligned before proceeding (handles live chain state)
+        _ensureRedeemEpochsAligned(hub, poolId, shareClassId, assetId, poolManager);
+
+        _processAsyncRedeemApproval(hub, poolId, shareClassId, assetId, shares, poolManager);
+        _processAsyncRedeemClaim(hub, poolId, shareClassId, assetId, investor, vault);
+    }
+
+    function _ensureRedeemEpochsAligned(
+        CHub memory hub,
+        PoolId poolId,
+        ShareClassId shareClassId,
+        AssetId assetId,
+        address poolManager
+    ) internal {
+        uint32 nowRedeemEpoch = hub.shareClassManager.nowRedeemEpoch(shareClassId, assetId);
+        uint32 nowRevokeEpoch = hub.shareClassManager.nowRevokeEpoch(shareClassId, assetId);
+
+        // Handle live chain state: if redemptions have been approved but not revoked,
+        // we need to revoke outstanding epochs before we can approve new ones
+        if (nowRedeemEpoch != nowRevokeEpoch) {
+            vm.startPrank(poolManager);
+            while (nowRevokeEpoch < nowRedeemEpoch) {
+                (, D18 sharePrice) = hub.shareClassManager.metrics(shareClassId);
+                hub.hub.revokeShares(
+                    poolId, shareClassId, assetId, nowRevokeEpoch, sharePrice, IntegrationConstants.SHARE_HOOK_GAS
+                );
+                nowRevokeEpoch = hub.shareClassManager.nowRevokeEpoch(shareClassId, assetId);
+            }
+            vm.stopPrank();
+        }
+    }
+
+    function _configureAsyncRedeemRestriction(
+        CHub memory hub,
+        CSpoke memory spoke,
+        PoolId poolId,
+        ShareClassId shareClassId,
+        address investor,
+        address poolManager
+    ) internal {
+        vm.startPrank(poolManager);
+        hub.hub.updateRestriction(
+            poolId, shareClassId, spoke.centrifugeId, _updateRestrictionMemberMsg(investor), EXTRA_GAS
+        );
+    }
+
+    function _processAsyncRedeemApproval(
+        CHub memory hub,
+        PoolId poolId,
+        ShareClassId shareClassId,
+        AssetId assetId,
+        uint128 shares,
+        address poolManager
+    ) internal {
+        vm.startPrank(poolManager);
+        uint32 redeemEpochId = hub.shareClassManager.nowRedeemEpoch(shareClassId, assetId);
+        hub.hub.approveRedeems(poolId, shareClassId, assetId, redeemEpochId, shares);
+
+        uint32 revokeEpochId = hub.shareClassManager.nowRevokeEpoch(shareClassId, assetId);
+        (, D18 sharePrice) = hub.shareClassManager.metrics(shareClassId);
+        hub.hub.revokeShares(
+            poolId, shareClassId, assetId, revokeEpochId, sharePrice, IntegrationConstants.SHARE_HOOK_GAS
+        );
+    }
+
+    function _processAsyncRedeemClaim(
+        CHub memory hub,
+        PoolId poolId,
+        ShareClassId shareClassId,
+        AssetId assetId,
+        address investor,
+        IAsyncRedeemVault vault
+    ) internal {
+        vm.startPrank(ANY);
+        vm.deal(ANY, GAS);
+        hub.hub.notifyRedeem(
+            poolId,
+            shareClassId,
+            assetId,
+            investor.toBytes32(),
+            hub.shareClassManager.maxRedeemClaims(shareClassId, investor.toBytes32(), assetId)
+        );
+
+        // Store initial asset balance for fork tests
+        uint256 initialAssets = IERC20(vault.asset()).balanceOf(investor);
+
+        vm.startPrank(investor);
+        vault.withdraw(vault.maxWithdraw(investor), investor, investor);
+
+        assertTrue(
+            IERC20(vault.asset()).balanceOf(investor) > initialAssets,
+            "Investor should have received assets from redemption"
         );
     }
 
@@ -110,10 +364,99 @@ contract ForkTestAsyncInvestments is ForkTestBase, VMLabeling {
             forkSpoke.spoke.assetToId(vault.asset(), 0),
             _poolAdmin(),
             investor,
-            true,
-            true,
             address(vault)
         );
+    }
+
+    //----------------------------------------------------------------------------------------------
+    // Sync Deposit Flows
+    //----------------------------------------------------------------------------------------------
+
+    function _syncDepositFlow(
+        CHub memory hub,
+        CSpoke memory spoke,
+        PoolId poolId,
+        ShareClassId shareClassId,
+        AssetId assetId,
+        address poolManager,
+        address investor,
+        uint128 amount
+    ) internal {
+        _baseConfigurePrices(hub, spoke, poolId, shareClassId, assetId, poolManager);
+        _configureSyncDepositVault(hub, spoke, poolId, shareClassId, assetId, poolManager);
+        _processSyncDeposit(hub, spoke, poolId, shareClassId, assetId, investor, amount);
+    }
+
+    function _configureSyncDepositVault(
+        CHub memory hub,
+        CSpoke memory spoke,
+        PoolId poolId,
+        ShareClassId shareClassId,
+        AssetId assetId,
+        address poolManager
+    ) internal {
+        vm.startPrank(poolManager);
+        // Check if vault already exists (for fork tests)
+        address existingVault = _getAsyncVault(spoke, poolId, shareClassId, assetId);
+        if (existingVault == address(0)) {
+            hub.hub.updateVault(
+                poolId, shareClassId, assetId, spoke.syncDepositVaultFactory, VaultUpdateKind.DeployAndLink, EXTRA_GAS
+            );
+        }
+        hub.hub.updateContract(
+            poolId,
+            shareClassId,
+            spoke.centrifugeId,
+            address(spoke.syncManager).toBytes32(),
+            _updateContractSyncDepositMaxReserveMsg(assetId, type(uint128).max),
+            EXTRA_GAS
+        );
+    }
+
+    function _processSyncDeposit(
+        CHub memory,
+        CSpoke memory spoke,
+        PoolId poolId,
+        ShareClassId shareClassId,
+        AssetId assetId,
+        address investor,
+        uint128 amount
+    ) internal {
+        IBaseVault vault = IBaseVault(_getAsyncVault(spoke, poolId, shareClassId, assetId));
+
+        // Store initial share balance for fork tests
+        uint256 initialShares = spoke.spoke.shareToken(poolId, shareClassId).balanceOf(investor);
+
+        vm.startPrank(investor);
+        spoke.usdc.approve(address(vault), amount);
+        vault.deposit(amount, investor);
+
+        // For fork tests: just verify shares increased
+        assertTrue(
+            spoke.spoke.shareToken(poolId, shareClassId).balanceOf(investor) > initialShares,
+            "Investor should have received shares"
+        );
+    }
+}
+
+/// @title ForkTestAsyncInvestments
+/// @notice Fork tests for async investment flows on Ethereum mainnet
+contract ForkTestAsyncInvestments is ForkTestInvestmentFlows {
+    using CastLib for *;
+    using RequestCallbackMessageLib for *;
+    using MessageLib for *;
+
+    // TODO(later): After v2 disable, switch to JAAA
+    IBaseVault constant VAULT = IBaseVault(IntegrationConstants.ETH_DEJAA_USDC_VAULT);
+
+    uint128 constant depositAmount = IntegrationConstants.DEFAULT_USDC_AMOUNT;
+
+    function test_completeAsyncDepositLocalFlow() public virtual {
+        completeAsyncDepositLocal(VAULT, makeAddr("INVESTOR_A"), depositAmount);
+    }
+
+    function test_completeAsyncRedeemLocalFlow() public virtual {
+        completeAsyncRedeemLocal(VAULT, makeAddr("INVESTOR_A"), depositAmount);
     }
 
     //----------------------------------------------------------------------------------------------
@@ -346,7 +689,7 @@ contract ForkTestAsyncInvestments is ForkTestBase, VMLabeling {
 
 /// @title ForkTestSyncInvestments
 /// @notice Fork tests for sync investment flows on Plume network
-contract ForkTestSyncInvestments is ForkTestBase, VMLabeling {
+contract ForkTestSyncInvestments is ForkTestInvestmentFlows {
     using CastLib for *;
 
     IBaseVault constant VAULT = IBaseVault(IntegrationConstants.PLUME_SYNC_DEPOSIT_VAULT);
@@ -358,14 +701,7 @@ contract ForkTestSyncInvestments is ForkTestBase, VMLabeling {
         _setupVMLabels();
 
         _baseConfigurePrices(
-            forkHub,
-            forkSpoke,
-            VAULT.poolId(),
-            VAULT.scId(),
-            forkSpoke.spoke.assetToId(VAULT.asset(), 0),
-            _poolAdmin(),
-            IntegrationConstants.identityPrice(),
-            IntegrationConstants.identityPrice()
+            forkHub, forkSpoke, VAULT.poolId(), VAULT.scId(), forkSpoke.spoke.assetToId(VAULT.asset(), 0), _poolAdmin()
         );
     }
 
@@ -415,10 +751,6 @@ contract ForkTestSyncInvestments is ForkTestBase, VMLabeling {
             usdcId: Spoke(IntegrationConstants.SPOKE).assetToId(IntegrationConstants.PLUME_PUSD, 0)
         });
 
-        // Initialize pricing state
-        currentAssetPrice = IntegrationConstants.identityPrice();
-        currentSharePrice = IntegrationConstants.identityPrice();
-
         // Fund pool admin
         vm.deal(_poolAdmin(), 10 ether);
     }
@@ -445,9 +777,7 @@ contract ForkTestSyncInvestments is ForkTestBase, VMLabeling {
             forkSpoke.spoke.assetToId(VAULT.asset(), 0),
             _poolAdmin(),
             investor,
-            amount,
-            true,
-            true
+            amount
         );
     }
 
@@ -462,8 +792,6 @@ contract ForkTestSyncInvestments is ForkTestBase, VMLabeling {
             forkSpoke.spoke.assetToId(VAULT.asset(), 0),
             _poolAdmin(),
             investor,
-            true,
-            true,
             address(VAULT)
         );
     }


### PR DESCRIPTION
Except several simplifications that can be done in EndToEnd, this PR decouples fork tests so that they do not depend on EndToEnd, which may be useful to recover fork tests after 3.1 if we go in that direction.