### PR TITLE
Sending messages while processing messages to unpaid

### DIFF
--- a/snapshots/AsyncVault.json
+++ b/snapshots/AsyncVault.json
@@ -1,4 +1,4 @@
 {
-  "fulfillDepositRequest": "794164",
-  "requestDeposit": "668413"
+  "fulfillDepositRequest": "806957",
+  "requestDeposit": "668517"
 }

--- a/snapshots/VaultRouter.json
+++ b/snapshots/VaultRouter.json
@@ -1,7 +1,7 @@
 {
-  "claimDeposit": "959639",
+  "claimDeposit": "972432",
   "enable": "60955",
   "lockDepositRequest": "95562",
-  "requestDeposit": "677818",
-  "requestRedeem": "2067014"
+  "requestDeposit": "677922",
+  "requestRedeem": "2080015"
 }

--- a/src/common/Gateway.sol
+++ b/src/common/Gateway.sol
@@ -46,6 +46,7 @@ contract Gateway is Auth, Recoverable, IGateway {
 
     // Outbound & payments
     bool public transient isBatching;
+    bool public transient unpaidMode;
     mapping(PoolId => Funds) public subsidy;
     mapping(uint16 centrifugeId => mapping(PoolId => bool)) public isOutgoingBlocked;
     mapping(uint16 centrifugeId => mapping(bytes32 batchHash => Underpaid)) public underpaid;
@@ -168,6 +169,9 @@ contract Gateway is Auth, Recoverable, IGateway {
 
             TransientBytesLib.append(batchSlot, message);
             return 0;
+        } else if (unpaidMode) {
+            _addUnpaidBatch(centrifugeId, message, gasLimit);
+            return 0;
         } else {
             return _send(centrifugeId, message, gasLimit);
         }
@@ -195,10 +199,8 @@ contract Gateway is Auth, Recoverable, IGateway {
     }
 
     /// @inheritdoc IGateway
-    function addUnpaidMessage(uint16 centrifugeId, bytes memory message, uint128 extraGasLimit) external auth {
-        uint128 gasLimit = gasService.messageGasLimit(centrifugeId, message) + extraGasLimit;
-        emit PrepareMessage(centrifugeId, processor.messagePoolId(message), message);
-        _addUnpaidBatch(centrifugeId, message, gasLimit);
+    function setUnpaidMode(bool enabled) external auth {
+        unpaidMode = enabled;
     }
 
     function _addUnpaidBatch(uint16 centrifugeId, bytes memory message, uint128 gasLimit) internal {
@@ -291,8 +293,13 @@ contract Gateway is Auth, Recoverable, IGateway {
             (uint16 centrifugeId, PoolId poolId) = _parseLocator(locators[i]);
             bytes32 outboundBatchSlot = _outboundBatchSlot(centrifugeId, poolId);
             uint128 gasLimit = _gasLimitSlot(centrifugeId, poolId).tloadUint128();
+            bytes memory batch = TransientBytesLib.get(outboundBatchSlot);
 
-            cost += _send(centrifugeId, TransientBytesLib.get(outboundBatchSlot), gasLimit);
+            if (unpaidMode) {
+                _addUnpaidBatch(centrifugeId, batch, gasLimit);
+            } else {
+                cost += _send(centrifugeId, batch, gasLimit);
+            }
 
             TransientBytesLib.clear(outboundBatchSlot);
             _gasLimitSlot(centrifugeId, poolId).tstore(uint256(0));

--- a/src/common/MessageDispatcher.sol
+++ b/src/common/MessageDispatcher.sol
@@ -417,7 +417,6 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
 
     /// @inheritdoc IHubMessageSender
     function sendExecuteTransferShares(
-        uint16 originCentrifugeId,
         uint16 targetCentrifugeId,
         PoolId poolId,
         ShareClassId scId,
@@ -436,13 +435,8 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
                 amount: amount
             }).serialize();
 
-            if (originCentrifugeId == localCentrifugeId) {
-                // Spoke chain X => Hub chain X => Spoke chain Y: payment done directly on X
-                return gateway.send(targetCentrifugeId, message, extraGasLimit);
-            } else {
-                // Spoke chain X => Hub chain Y => Spoke chain Z
-                gateway.addUnpaidMessage(targetCentrifugeId, message, extraGasLimit);
-            }
+            // Spoke chain X => Hub chain Y => Spoke chain Z
+            return gateway.send(targetCentrifugeId, message, extraGasLimit);
         }
     }
 

--- a/src/common/MessageDispatcher.sol
+++ b/src/common/MessageDispatcher.sol
@@ -428,15 +428,16 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
             // Spoke chain X => Hub chain Y => Spoke chain Y
             spoke.executeTransferShares(poolId, scId, receiver, amount);
         } else {
-            bytes memory message = MessageLib.ExecuteTransferShares({
-                poolId: poolId.raw(),
-                scId: scId.raw(),
-                receiver: receiver,
-                amount: amount
-            }).serialize();
-
-            // Spoke chain X => Hub chain Y => Spoke chain Z
-            return gateway.send(targetCentrifugeId, message, extraGasLimit);
+            return gateway.send(
+                targetCentrifugeId,
+                MessageLib.ExecuteTransferShares({
+                    poolId: poolId.raw(),
+                    scId: scId.raw(),
+                    receiver: receiver,
+                    amount: amount
+                }).serialize(),
+                extraGasLimit
+            );
         }
     }
 

--- a/src/common/MessageProcessor.sol
+++ b/src/common/MessageProcessor.sol
@@ -73,6 +73,7 @@ contract MessageProcessor is Auth, IMessageProcessor {
     /// @inheritdoc IMessageHandler
     function handle(uint16 centrifugeId, bytes calldata message) external auth {
         MessageType kind = message.messageType();
+        gateway.setUnpaidMode(true);
 
         uint16 sourceCentrifugeId = message.messageSourceCentrifugeId();
         require(sourceCentrifugeId == 0 || sourceCentrifugeId == centrifugeId, InvalidSourceChain());
@@ -213,6 +214,8 @@ contract MessageProcessor is Auth, IMessageProcessor {
         } else {
             revert InvalidMessage(uint8(kind));
         }
+
+        gateway.setUnpaidMode(false);
     }
 
     /// @inheritdoc IMessageProperties

--- a/src/common/interfaces/IGateway.sol
+++ b/src/common/interfaces/IGateway.sol
@@ -94,6 +94,9 @@ interface IGateway is IMessageHandler, IRecoverable {
     /// @param  canSend If can send messages or not
     function blockOutgoing(uint16 centrifugeId, PoolId poolId, bool canSend) external;
 
+    /// @notice Sets the gateway in unpaid mode where any call to send will store the message as unpaid.
+    function setUnpaidMode(bool enabled) external;
+
     /// @notice Repay an underpaid batch.
     function repay(uint16 centrifugeId, bytes memory batch) external payable;
 
@@ -112,11 +115,6 @@ interface IGateway is IMessageHandler, IRecoverable {
     /// @notice Handling outgoing messages.
     /// @param centrifugeId Destination chain
     function send(uint16 centrifugeId, bytes calldata message, uint128 extraGasLimit) external returns (uint256 cost);
-
-    /// @notice Add a message to the underpaid storage to be repay and send later.
-    /// @dev It only supports one message, not a batch
-    /// @param extraGasLimit Adds an extra cost for the message
-    function addUnpaidMessage(uint16 centrifugeId, bytes memory message, uint128 extraGasLimit) external;
 
     /// @notice Initialize batching message
     function startBatching() external;

--- a/src/common/interfaces/IGatewaySenders.sol
+++ b/src/common/interfaces/IGatewaySenders.sol
@@ -115,7 +115,6 @@ interface IHubMessageSender is ILocalCentrifugeId {
 
     /// @notice Creates and send the message
     function sendExecuteTransferShares(
-        uint16 originCentrifugeId,
         uint16 targetCentrifugeId,
         PoolId poolId,
         ShareClassId scId,

--- a/src/hub/HubHandler.sol
+++ b/src/hub/HubHandler.sol
@@ -125,8 +125,6 @@ contract HubHandler is Auth, IHubHandler, IHubGatewayHandler {
 
         emit ForwardTransferShares(originCentrifugeId, targetCentrifugeId, poolId, scId, receiver, amount);
 
-        return sender.sendExecuteTransferShares(
-            originCentrifugeId, targetCentrifugeId, poolId, scId, receiver, amount, extraGasLimit
-        );
+        return sender.sendExecuteTransferShares(targetCentrifugeId, poolId, scId, receiver, amount, extraGasLimit);
     }
 }

--- a/src/valuations/IdentityValuation.sol
+++ b/src/valuations/IdentityValuation.sol
@@ -21,7 +21,7 @@ contract IdentityValuation is IIdentityValuation {
     }
 
     /// @inheritdoc IValuation
-    function getPrice(PoolId poolId, ShareClassId scId, AssetId assetId) external pure returns (D18) {
+    function getPrice(PoolId, ShareClassId, AssetId) external pure returns (D18) {
         return d18(1e18);
     }
 

--- a/test/hub/Deployment.t.sol
+++ b/test/hub/Deployment.t.sol
@@ -142,6 +142,7 @@ contract HubDeploymentCommonExtTest is HubDeploymentTest {
         vm.assume(nonWard != address(messageDispatcher)); // From common
         vm.assume(nonWard != address(messageProcessor)); // From common
         vm.assume(nonWard != address(multiAdapter)); // From common
+        vm.assume(nonWard != address(crosschainBatcher)); // From common
         vm.assume(nonWard != address(hub));
 
         assertEq(gateway.wards(address(hub)), 1);

--- a/test/integration/EndToEnd.t.sol
+++ b/test/integration/EndToEnd.t.sol
@@ -12,7 +12,7 @@ import {MathLib} from "../../src/misc/libraries/MathLib.sol";
 import {ETH_ADDRESS} from "../../src/misc/interfaces/IRecoverable.sol";
 
 import {Root} from "../../src/common/Root.sol";
-import {Gateway} from "../../src/common/Gateway.sol";
+import {IGateway, Gateway} from "../../src/common/Gateway.sol";
 import {Guardian} from "../../src/common/Guardian.sol";
 import {PoolId} from "../../src/common/types/PoolId.sol";
 import {GasService} from "../../src/common/GasService.sol";
@@ -233,6 +233,8 @@ contract EndToEndDeployment is Test {
 
         vm.label(address(adapterAToB), "AdapterAToB");
         vm.label(address(adapterBToA), "AdapterBToA");
+
+        vm.recordLogs();
     }
 
     function _setAdapter(FullDeployer deploy, uint16 remoteCentrifugeId, IAdapter adapter) internal {
@@ -367,6 +369,18 @@ contract EndToEndUtils is EndToEndDeployment {
             vaultAddr = address(spoke.spoke.vault(poolId, shareClassId, assetId, spoke.asyncRequestManager));
         }
         assertNotEq(vaultAddr, address(0));
+    }
+
+    function _getLastUnpaidMessage() internal returns (bytes memory message) {
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        for (uint256 i = logs.length - 1; i >= 0; i--) {
+            if (logs[i].topics[0] == bytes32(IGateway.UnderpaidBatch.selector)) {
+                return abi.decode(logs[i].data, (bytes));
+            }
+        }
+
+        vm.recordLogs();
     }
 }
 
@@ -874,6 +888,9 @@ contract EndToEndFlows is EndToEndUtils {
         uint128 shares = uint128(s.spoke.shareToken(POOL_A, SC_1).balanceOf(INVESTOR_A));
         vault.requestRedeem(shares, INVESTOR_A, INVESTOR_A);
         vault.cancelRedeemRequest(PLACEHOLDER_REQUEST_ID, INVESTOR_A);
+
+        if (!sameChain) h.gateway.repay{value: GAS}(s.centrifugeId, _getLastUnpaidMessage());
+
         vault.claimCancelRedeemRequest(PLACEHOLDER_REQUEST_ID, INVESTOR_A, INVESTOR_A);
 
         // CHECKS
@@ -1112,6 +1129,9 @@ contract EndToEndUseCases is EndToEndFlows, VMLabeling {
         s.usdc.approve(address(vault), USDC_AMOUNT_1);
         vault.requestDeposit(USDC_AMOUNT_1, INVESTOR_A, INVESTOR_A);
         vault.cancelDepositRequest(PLACEHOLDER_REQUEST_ID, INVESTOR_A);
+
+        if (!sameChain) h.gateway.repay{value: GAS}(s.centrifugeId, _getLastUnpaidMessage());
+
         vault.claimCancelDepositRequest(PLACEHOLDER_REQUEST_ID, INVESTOR_A, INVESTOR_A);
 
         // CHECKS

--- a/test/integration/EndToEnd.t.sol
+++ b/test/integration/EndToEnd.t.sol
@@ -12,11 +12,11 @@ import {MathLib} from "../../src/misc/libraries/MathLib.sol";
 import {ETH_ADDRESS} from "../../src/misc/interfaces/IRecoverable.sol";
 
 import {Root} from "../../src/common/Root.sol";
-import {IGateway, Gateway} from "../../src/common/Gateway.sol";
 import {Guardian} from "../../src/common/Guardian.sol";
 import {PoolId} from "../../src/common/types/PoolId.sol";
 import {GasService} from "../../src/common/GasService.sol";
 import {AccountId} from "../../src/common/types/AccountId.sol";
+import {IGateway, Gateway} from "../../src/common/Gateway.sol";
 import {ISafe} from "../../src/common/interfaces/IGuardian.sol";
 import {IAdapter} from "../../src/common/interfaces/IAdapter.sol";
 import {PricingLib} from "../../src/common/libraries/PricingLib.sol";

--- a/test/integration/ThreeChainEndToEnd.t.sol
+++ b/test/integration/ThreeChainEndToEnd.t.sol
@@ -144,6 +144,9 @@ contract ThreeChainEndToEndDeployment is EndToEndFlows {
         // If hub is not source, then message will be pending as unpaid on hub until repaid
         if (direction == CrossChainDirection.WithIntermediaryHub) {
             assertEq(shareTokenC.balanceOf(INVESTOR_A), 0, "Share transfer not executed due to unpaid message");
+
+            vm.expectEmit();
+            emit ISpoke.ExecuteTransferShares(POOL_A, SC_1, INVESTOR_A, amount);
             h.gateway.repay{value: GAS}(sC.centrifugeId, _getLastUnpaidMessage());
         }
 

--- a/test/integration/ThreeChainEndToEnd.t.sol
+++ b/test/integration/ThreeChainEndToEnd.t.sol
@@ -8,12 +8,9 @@ import {IntegrationConstants} from "./utils/IntegrationConstants.sol";
 import {d18} from "../../src/misc/types/D18.sol";
 import {CastLib} from "../../src/misc/libraries/CastLib.sol";
 
-import {PoolId} from "../../src/common/types/PoolId.sol";
 import {ISafe} from "../../src/common/interfaces/IGuardian.sol";
 import {IGateway} from "../../src/common/interfaces/IGateway.sol";
 import {MessageLib} from "../../src/common/libraries/MessageLib.sol";
-import {ShareClassId} from "../../src/common/types/ShareClassId.sol";
-import {IMultiAdapter} from "../../src/common/interfaces/IMultiAdapter.sol";
 
 import {IHub} from "../../src/hub/interfaces/IHub.sol";
 

--- a/test/spoke/Deployment.t.sol
+++ b/test/spoke/Deployment.t.sol
@@ -117,6 +117,7 @@ contract SpokeDeploymentCommonExtTest is SpokeDeploymentTest {
         vm.assume(nonWard != address(messageDispatcher)); // From common
         vm.assume(nonWard != address(messageProcessor)); // From common
         vm.assume(nonWard != address(multiAdapter)); // From common
+        vm.assume(nonWard != address(crosschainBatcher)); // From common
         vm.assume(nonWard != address(spoke));
         vm.assume(nonWard != address(balanceSheet));
 

--- a/test/vaults/Deployment.t.sol
+++ b/test/vaults/Deployment.t.sol
@@ -131,6 +131,7 @@ contract VaultsDeploymentSpokeExtTest is VaultsDeploymentTest {
         vm.assume(nonWard != address(messageDispatcher)); // From common
         vm.assume(nonWard != address(messageProcessor)); // From common
         vm.assume(nonWard != address(multiAdapter)); // From common
+        vm.assume(nonWard != address(crosschainBatcher)); // From common
         vm.assume(nonWard != address(spoke)); // From spoke
         vm.assume(nonWard != address(balanceSheet)); // From spoke
         vm.assume(nonWard != address(vaultRouter));


### PR DESCRIPTION
Thread: https://kflabs.slack.com/archives/C07PG2EUR9C/p1758793226119319

TLDR: The gateway enters a mode where each call to `send` becomes unpaid while processing a message. That way we get out of the box the `addUnpaidMessage` behavior for sending any message.