### PR TITLE
ci: fix forge fmt

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -27,7 +27,7 @@ ignored_warnings_from = [
   "src/misc/ReentrancyProtection.sol", # Issue: https://github.com/ethereum/solidity/issues/14359
 ]
 
-[lint]
+[profile.default.lint]
 severity = ["high"]
 exclude_lints = ["erc20-unchecked-transfer", "incorrect-shift"]
 
@@ -100,7 +100,7 @@ int_types = "long"
 multiline_func_header = "attributes_first"
 quote_style = "double"
 number_underscore = "preserve"
-wrap_comments = true
+wrap_comments = false
 ignore = [
   "test/*.sol"
 ]

--- a/script/AdaptersDeployer.s.sol
+++ b/script/AdaptersDeployer.s.sol
@@ -70,9 +70,11 @@ contract AdaptersDeployer is CommonDeployer {
     AxelarAdapter axelarAdapter;
     LayerZeroAdapter layerZeroAdapter;
 
-    function deployAdapters(CommonInput memory input, AdaptersInput memory adaptersInput, AdaptersActionBatcher batcher)
-        public
-    {
+    function deployAdapters(
+        CommonInput memory input,
+        AdaptersInput memory adaptersInput,
+        AdaptersActionBatcher batcher
+    ) public {
         _preDeployAdapters(input, adaptersInput, batcher);
         _postDeployAdapters(batcher);
     }

--- a/script/CommonDeployer.s.sol
+++ b/script/CommonDeployer.s.sol
@@ -137,11 +137,9 @@ abstract contract CommonDeployer is Script, JsonRegistry, CreateXScript {
             // Special handling for v3.0.1 contracts that were deployed with version "3" instead of keccak256("3")
             if (
                 version == keccak256(abi.encodePacked("3"))
-                    && (
-                        contractNameHash == keccak256(bytes("asyncRequestManager-2"))
-                            || contractNameHash == keccak256(bytes("syncDepositVaultFactory-2"))
-                            || contractNameHash == keccak256(bytes("asyncVaultFactory-2"))
-                    )
+                    && (contractNameHash == keccak256(bytes("asyncRequestManager-2"))
+                        || contractNameHash == keccak256(bytes("syncDepositVaultFactory-2"))
+                        || contractNameHash == keccak256(bytes("asyncVaultFactory-2")))
             ) {
                 baseHash = keccak256(abi.encodePacked(contractName, bytes32(bytes("3"))));
             } else {
@@ -195,14 +193,12 @@ abstract contract CommonDeployer is Script, JsonRegistry, CreateXScript {
         );
 
         gateway = Gateway(
-            payable(
-                create3(
+            payable(create3(
                     generateSalt("gateway"),
                     abi.encodePacked(
                         type(Gateway).creationCode, abi.encode(input.centrifugeId, root, gasService, batcher)
                     )
-                )
-            )
+                ))
         );
 
         multiAdapter = MultiAdapter(

--- a/script/TestData.s.sol
+++ b/script/TestData.s.sol
@@ -197,9 +197,8 @@ contract TestData is FullDeployer {
             state.scId,
             centrifugeId,
             UpdateRestrictionMessageLib.UpdateRestrictionMember({
-                user: bytes32(bytes20(msg.sender)),
-                validUntil: type(uint64).max
-            }).serialize(),
+                    user: bytes32(bytes20(msg.sender)), validUntil: type(uint64).max
+                }).serialize(),
             0
         );
 
@@ -320,9 +319,8 @@ contract TestData is FullDeployer {
             centrifugeId,
             address(syncManager).toBytes32(),
             UpdateContractMessageLib.UpdateContractSyncDepositMaxReserve({
-                assetId: assetId.raw(),
-                maxReserve: type(uint128).max
-            }).serialize(),
+                    assetId: assetId.raw(), maxReserve: type(uint128).max
+                }).serialize(),
             0
         );
 

--- a/script/WireAdapters.s.sol
+++ b/script/WireAdapters.s.sol
@@ -72,22 +72,24 @@ contract WireAdapters is Script {
 
             // Wire WormholeAdapter
             if (localWormholeAddr != address(0)) {
-                IWormholeAdapter(localWormholeAddr).wire(
-                    remoteCentrifugeId,
-                    uint16(vm.parseJsonUint(remoteConfig, "$.adapters.wormhole.wormholeId")),
-                    vm.parseJsonAddress(remoteConfig, "$.contracts.wormholeAdapter")
-                );
+                IWormholeAdapter(localWormholeAddr)
+                    .wire(
+                        remoteCentrifugeId,
+                        uint16(vm.parseJsonUint(remoteConfig, "$.adapters.wormhole.wormholeId")),
+                        vm.parseJsonAddress(remoteConfig, "$.contracts.wormholeAdapter")
+                    );
 
                 console.log("Wired WormholeAdapter from", localNetwork, "to", remoteNetwork);
             }
 
             // Wire AxelarAdapter
             if (localAxelarAddr != address(0)) {
-                IAxelarAdapter(localAxelarAddr).wire(
-                    remoteCentrifugeId,
-                    vm.parseJsonString(remoteConfig, "$.adapters.axelar.axelarId"),
-                    vm.toString(vm.parseJsonAddress(remoteConfig, "$.contracts.axelarAdapter"))
-                );
+                IAxelarAdapter(localAxelarAddr)
+                    .wire(
+                        remoteCentrifugeId,
+                        vm.parseJsonString(remoteConfig, "$.adapters.axelar.axelarId"),
+                        vm.toString(vm.parseJsonAddress(remoteConfig, "$.contracts.axelarAdapter"))
+                    );
 
                 console.log("Wired AxelarAdapter from", localNetwork, "to", remoteNetwork);
             }

--- a/script/utils/ICreateX.sol
+++ b/script/utils/ICreateX.sol
@@ -77,10 +77,12 @@ interface ICreateX {
         payable
         returns (address newContract);
 
-    function deployCreate2AndInit(bytes memory initCode, bytes memory data, Values memory values, address refundAddress)
-        external
-        payable
-        returns (address newContract);
+    function deployCreate2AndInit(
+        bytes memory initCode,
+        bytes memory data,
+        Values memory values,
+        address refundAddress
+    ) external payable returns (address newContract);
 
     function deployCreate2AndInit(bytes memory initCode, bytes memory data, Values memory values)
         external
@@ -99,10 +101,7 @@ interface ICreateX {
         pure
         returns (address computedAddress);
 
-    function computeCreate2Address(bytes32 salt, bytes32 initCodeHash)
-        external
-        view
-        returns (address computedAddress);
+    function computeCreate2Address(bytes32 salt, bytes32 initCodeHash) external view returns (address computedAddress);
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                           CREATE3                          */
@@ -125,10 +124,12 @@ interface ICreateX {
         payable
         returns (address newContract);
 
-    function deployCreate3AndInit(bytes memory initCode, bytes memory data, Values memory values, address refundAddress)
-        external
-        payable
-        returns (address newContract);
+    function deployCreate3AndInit(
+        bytes memory initCode,
+        bytes memory data,
+        Values memory values,
+        address refundAddress
+    ) external payable returns (address newContract);
 
     function deployCreate3AndInit(bytes memory initCode, bytes memory data, Values memory values)
         external

--- a/src/adapters/AxelarAdapter.sol
+++ b/src/adapters/AxelarAdapter.sol
@@ -76,7 +76,13 @@ contract AxelarAdapter is Auth, IAxelarAdapter {
     //----------------------------------------------------------------------------------------------
 
     /// @inheritdoc IAdapter
-    function send(uint16 centrifugeId, bytes calldata payload, uint256, /* gasLimit */ address refund)
+    function send(
+        uint16 centrifugeId,
+        bytes calldata payload,
+        uint256,
+        /* gasLimit */
+        address refund
+    )
         external
         payable
         returns (bytes32 adapterData)
@@ -85,9 +91,9 @@ contract AxelarAdapter is Auth, IAxelarAdapter {
         AxelarDestination memory destination = destinations[centrifugeId];
         require(bytes(destination.axelarId).length != 0, UnknownChainId());
 
-        axelarGasService.payNativeGasForContractCall{value: msg.value}(
-            address(this), destination.axelarId, destination.addr, payload, refund
-        );
+        axelarGasService.payNativeGasForContractCall{
+            value: msg.value
+        }(address(this), destination.axelarId, destination.addr, payload, refund);
 
         axelarGateway.callContract(destination.axelarId, destination.addr, payload);
 

--- a/src/adapters/WormholeAdapter.sol
+++ b/src/adapters/WormholeAdapter.sol
@@ -80,9 +80,9 @@ contract WormholeAdapter is Auth, IWormholeAdapter {
         WormholeDestination memory destination = destinations[centrifugeId];
         require(destination.wormholeId != 0, UnknownChainId());
 
-        uint64 sequence = relayer.sendPayloadToEvm{value: msg.value}(
-            destination.wormholeId, destination.addr, payload, 0, gasLimit, localWormholeId, refund
-        );
+        uint64 sequence = relayer.sendPayloadToEvm{
+            value: msg.value
+        }(destination.wormholeId, destination.addr, payload, 0, gasLimit, localWormholeId, refund);
 
         adapterData = bytes32(bytes8(sequence));
     }

--- a/src/common/MessageDispatcher.sol
+++ b/src/common/MessageDispatcher.sol
@@ -105,14 +105,14 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
             return gateway.send(
                 centrifugeId,
                 MessageLib.NotifyShareClass({
-                    poolId: poolId.raw(),
-                    scId: scId.raw(),
-                    name: name,
-                    symbol: symbol.toBytes32(),
-                    decimals: decimals,
-                    salt: salt,
-                    hook: hook
-                }).serialize(),
+                        poolId: poolId.raw(),
+                        scId: scId.raw(),
+                        name: name,
+                        symbol: symbol.toBytes32(),
+                        decimals: decimals,
+                        salt: salt,
+                        hook: hook
+                    }).serialize(),
                 0
             );
         }
@@ -132,11 +132,8 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
             return gateway.send(
                 centrifugeId,
                 MessageLib.NotifyShareMetadata({
-                    poolId: poolId.raw(),
-                    scId: scId.raw(),
-                    name: name,
-                    symbol: symbol.toBytes32()
-                }).serialize(),
+                        poolId: poolId.raw(), scId: scId.raw(), name: name, symbol: symbol.toBytes32()
+                    }).serialize(),
                 0
             );
         }
@@ -172,11 +169,8 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
             return gateway.send(
                 chainId,
                 MessageLib.NotifyPricePoolPerShare({
-                    poolId: poolId.raw(),
-                    scId: scId.raw(),
-                    price: price.raw(),
-                    timestamp: timestamp
-                }).serialize(),
+                        poolId: poolId.raw(), scId: scId.raw(), price: price.raw(), timestamp: timestamp
+                    }).serialize(),
                 0
             );
         }
@@ -195,12 +189,12 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
             return gateway.send(
                 assetId.centrifugeId(),
                 MessageLib.NotifyPricePoolPerAsset({
-                    poolId: poolId.raw(),
-                    scId: scId.raw(),
-                    assetId: assetId.raw(),
-                    price: price.raw(),
-                    timestamp: timestamp
-                }).serialize(),
+                        poolId: poolId.raw(),
+                        scId: scId.raw(),
+                        assetId: assetId.raw(),
+                        price: price.raw(),
+                        timestamp: timestamp
+                    }).serialize(),
                 0
             );
         }
@@ -261,12 +255,12 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
             return gateway.send(
                 assetId.centrifugeId(),
                 MessageLib.UpdateVault({
-                    poolId: poolId.raw(),
-                    scId: scId.raw(),
-                    assetId: assetId.raw(),
-                    vaultOrFactory: vaultOrFactory,
-                    kind: uint8(kind)
-                }).serialize(),
+                        poolId: poolId.raw(),
+                        scId: scId.raw(),
+                        assetId: assetId.raw(),
+                        vaultOrFactory: vaultOrFactory,
+                        kind: uint8(kind)
+                    }).serialize(),
                 extraGasLimit
             );
         }
@@ -298,7 +292,8 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
         } else {
             return gateway.send(
                 centrifugeId,
-                MessageLib.UpdateBalanceSheetManager({poolId: poolId.raw(), who: who, canManage: canManage}).serialize(),
+                MessageLib.UpdateBalanceSheetManager({poolId: poolId.raw(), who: who, canManage: canManage})
+                    .serialize(),
                 0
             );
         }
@@ -316,11 +311,8 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
             return gateway.send(
                 assetId.centrifugeId(),
                 MessageLib.MaxAssetPriceAge({
-                    poolId: poolId.raw(),
-                    scId: scId.raw(),
-                    assetId: assetId.raw(),
-                    maxPriceAge: maxPriceAge
-                }).serialize(),
+                        poolId: poolId.raw(), scId: scId.raw(), assetId: assetId.raw(), maxPriceAge: maxPriceAge
+                    }).serialize(),
                 0
             );
         }
@@ -403,13 +395,13 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
             return gateway.send(
                 poolId.centrifugeId(),
                 MessageLib.InitiateTransferShares({
-                    centrifugeId: targetCentrifugeId,
-                    poolId: poolId.raw(),
-                    scId: scId.raw(),
-                    receiver: receiver,
-                    amount: amount,
-                    extraGasLimit: remoteExtraGasLimit
-                }).serialize(),
+                        centrifugeId: targetCentrifugeId,
+                        poolId: poolId.raw(),
+                        scId: scId.raw(),
+                        receiver: receiver,
+                        amount: amount,
+                        extraGasLimit: remoteExtraGasLimit
+                    }).serialize(),
                 extraGasLimit
             );
         }
@@ -430,11 +422,8 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
             spoke.executeTransferShares(poolId, scId, receiver, amount);
         } else {
             bytes memory message = MessageLib.ExecuteTransferShares({
-                poolId: poolId.raw(),
-                scId: scId.raw(),
-                receiver: receiver,
-                amount: amount
-            }).serialize();
+                    poolId: poolId.raw(), scId: scId.raw(), receiver: receiver, amount: amount
+                }).serialize();
 
             if (originCentrifugeId == localCentrifugeId) {
                 // Spoke chain X => Hub chain X => Spoke chain Y: payment done directly on X
@@ -471,16 +460,16 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
             return gateway.send(
                 poolId.centrifugeId(),
                 MessageLib.UpdateHoldingAmount({
-                    poolId: poolId.raw(),
-                    scId: scId.raw(),
-                    assetId: assetId.raw(),
-                    amount: data.netAmount,
-                    pricePerUnit: pricePoolPerAsset.raw(),
-                    timestamp: uint64(block.timestamp),
-                    isIncrease: data.isIncrease,
-                    isSnapshot: data.isSnapshot,
-                    nonce: data.nonce
-                }).serialize(),
+                        poolId: poolId.raw(),
+                        scId: scId.raw(),
+                        assetId: assetId.raw(),
+                        amount: data.netAmount,
+                        pricePerUnit: pricePoolPerAsset.raw(),
+                        timestamp: uint64(block.timestamp),
+                        isIncrease: data.isIncrease,
+                        isSnapshot: data.isSnapshot,
+                        nonce: data.nonce
+                    }).serialize(),
                 extraGasLimit
             );
         }
@@ -500,14 +489,14 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
             return gateway.send(
                 poolId.centrifugeId(),
                 MessageLib.UpdateShares({
-                    poolId: poolId.raw(),
-                    scId: scId.raw(),
-                    shares: data.netAmount,
-                    timestamp: uint64(block.timestamp),
-                    isIssuance: data.isIncrease,
-                    isSnapshot: data.isSnapshot,
-                    nonce: data.nonce
-                }).serialize(),
+                        poolId: poolId.raw(),
+                        scId: scId.raw(),
+                        shares: data.netAmount,
+                        timestamp: uint64(block.timestamp),
+                        isIssuance: data.isIncrease,
+                        isSnapshot: data.isSnapshot,
+                        nonce: data.nonce
+                    }).serialize(),
                 extraGasLimit
             );
         }
@@ -560,11 +549,8 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
             return gateway.send(
                 assetId.centrifugeId(),
                 MessageLib.RequestCallback({
-                    poolId: poolId.raw(),
-                    scId: scId.raw(),
-                    assetId: assetId.raw(),
-                    payload: payload
-                }).serialize(),
+                        poolId: poolId.raw(), scId: scId.raw(), assetId: assetId.raw(), payload: payload
+                    }).serialize(),
                 extraGasLimit
             );
         }
@@ -584,11 +570,8 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
             return gateway.send(
                 centrifugeId,
                 MessageLib.SetPoolAdapters({
-                    poolId: poolId.raw(),
-                    threshold: threshold,
-                    recoveryIndex: recoveryIndex,
-                    adapterList: adapters
-                }).serialize(),
+                        poolId: poolId.raw(), threshold: threshold, recoveryIndex: recoveryIndex, adapterList: adapters
+                    }).serialize(),
                 0
             );
         }

--- a/src/common/interfaces/IGatewaySenders.sol
+++ b/src/common/interfaces/IGatewaySenders.sol
@@ -104,9 +104,7 @@ interface IHubMessageSender is ILocalCentrifugeId {
     ) external returns (uint256 cost);
 
     /// @notice Creates and send the message
-    function sendSetRequestManager(uint16 centrifugeId, PoolId poolId, bytes32 manager)
-        external
-        returns (uint256 cost);
+    function sendSetRequestManager(uint16 centrifugeId, PoolId poolId, bytes32 manager) external returns (uint256 cost);
 
     /// @notice Creates and send the message
     function sendUpdateBalanceSheetManager(uint16 centrifugeId, PoolId poolId, bytes32 who, bool canManage)

--- a/src/common/libraries/MessageLib.sol
+++ b/src/common/libraries/MessageLib.sol
@@ -373,10 +373,7 @@ library MessageLib {
     {
         require(messageType(data) == MessageType.NotifyPricePoolPerShare, UnknownMessageType());
         return NotifyPricePoolPerShare({
-            poolId: data.toUint64(1),
-            scId: data.toBytes16(9),
-            price: data.toUint128(25),
-            timestamp: data.toUint64(41)
+            poolId: data.toUint64(1), scId: data.toBytes16(9), price: data.toUint128(25), timestamp: data.toUint64(41)
         });
     }
 
@@ -510,10 +507,7 @@ library MessageLib {
     function deserializeExecuteTransferShares(bytes memory data) internal pure returns (ExecuteTransferShares memory) {
         require(messageType(data) == MessageType.ExecuteTransferShares, UnknownMessageType());
         return ExecuteTransferShares({
-            poolId: data.toUint64(1),
-            scId: data.toBytes16(9),
-            receiver: data.toBytes32(25),
-            amount: data.toUint128(57)
+            poolId: data.toUint64(1), scId: data.toBytes16(9), receiver: data.toBytes32(25), amount: data.toUint128(57)
         });
     }
 
@@ -536,9 +530,7 @@ library MessageLib {
 
         uint16 payloadLength = data.toUint16(25);
         return UpdateRestriction({
-            poolId: data.toUint64(1),
-            scId: data.toBytes16(9),
-            payload: data.slice(27, payloadLength)
+            poolId: data.toUint64(1), scId: data.toBytes16(9), payload: data.slice(27, payloadLength)
         });
     }
 

--- a/src/common/libraries/PricingLib.sol
+++ b/src/common/libraries/PricingLib.sol
@@ -40,8 +40,8 @@ library PricingLib {
         uint8 shareDecimals = IERC20Metadata(shareToken).decimals();
 
         return PricingLib.convertWithReciprocalPrice(
-            assetAmount, assetDecimals, shareDecimals, priceAssetPerShare_, rounding
-        ).toUint128();
+                assetAmount, assetDecimals, shareDecimals, priceAssetPerShare_, rounding
+            ).toUint128();
     }
 
     /// @dev Converts the given asset amount to share amount. Returned value is in share decimals.
@@ -63,8 +63,8 @@ library PricingLib {
         uint8 shareDecimals = IERC20Metadata(shareToken).decimals();
 
         return PricingLib.assetToShareAmount(
-            assetAmount, assetDecimals, shareDecimals, pricePoolPerAsset, pricePoolPerShare, rounding
-        ).toUint128();
+                assetAmount, assetDecimals, shareDecimals, pricePoolPerAsset, pricePoolPerShare, rounding
+            ).toUint128();
     }
 
     /// @dev Converts the given share amount to asset amount. Returned value is in share decimals.
@@ -110,8 +110,8 @@ library PricingLib {
 
         // NOTE: Pool and share denomination are always equal by design
         return PricingLib.shareToAssetAmount(
-            shareAmount, shareDecimals, assetDecimals, pricePoolPerShare, pricePoolPerAsset, rounding
-        ).toUint128();
+                shareAmount, shareDecimals, assetDecimals, pricePoolPerShare, pricePoolPerAsset, rounding
+            ).toUint128();
     }
 
     /// @dev Calculates the asset price per share returns the value in price decimals
@@ -134,9 +134,8 @@ library PricingLib {
 
         // NOTE: More precise than utilizing D18
         return d18(
-            _toPriceDecimals(assets, assetDecimals).mulDiv(
-                10 ** PRICE_DECIMALS, _toPriceDecimals(shares, shareDecimals), rounding
-            ).toUint128()
+            _toPriceDecimals(assets, assetDecimals)
+                .mulDiv(10 ** PRICE_DECIMALS, _toPriceDecimals(shares, shareDecimals), rounding).toUint128()
         );
     }
 
@@ -166,8 +165,11 @@ library PricingLib {
         }
 
         return MathLib.mulDiv(
-            priceQuotePerBase.raw(), baseAmount * 10 ** quoteDecimals, 10 ** (baseDecimals + PRICE_DECIMALS), rounding
-        ) // cancel out exponentiation from D18 multiplication
+                priceQuotePerBase.raw(),
+                baseAmount * 10 ** quoteDecimals,
+                10 ** (baseDecimals + PRICE_DECIMALS),
+                rounding
+            ) // cancel out exponentiation from D18 multiplication
             .toUint128();
     }
 
@@ -189,11 +191,11 @@ library PricingLib {
         }
 
         return MathLib.mulDiv(
-            10 ** quoteDecimals * baseAmount,
-            10 ** PRICE_DECIMALS,
-            10 ** baseDecimals * priceBasePerQuote.raw(),
-            rounding
-        ).toUint128();
+                10 ** quoteDecimals * baseAmount,
+                10 ** PRICE_DECIMALS,
+                10 ** baseDecimals * priceBasePerQuote.raw(),
+                rounding
+            ).toUint128();
     }
 
     /// @dev Converts an amount using decimals and two prices.
@@ -211,11 +213,11 @@ library PricingLib {
         require(priceDenominator.isNotZero(), DivisionByZero());
 
         return MathLib.mulDiv(
-            priceNumerator.raw(),
-            10 ** quoteDecimals * baseAmount,
-            10 ** baseDecimals * priceDenominator.raw(),
-            rounding
-        ).toUint128();
+                priceNumerator.raw(),
+                10 ** quoteDecimals * baseAmount,
+                10 ** baseDecimals * priceDenominator.raw(),
+                rounding
+            ).toUint128();
     }
 
     /// @dev Converts asset amount to share amount.
@@ -230,8 +232,9 @@ library PricingLib {
         D18 pricePoolPerShare,
         MathLib.Rounding rounding
     ) internal pure returns (uint128 shareAmount) {
-        return
-            convertWithPrices(assetAmount, assetDecimals, shareDecimals, pricePoolPerAsset, pricePoolPerShare, rounding);
+        return convertWithPrices(
+            assetAmount, assetDecimals, shareDecimals, pricePoolPerAsset, pricePoolPerShare, rounding
+        );
     }
 
     /// @dev Converts share amount to asset asset amount.
@@ -246,8 +249,9 @@ library PricingLib {
         D18 pricePoolPerAsset,
         MathLib.Rounding rounding
     ) internal pure returns (uint128 assetAmount) {
-        return
-            convertWithPrices(shareAmount, shareDecimals, assetDecimals, pricePoolPerShare, pricePoolPerAsset, rounding);
+        return convertWithPrices(
+            shareAmount, shareDecimals, assetDecimals, pricePoolPerShare, pricePoolPerAsset, rounding
+        );
     }
 
     /// @dev Converts pool amount to asset amount.

--- a/src/common/libraries/RequestCallbackMessageLib.sol
+++ b/src/common/libraries/RequestCallbackMessageLib.sol
@@ -77,9 +77,7 @@ library RequestCallbackMessageLib {
         require(requestCallbackType(data) == RequestCallbackType.RevokedShares, UnknownRequestCallbackType());
 
         return RevokedShares({
-            assetAmount: data.toUint128(1),
-            shareAmount: data.toUint128(17),
-            pricePoolPerShare: data.toUint128(33)
+            assetAmount: data.toUint128(1), shareAmount: data.toUint128(17), pricePoolPerShare: data.toUint128(33)
         });
     }
 

--- a/src/hooks/BaseTransferHook.sol
+++ b/src/hooks/BaseTransferHook.sol
@@ -43,7 +43,8 @@ abstract contract BaseTransferHook is Auth, IMemberlist, IFreezable, ITransferHo
         address deployer
     ) Auth(deployer) {
         require(
-            redeemSource_ != depositTarget_ && depositTarget_ != crosschainSource_ && redeemSource_ != crosschainSource_,
+            redeemSource_ != depositTarget_ && depositTarget_ != crosschainSource_
+                && redeemSource_ != crosschainSource_,
             InvalidInputs()
         );
 
@@ -74,11 +75,22 @@ abstract contract BaseTransferHook is Auth, IMemberlist, IFreezable, ITransferHo
         address, /* to */
         uint256, /* value */
         HookData calldata /* hookData */
-    ) external pure virtual returns (bytes4) {
+    )
+        external
+        pure
+        virtual
+        returns (bytes4)
+    {
         return ITransferHook.onERC20AuthTransfer.selector;
     }
 
-    function checkERC20Transfer(address from, address to, uint256, /* value */ HookData calldata hookData)
+    function checkERC20Transfer(
+        address from,
+        address to,
+        uint256,
+        /* value */
+        HookData calldata hookData
+    )
         public
         view
         virtual

--- a/src/hooks/FreelyTransferable.sol
+++ b/src/hooks/FreelyTransferable.sol
@@ -20,7 +20,13 @@ contract FreelyTransferable is BaseTransferHook {
     ) BaseTransferHook(root_, redeemSource_, depositTarget_, crosschainSource_, deployer) {}
 
     /// @inheritdoc ITransferHook
-    function checkERC20Transfer(address from, address to, uint256, /* value */ HookData calldata hookData)
+    function checkERC20Transfer(
+        address from,
+        address to,
+        uint256,
+        /* value */
+        HookData calldata hookData
+    )
         public
         view
         override

--- a/src/hooks/FullRestrictions.sol
+++ b/src/hooks/FullRestrictions.sol
@@ -19,7 +19,13 @@ contract FullRestrictions is BaseTransferHook {
     ) BaseTransferHook(root_, redeemSource_, depositTarget_, crosschainSource_, deployer) {}
 
     /// @inheritdoc ITransferHook
-    function checkERC20Transfer(address from, address to, uint256, /* value */ HookData calldata hookData)
+    function checkERC20Transfer(
+        address from,
+        address to,
+        uint256,
+        /* value */
+        HookData calldata hookData
+    )
         public
         view
         override

--- a/src/hooks/RedemptionRestrictions.sol
+++ b/src/hooks/RedemptionRestrictions.sol
@@ -20,7 +20,13 @@ contract RedemptionRestrictions is BaseTransferHook {
     ) BaseTransferHook(root_, redeemSource_, depositTarget_, crosschainSource_, deployer) {}
 
     /// @inheritdoc ITransferHook
-    function checkERC20Transfer(address from, address to, uint256, /* value */ HookData calldata hookData)
+    function checkERC20Transfer(
+        address from,
+        address to,
+        uint256,
+        /* value */
+        HookData calldata hookData
+    )
         public
         view
         override

--- a/src/hub/Holdings.sol
+++ b/src/hub/Holdings.sol
@@ -178,8 +178,9 @@ contract Holdings is Auth, IHoldings {
         uint128 currentAmountValue = holding_.valuation.getQuote(poolId, scId, assetId, holding_.assetAmount);
 
         isPositive = currentAmountValue >= holding_.assetAmountValue;
-        diffValue =
-            isPositive ? currentAmountValue - holding_.assetAmountValue : holding_.assetAmountValue - currentAmountValue;
+        diffValue = isPositive
+            ? currentAmountValue - holding_.assetAmountValue
+            : holding_.assetAmountValue - currentAmountValue;
 
         holding_.assetAmountValue = currentAmountValue;
 

--- a/src/hub/interfaces/IHoldings.sol
+++ b/src/hub/interfaces/IHoldings.sol
@@ -145,11 +145,9 @@ interface IHoldings {
     function updateIsLiability(PoolId poolId, ShareClassId scId, AssetId assetId, bool isLiability) external;
 
     /// @notice Sets an account id for an specific kind
-    function setAccountId(PoolId poolId, ShareClassId scId, AssetId assetId, uint8 kind, AccountId accountId)
-        external;
+    function setAccountId(PoolId poolId, ShareClassId scId, AssetId assetId, uint8 kind, AccountId accountId) external;
 
-    function setSnapshot(PoolId poolId, ShareClassId scId, uint16 centrifugeId, bool isSnapshot, uint64 nonce)
-        external;
+    function setSnapshot(PoolId poolId, ShareClassId scId, uint16 centrifugeId, bool isSnapshot, uint64 nonce) external;
 
     function setSnapshotHook(PoolId poolId, ISnapshotHook hook) external;
 
@@ -175,10 +173,7 @@ interface IHoldings {
     function isLiability(PoolId poolId, ShareClassId scId, AssetId assetId) external view returns (bool);
 
     /// @notice Returns an account id for an specific kind
-    function accountId(PoolId poolId, ShareClassId scId, AssetId assetId, uint8 kind)
-        external
-        view
-        returns (AccountId);
+    function accountId(PoolId poolId, ShareClassId scId, AssetId assetId, uint8 kind) external view returns (AccountId);
 
     /// @notice Tells if the holding was initialized for an asset in a share class
     function isInitialized(PoolId poolId, ShareClassId scId, AssetId assetId) external view returns (bool);

--- a/src/hub/interfaces/IHub.sol
+++ b/src/hub/interfaces/IHub.sol
@@ -121,9 +121,7 @@ interface IHub {
         returns (uint256 cost);
 
     /// @notice Notify to a CV instance that share metadata has updated
-    function notifyShareMetadata(PoolId poolId, ShareClassId scId, uint16 centrifugeId)
-        external
-        returns (uint256 cost);
+    function notifyShareMetadata(PoolId poolId, ShareClassId scId, uint16 centrifugeId) external returns (uint256 cost);
 
     /// @notice Update on a CV instance the hook of a share token
     function updateShareHook(PoolId poolId, ShareClassId scId, uint16 centrifugeId, bytes32 hook)
@@ -334,9 +332,7 @@ interface IHub {
     /// @param centrifugeId The centrifuge chain ID
     /// @param data The encoded function call data
     /// @return cost The gas cost for the operation
-    function callRequestManager(PoolId poolId, uint16 centrifugeId, bytes calldata data)
-        external
-        returns (uint256 cost);
+    function callRequestManager(PoolId poolId, uint16 centrifugeId, bytes calldata data) external returns (uint256 cost);
 
     function updateAccountingAmount(PoolId poolId, ShareClassId scId, AssetId assetId, bool isPositive, uint128 diff)
         external;

--- a/src/hub/interfaces/IShareClassManager.sol
+++ b/src/hub/interfaces/IShareClassManager.sol
@@ -127,8 +127,5 @@ interface IShareClassManager {
     /// @return name The registered name of the share class token
     /// @return symbol The registered symbol of the share class token
     /// @return salt The registered salt of the share class token, used for deterministic deployments
-    function metadata(ShareClassId scId)
-        external
-        view
-        returns (string memory name, string memory symbol, bytes32 salt);
+    function metadata(ShareClassId scId) external view returns (string memory name, string memory symbol, bytes32 salt);
 }

--- a/src/managers/MerkleProofManager.sol
+++ b/src/managers/MerkleProofManager.sol
@@ -36,7 +36,14 @@ contract MerkleProofManager is IMerkleProofManager, IUpdateContract {
     //----------------------------------------------------------------------------------------------
 
     /// @inheritdoc IUpdateContract
-    function update(PoolId poolId_, ShareClassId, /* scId */ bytes calldata payload) external {
+    function update(
+        PoolId poolId_,
+        ShareClassId,
+        /* scId */
+        bytes calldata payload
+    )
+        external
+    {
         require(poolId == poolId_, InvalidPoolId());
         require(msg.sender == contractUpdater, NotAuthorized());
 

--- a/src/managers/OnOfframpManager.sol
+++ b/src/managers/OnOfframpManager.sol
@@ -93,14 +93,30 @@ contract OnOfframpManager is IOnOfframpManager {
     //----------------------------------------------------------------------------------------------
 
     /// @inheritdoc IDepositManager
-    function deposit(address asset, uint256, /* tokenId */ uint128 amount, address /* owner */ ) external {
+    function deposit(
+        address asset,
+        uint256,
+        /* tokenId */
+        uint128 amount,
+        address /* owner */
+    )
+        external
+    {
         require(onramp[asset], NotAllowedOnrampAsset());
 
         balanceSheet.deposit(poolId, scId, asset, 0, amount);
     }
 
     /// @inheritdoc IWithdrawManager
-    function withdraw(address asset, uint256, /* tokenId */ uint128 amount, address receiver) external {
+    function withdraw(
+        address asset,
+        uint256,
+        /* tokenId */
+        uint128 amount,
+        address receiver
+    )
+        external
+    {
         require(relayer[msg.sender], NotRelayer());
         require(receiver != address(0) && offramp[asset][receiver], InvalidOfframpDestination());
 
@@ -131,9 +147,9 @@ contract OnOfframpManagerFactory is IOnOfframpManagerFactory {
     function newManager(PoolId poolId, ShareClassId scId) external returns (IOnOfframpManager) {
         balanceSheet.spoke().shareToken(poolId, scId); // Check for existence
 
-        OnOfframpManager manager = new OnOfframpManager{salt: keccak256(abi.encode(poolId.raw(), scId.raw()))}(
-            poolId, scId, contractUpdater, balanceSheet
-        );
+        OnOfframpManager manager = new OnOfframpManager{
+            salt: keccak256(abi.encode(poolId.raw(), scId.raw()))
+        }(poolId, scId, contractUpdater, balanceSheet);
 
         emit DeployOnOfframpManager(poolId, scId, address(manager));
         return IOnOfframpManager(manager);

--- a/src/misc/interfaces/IERC6909.sol
+++ b/src/misc/interfaces/IERC6909.sol
@@ -159,9 +159,7 @@ interface IERC6909Fungible is IERC6909 {
     /// @param receiver     Address of the receiving party
     /// @param tokenId      Token Id
     /// @param amount       Amount to be transferred
-    function authTransferFrom(address sender, address receiver, uint256 tokenId, uint256 amount)
-        external
-        returns (bool);
+    function authTransferFrom(address sender, address receiver, uint256 tokenId, uint256 amount) external returns (bool);
 }
 
 /// @dev  A factory contract to deploy new collateral contracts implementing IERC6909.

--- a/src/misc/interfaces/IERC7540.sol
+++ b/src/misc/interfaces/IERC7540.sol
@@ -58,10 +58,7 @@ interface IERC7540Deposit is IERC7540Operator {
      * - MUST NOT show any variations depending on the caller.
      * - MUST NOT revert unless due to integer overflow caused by an unreasonably large input.
      */
-    function pendingDepositRequest(uint256 requestId, address controller)
-        external
-        view
-        returns (uint256 pendingAssets);
+    function pendingDepositRequest(uint256 requestId, address controller) external view returns (uint256 pendingAssets);
 
     /**
      * @dev Returns the amount of requested assets in Claimable state for the controller to deposit or mint.
@@ -119,10 +116,7 @@ interface IERC7540Redeem is IERC7540Operator {
      * - MUST NOT show any variations depending on the caller.
      * - MUST NOT revert unless due to integer overflow caused by an unreasonably large input.
      */
-    function pendingRedeemRequest(uint256 requestId, address controller)
-        external
-        view
-        returns (uint256 pendingShares);
+    function pendingRedeemRequest(uint256 requestId, address controller) external view returns (uint256 pendingShares);
 
     /**
      * @dev Returns the amount of requested shares in Claimable state for the controller to redeem or withdraw.
@@ -160,10 +154,7 @@ interface IERC7887Deposit {
      *
      * - MUST NOT show any variations depending on the caller.
      */
-    function pendingCancelDepositRequest(uint256 requestId, address controller)
-        external
-        view
-        returns (bool isPending);
+    function pendingCancelDepositRequest(uint256 requestId, address controller) external view returns (bool isPending);
 
     /**
      * @dev Returns the amount of assets that were canceled from a deposit Request, and can now be claimed.

--- a/src/misc/libraries/MathLib.sol
+++ b/src/misc/libraries/MathLib.sol
@@ -6,7 +6,6 @@ library MathLib {
         Down, // Toward negative infinity
         Up, // Toward infinity
         Zero // Toward zero
-
     }
 
     error MulDiv_Overflow();
@@ -145,6 +144,7 @@ library MathLib {
             return result;
         }
     }
+
     // slither-disable-end divide-before-multiply
 
     /// @notice Calculates x * y / denominator with full precision, following the selected rounding direction.

--- a/src/misc/libraries/SignatureLib.sol
+++ b/src/misc/libraries/SignatureLib.sol
@@ -33,8 +33,8 @@ library SignatureLib {
         if (signer.code.length > 0) {
             (bool success, bytes memory result) =
                 signer.staticcall(abi.encodeCall(IERC1271.isValidSignature, (digest, signature)));
-            valid =
-                (success && result.length == 32 && abi.decode(result, (bytes4)) == IERC1271.isValidSignature.selector);
+            valid = (success && result.length == 32
+                    && abi.decode(result, (bytes4)) == IERC1271.isValidSignature.selector);
         }
     }
 }

--- a/src/spoke/BalanceSheet.sol
+++ b/src/spoke/BalanceSheet.sol
@@ -326,9 +326,7 @@ contract BalanceSheet is Auth, Multicall, Recoverable, IBalanceSheet, IBalanceSh
     // Internal
     //----------------------------------------------------------------------------------------------
 
-    function _updateAssets(PoolId poolId, ShareClassId scId, AssetId assetId, uint128 amount, bool isDeposit)
-        internal
-    {
+    function _updateAssets(PoolId poolId, ShareClassId scId, AssetId assetId, uint128 amount, bool isDeposit) internal {
         if (amount == 0) return;
         ShareQueueAmount storage shareQueue = queuedShares[poolId][scId];
         AssetQueueAmount storage assetQueue = queuedAssets[poolId][scId][assetId];
@@ -339,8 +337,9 @@ contract BalanceSheet is Auth, Multicall, Recoverable, IBalanceSheet, IBalanceSh
 
     function _pricePoolPerAsset(PoolId poolId, ShareClassId scId, AssetId assetId) internal view returns (D18) {
         if (TransientStorageLib.tloadBool(keccak256(abi.encode("pricePoolPerAssetIsSet", poolId, scId, assetId)))) {
-            return
-                d18(TransientStorageLib.tloadUint128(keccak256(abi.encode("pricePoolPerAsset", poolId, scId, assetId))));
+            return d18(
+                TransientStorageLib.tloadUint128(keccak256(abi.encode("pricePoolPerAsset", poolId, scId, assetId)))
+            );
         }
 
         D18 pricePoolPerAsset = spoke.pricePoolPerAsset(poolId, scId, assetId, true);

--- a/src/spoke/BalanceSheet.sol
+++ b/src/spoke/BalanceSheet.sol
@@ -335,6 +335,7 @@ contract BalanceSheet is Auth, Multicall, Recoverable, IBalanceSheet, IBalanceSh
         else assetQueue.withdrawals += amount;
     }
 
+    // forgefmt: disable-next-item
     function _pricePoolPerAsset(PoolId poolId, ShareClassId scId, AssetId assetId) internal view returns (D18) {
         if (TransientStorageLib.tloadBool(keccak256(abi.encode("pricePoolPerAssetIsSet", poolId, scId, assetId)))) {
             return d18(

--- a/src/spoke/ShareToken.sol
+++ b/src/spoke/ShareToken.sol
@@ -127,9 +127,8 @@ contract ShareToken is ERC20, IShareToken {
         success = _transferFrom(sender, from, to, value);
         address hook_ = hook;
         if (hook_ != address(0)) {
-            ITransferHook(hook_).onERC20AuthTransfer(
-                sender, from, to, value, HookData(hookDataOf(from), hookDataOf(to))
-            );
+            ITransferHook(hook_)
+                .onERC20AuthTransfer(sender, from, to, value, HookData(hookDataOf(from), hookDataOf(to)));
         }
     }
 

--- a/src/spoke/interfaces/IBalanceSheet.sol
+++ b/src/spoke/interfaces/IBalanceSheet.sol
@@ -134,9 +134,7 @@ interface IBalanceSheet {
         returns (uint256 cost);
 
     /// @notice Sends the queued updated shares changed to the Hub
-    function submitQueuedShares(PoolId poolId, ShareClassId scId, uint128 extraGasLimit)
-        external
-        returns (uint256 cost);
+    function submitQueuedShares(PoolId poolId, ShareClassId scId, uint128 extraGasLimit) external returns (uint256 cost);
 
     /// @notice Force-transfers share tokens.
     function transferSharesFrom(

--- a/src/spoke/interfaces/ISpoke.sol
+++ b/src/spoke/interfaces/ISpoke.sol
@@ -274,10 +274,7 @@ interface ISpoke {
     /// @param scId The share class id
     /// @param checkValidity Whether to check if the price is valid
     /// @return price The pool price per share
-    function pricePoolPerShare(PoolId poolId, ShareClassId scId, bool checkValidity)
-        external
-        view
-        returns (D18 price);
+    function pricePoolPerShare(PoolId poolId, ShareClassId scId, bool checkValidity) external view returns (D18 price);
 
     /// @notice Returns the price per asset for a given pool, share class and the underlying asset id. The Provided
     /// price is defined as POOL_UNIT/ASSET_UNIT.

--- a/src/spoke/libraries/UpdateContractMessageLib.sol
+++ b/src/spoke/libraries/UpdateContractMessageLib.sol
@@ -86,10 +86,7 @@ library UpdateContractMessageLib {
         require(updateContractType(data) == UpdateContractType.UpdateAddress, UnknownMessageType());
 
         return UpdateContractUpdateAddress({
-            kind: data.toBytes32(1),
-            assetId: data.toUint128(33),
-            what: data.toBytes32(49),
-            isEnabled: data.toBool(81)
+            kind: data.toBytes32(1), assetId: data.toUint128(33), what: data.toBytes32(49), isEnabled: data.toBool(81)
         });
     }
 

--- a/src/valuations/IdentityValuation.sol
+++ b/src/valuations/IdentityValuation.sol
@@ -21,7 +21,7 @@ contract IdentityValuation is IIdentityValuation {
     }
 
     /// @inheritdoc IValuation
-    function getPrice(PoolId poolId, ShareClassId scId, AssetId assetId) external pure returns (D18) {
+    function getPrice(PoolId, ShareClassId, AssetId) external pure returns (D18) {
         return d18(1e18);
     }
 

--- a/src/vaults/AsyncRequestManager.sol
+++ b/src/vaults/AsyncRequestManager.sol
@@ -555,7 +555,13 @@ contract AsyncRequestManager is Auth, Recoverable, IAsyncRequestManager {
         return pricePoolPerShare.isZero()
             ? 0
             : PricingLib.assetToShareAmount(
-                vault_.share(), vd.asset, vd.tokenId, assets_, pricePoolPerAsset, pricePoolPerShare, MathLib.Rounding.Down
+                vault_.share(),
+                vd.asset,
+                vd.tokenId,
+                assets_,
+                pricePoolPerAsset,
+                pricePoolPerShare,
+                MathLib.Rounding.Down
             );
     }
 
@@ -569,7 +575,13 @@ contract AsyncRequestManager is Auth, Recoverable, IAsyncRequestManager {
         return pricePoolPerAsset.isZero()
             ? 0
             : PricingLib.shareToAssetAmount(
-                vault_.share(), shares_, vd.asset, vd.tokenId, pricePoolPerShare, pricePoolPerAsset, MathLib.Rounding.Down
+                vault_.share(),
+                shares_,
+                vd.asset,
+                vd.tokenId,
+                pricePoolPerShare,
+                pricePoolPerAsset,
+                MathLib.Rounding.Down
             );
     }
 

--- a/src/vaults/BaseVaults.sol
+++ b/src/vaults/BaseVaults.sol
@@ -48,8 +48,9 @@ abstract contract BaseVault is Auth, Recoverable, IBaseVault {
     bytes32 private immutable versionHash;
     uint256 public immutable deploymentChainId;
     bytes32 private immutable _DOMAIN_SEPARATOR;
-    bytes32 public constant AUTHORIZE_OPERATOR_TYPEHASH =
-        keccak256("AuthorizeOperator(address controller,address operator,bool approved,bytes32 nonce,uint256 deadline)");
+    bytes32 public constant AUTHORIZE_OPERATOR_TYPEHASH = keccak256(
+        "AuthorizeOperator(address controller,address operator,bool approved,bytes32 nonce,uint256 deadline)"
+    );
 
     /// @inheritdoc IERC7741
     mapping(address controller => mapping(bytes32 nonce => bool used)) public authorizations;
@@ -275,10 +276,7 @@ abstract contract BaseAsyncRedeemVault is BaseVault, IAsyncRedeemVault {
     }
 
     /// @inheritdoc IERC7887Redeem
-    function claimCancelRedeemRequest(uint256, address receiver, address controller)
-        external
-        returns (uint256 shares)
-    {
+    function claimCancelRedeemRequest(uint256, address receiver, address controller) external returns (uint256 shares) {
         _validateController(controller);
         shares = asyncRedeemManager.claimCancelRedeemRequest(this, receiver, controller);
         emit CancelRedeemClaim(controller, receiver, REQUEST_ID, msg.sender, shares);

--- a/src/vaults/BatchRequestManager.sol
+++ b/src/vaults/BatchRequestManager.sol
@@ -62,8 +62,9 @@ contract BatchRequestManager is Auth, ReentrancyProtection, IBatchRequestManager
     // Queued requests
     mapping(ShareClassId scId => mapping(AssetId payoutAssetId => mapping(bytes32 investor => QueuedOrder queued)))
         public queuedRedeemRequest;
-    mapping(ShareClassId scId => mapping(AssetId depositAssetId => mapping(bytes32 investor => QueuedOrder queued)))
-        public queuedDepositRequest;
+    mapping(
+        ShareClassId scId => mapping(AssetId depositAssetId => mapping(bytes32 investor => QueuedOrder queued))
+    ) public queuedDepositRequest;
 
     // Force cancel request safeguards
     mapping(ShareClassId scId => mapping(AssetId depositAssetId => mapping(bytes32 investor => bool cancelled))) public
@@ -112,8 +113,8 @@ contract BatchRequestManager is Auth, ReentrancyProtection, IBatchRequestManager
                     poolId,
                     scId,
                     assetId,
-                    RequestCallbackMessageLib.FulfilledDepositRequest(m.investor, 0, 0, cancelledAssetAmount).serialize(
-                    ),
+                    RequestCallbackMessageLib.FulfilledDepositRequest(m.investor, 0, 0, cancelledAssetAmount)
+                        .serialize(),
                     0
                 );
             }
@@ -127,7 +128,8 @@ contract BatchRequestManager is Auth, ReentrancyProtection, IBatchRequestManager
                     poolId,
                     scId,
                     assetId,
-                    RequestCallbackMessageLib.FulfilledRedeemRequest(m.investor, 0, 0, cancelledShareAmount).serialize(),
+                    RequestCallbackMessageLib.FulfilledRedeemRequest(m.investor, 0, 0, cancelledShareAmount)
+                        .serialize(),
                     0
                 );
             }
@@ -137,10 +139,13 @@ contract BatchRequestManager is Auth, ReentrancyProtection, IBatchRequestManager
     }
 
     /// @inheritdoc IBatchRequestManager
-    function requestDeposit(PoolId poolId, ShareClassId scId_, uint128 amount, bytes32 investor, AssetId depositAssetId)
-        public
-        auth
-    {
+    function requestDeposit(
+        PoolId poolId,
+        ShareClassId scId_,
+        uint128 amount,
+        bytes32 investor,
+        AssetId depositAssetId
+    ) public auth {
         // NOTE: Vaults ensure amount > 0
         _updatePending(poolId, scId_, amount, true, investor, depositAssetId, RequestType.Deposit);
     }
@@ -471,8 +476,8 @@ contract BatchRequestManager is Auth, ReentrancyProtection, IBatchRequestManager
                 scId,
                 assetId,
                 RequestCallbackMessageLib.FulfilledDepositRequest(
-                    investor, totalPaymentAssetAmount, totalPayoutShareAmount, cancelledAssetAmount
-                ).serialize(),
+                        investor, totalPaymentAssetAmount, totalPayoutShareAmount, cancelledAssetAmount
+                    ).serialize(),
                 0
             );
         }
@@ -582,8 +587,8 @@ contract BatchRequestManager is Auth, ReentrancyProtection, IBatchRequestManager
                 scId,
                 assetId,
                 RequestCallbackMessageLib.FulfilledRedeemRequest(
-                    investor, totalPayoutAssetAmount, totalPaymentShareAmount, cancelledShareAmount
-                ).serialize(),
+                        investor, totalPayoutAssetAmount, totalPaymentShareAmount, cancelledShareAmount
+                    ).serialize(),
                 0
             );
         }
@@ -691,11 +696,7 @@ contract BatchRequestManager is Auth, ReentrancyProtection, IBatchRequestManager
     }
 
     /// @inheritdoc IBatchRequestManager
-    function maxRedeemClaims(ShareClassId scId_, bytes32 investor, AssetId payoutAssetId)
-        public
-        view
-        returns (uint32)
-    {
+    function maxRedeemClaims(ShareClassId scId_, bytes32 investor, AssetId payoutAssetId) public view returns (uint32) {
         return _maxClaims(redeemRequest[scId_][payoutAssetId][investor], epochId[scId_][payoutAssetId].revoke);
     }
 
@@ -798,8 +799,9 @@ contract BatchRequestManager is Auth, ReentrancyProtection, IBatchRequestManager
         //       We keep subtraction of amount over setting to zero on purpose to not limit future higher level logic
         userOrder.pending = isIncrement ? userOrder.pending + amount : userOrder.pending - amount;
 
-        userOrder.lastUpdate =
-            requestType == RequestType.Deposit ? nowDepositEpoch(scId_, assetId) : nowRedeemEpoch(scId_, assetId);
+        userOrder.lastUpdate = requestType == RequestType.Deposit
+            ? nowDepositEpoch(scId_, assetId)
+            : nowRedeemEpoch(scId_, assetId);
 
         if (requestType == RequestType.Deposit) {
             _updatePendingDeposit(poolId, scId_, amount, isIncrement, investor, assetId, userOrder, queued);
@@ -831,8 +833,9 @@ contract BatchRequestManager is Auth, ReentrancyProtection, IBatchRequestManager
         QueuedOrder storage queued,
         RequestType requestType
     ) internal returns (bool skipPendingUpdate) {
-        uint32 currentEpoch =
-            requestType == RequestType.Deposit ? nowDepositEpoch(scId_, assetId) : nowRedeemEpoch(scId_, assetId);
+        uint32 currentEpoch = requestType == RequestType.Deposit
+            ? nowDepositEpoch(scId_, assetId)
+            : nowRedeemEpoch(scId_, assetId);
 
         // Short circuit if user can mutate pending, i.e. last update happened after latest approval or is first update
         if (_canMutatePending(userOrder, currentEpoch)) {

--- a/src/vaults/SyncManager.sol
+++ b/src/vaults/SyncManager.sol
@@ -126,7 +126,12 @@ contract SyncManager is Auth, Recoverable, ISyncManager {
     //----------------------------------------------------------------------------------------------
 
     /// @inheritdoc ISyncDepositManager
-    function previewMint(IBaseVault vault_, address, /* sender */ uint256 shares)
+    function previewMint(
+        IBaseVault vault_,
+        address,
+        /* sender */
+        uint256 shares
+    )
         public
         view
         returns (uint256 assets)
@@ -135,7 +140,12 @@ contract SyncManager is Auth, Recoverable, ISyncManager {
     }
 
     /// @inheritdoc ISyncDepositManager
-    function previewDeposit(IBaseVault vault_, address, /* sender */ uint256 assets)
+    function previewDeposit(
+        IBaseVault vault_,
+        address,
+        /* sender */
+        uint256 assets
+    )
         public
         view
         returns (uint256 shares)
@@ -144,7 +154,7 @@ contract SyncManager is Auth, Recoverable, ISyncManager {
     }
 
     /// @inheritdoc IDepositManager
-    function maxMint(IBaseVault vault_, address /* owner */ ) public view returns (uint256) {
+    function maxMint(IBaseVault vault_, address /* owner */) public view returns (uint256) {
         VaultDetails memory vaultDetails = spoke.vaultDetails(vault_);
         uint128 maxAssets =
             _maxDeposit(vault_.poolId(), vault_.scId(), vaultDetails.asset, vaultDetails.tokenId, vault_);
@@ -152,7 +162,7 @@ contract SyncManager is Auth, Recoverable, ISyncManager {
     }
 
     /// @inheritdoc IDepositManager
-    function maxDeposit(IBaseVault vault_, address /* owner */ ) public view returns (uint256) {
+    function maxDeposit(IBaseVault vault_, address /* owner */) public view returns (uint256) {
         VaultDetails memory vaultDetails = spoke.vaultDetails(vault_);
         return _maxDeposit(vault_.poolId(), vault_.scId(), vaultDetails.asset, vaultDetails.tokenId, vault_);
     }

--- a/src/vaults/interfaces/IBatchRequestManager.sol
+++ b/src/vaults/interfaces/IBatchRequestManager.sol
@@ -274,10 +274,13 @@ interface IBatchRequestManager is IHubRequestManager {
     //----------------------------------------------------------------------------------------------
 
     /// @notice Notify a deposit for an investor address located in the chain where the asset belongs
-    function notifyDeposit(PoolId poolId, ShareClassId scId, AssetId depositAssetId, bytes32 investor, uint32 maxClaims)
-        external
-        payable
-        returns (uint256 cost);
+    function notifyDeposit(
+        PoolId poolId,
+        ShareClassId scId,
+        AssetId depositAssetId,
+        bytes32 investor,
+        uint32 maxClaims
+    ) external payable returns (uint256 cost);
 
     /// @notice Notify a redemption for an investor address located in the chain where the asset belongs
     function notifyRedeem(PoolId poolId, ShareClassId scId, AssetId payoutAssetId, bytes32 investor, uint32 maxClaims)
@@ -302,10 +305,7 @@ interface IBatchRequestManager is IHubRequestManager {
         view
         returns (uint32);
 
-    function maxRedeemClaims(ShareClassId scId, bytes32 investor, AssetId payoutAssetId)
-        external
-        view
-        returns (uint32);
+    function maxRedeemClaims(ShareClassId scId, bytes32 investor, AssetId payoutAssetId) external view returns (uint32);
 
     //----------------------------------------------------------------------------------------------
     // Epoch data access

--- a/src/vaults/interfaces/IVaultManagers.sol
+++ b/src/vaults/interfaces/IVaultManagers.sol
@@ -35,9 +35,7 @@ interface IDepositManager {
     ///         The shares required to fulfill the mint have already been minted and transferred to the escrow on
     ///         fulfillDepositRequest.
     ///         Receiver has to pass all the share token restrictions in order to receive the shares.
-    function mint(IBaseVault vault, uint256 shares, address receiver, address owner)
-        external
-        returns (uint256 assets);
+    function mint(IBaseVault vault, uint256 shares, address receiver, address owner) external returns (uint256 assets);
 
     /// @notice Returns the max amount of assets based on the unclaimed amount of shares after at least one successful
     ///         deposit order fulfillment on the corresponding CP instance.
@@ -118,9 +116,7 @@ interface IRedeemManager {
     ///         on fulfillRedeemRequest.
     ///         The assets required to fulfill the redemption have already been reserved in escrow on
     ///         fulfillRedeemtRequest.
-    function redeem(IBaseVault vault, uint256 shares, address receiver, address owner)
-        external
-        returns (uint256 assets);
+    function redeem(IBaseVault vault, uint256 shares, address receiver, address owner) external returns (uint256 assets);
 
     /// @notice Processes owner's asset withdrawal after the epoch has been executed on the corresponding CP instance
     /// and the redeem order

--- a/test/adapters/unit/AxelarAdapter.t.sol
+++ b/test/adapters/unit/AxelarAdapter.t.sol
@@ -27,7 +27,7 @@ contract MockAxelarGateway is Mock {
 }
 
 contract MockAxelarGasService is Mock {
-    function estimateGasFee(string calldata, string calldata, bytes calldata, uint256, bytes calldata /* params */ )
+    function estimateGasFee(string calldata, string calldata, bytes calldata, uint256, bytes calldata /* params */)
         external
         view
         returns (uint256 gasEstimate)
@@ -169,9 +169,7 @@ contract AxelarAdapterTest is AxelarAdapterTestBase {
         adapter.execute(commandId, AXELAR_CHAIN_ID, validAddress.toAxelarString(), payload);
     }
 
-    function testOutgoingCalls(bytes calldata payload, address invalidOrigin, uint256 gasLimit, address refund)
-        public
-    {
+    function testOutgoingCalls(bytes calldata payload, address invalidOrigin, uint256 gasLimit, address refund) public {
         vm.assume(invalidOrigin != address(GATEWAY));
 
         vm.deal(address(this), 0.1 ether);

--- a/test/adapters/unit/LayerZeroAdapter.t.sol
+++ b/test/adapters/unit/LayerZeroAdapter.t.sol
@@ -193,9 +193,7 @@ contract LayerZeroAdapterTest is LayerZeroAdapterTestBase {
         );
     }
 
-    function testOutgoingCalls(bytes calldata payload, address invalidOrigin, uint128 gasLimit, address refund)
-        public
-    {
+    function testOutgoingCalls(bytes calldata payload, address invalidOrigin, uint128 gasLimit, address refund) public {
         vm.assume(invalidOrigin != address(GATEWAY));
 
         vm.deal(address(this), 0.1 ether);

--- a/test/adapters/unit/WormholeAdapter.t.sol
+++ b/test/adapters/unit/WormholeAdapter.t.sol
@@ -159,9 +159,7 @@ contract WormholeAdapterTest is WormholeAdapterTestBase {
         );
     }
 
-    function testOutgoingCalls(bytes calldata payload, address invalidOrigin, uint256 gasLimit, address refund)
-        public
-    {
+    function testOutgoingCalls(bytes calldata payload, address invalidOrigin, uint256 gasLimit, address refund) public {
         vm.assume(invalidOrigin != address(GATEWAY));
 
         vm.deal(address(this), 0.1 ether);

--- a/test/common/unit/CrosschainBatcher.t.sol
+++ b/test/common/unit/CrosschainBatcher.t.sol
@@ -81,9 +81,9 @@ contract CrosschainBatcherTestWithBatch is CrosschainBatcherTest {
     function testWithCallback() public {
         vm.prank(ANY);
         vm.deal(ANY, PAYMENT);
-        uint256 cost = batcher.execute{value: PAYMENT}(
-            abi.encodeWithSelector(CrosschainBatcherTestWithBatch._success.selector, true, 1)
-        );
+        uint256 cost = batcher.execute{
+            value: PAYMENT
+        }(abi.encodeWithSelector(CrosschainBatcherTestWithBatch._success.selector, true, 1));
         assertEq(cost, COST);
         assertEq(batcher.caller(), address(0));
     }

--- a/test/common/unit/libraries/MessageLib.t.sol
+++ b/test/common/unit/libraries/MessageLib.t.sol
@@ -178,10 +178,7 @@ contract TestMessageLibIdentities is Test {
         assertEq(a.serialize().messageSourceCentrifugeId(), 0);
     }
 
-    function testRecoverTokens(bytes32 target, bytes32 token, uint256 tokenId, bytes32 to, uint256 amount)
-        public
-        pure
-    {
+    function testRecoverTokens(bytes32 target, bytes32 token, uint256 tokenId, bytes32 to, uint256 amount) public pure {
         MessageLib.RecoverTokens memory a =
             MessageLib.RecoverTokens({target: target, token: token, tokenId: tokenId, to: to, amount: amount});
         MessageLib.RecoverTokens memory b = MessageLib.deserializeRecoverTokens(a.serialize());
@@ -218,10 +215,7 @@ contract TestMessageLibIdentities is Test {
         vm.assume(adapterList.length <= 20);
 
         MessageLib.SetPoolAdapters memory a = MessageLib.SetPoolAdapters({
-            poolId: poolId,
-            threshold: threshold,
-            recoveryIndex: recoveryIndex,
-            adapterList: adapterList
+            poolId: poolId, threshold: threshold, recoveryIndex: recoveryIndex, adapterList: adapterList
         });
         MessageLib.SetPoolAdapters memory b = MessageLib.deserializeSetPoolAdapters(a.serialize());
 
@@ -258,13 +252,7 @@ contract TestMessageLibIdentities is Test {
         bytes32 hook
     ) public pure {
         MessageLib.NotifyShareClass memory a = MessageLib.NotifyShareClass({
-            poolId: poolId,
-            scId: scId,
-            name: name,
-            symbol: symbol,
-            decimals: decimals,
-            salt: salt,
-            hook: hook
+            poolId: poolId, scId: scId, name: name, symbol: symbol, decimals: decimals, salt: salt, hook: hook
         });
         MessageLib.NotifyShareClass memory b = MessageLib.deserializeNotifyShareClass(a.serialize());
 
@@ -303,11 +291,7 @@ contract TestMessageLibIdentities is Test {
         pure
     {
         MessageLib.NotifyPricePoolPerAsset memory a = MessageLib.NotifyPricePoolPerAsset({
-            poolId: poolId,
-            scId: scId,
-            assetId: assetId,
-            price: price,
-            timestamp: timestamp
+            poolId: poolId, scId: scId, assetId: assetId, price: price, timestamp: timestamp
         });
         MessageLib.NotifyPricePoolPerAsset memory b = MessageLib.deserializeNotifyPricePoolPerAsset(a.serialize());
 
@@ -482,11 +466,7 @@ contract TestMessageLibIdentities is Test {
         pure
     {
         MessageLib.UpdateVault memory a = MessageLib.UpdateVault({
-            poolId: poolId,
-            scId: scId,
-            assetId: assetId,
-            vaultOrFactory: vaultOrFactory,
-            kind: kind
+            poolId: poolId, scId: scId, assetId: assetId, vaultOrFactory: vaultOrFactory, kind: kind
         });
         MessageLib.UpdateVault memory b = MessageLib.deserializeUpdateVault(a.serialize());
 

--- a/test/common/unit/libraries/RequestCallbackMessageLib.t.sol
+++ b/test/common/unit/libraries/RequestCallbackMessageLib.t.sol
@@ -21,8 +21,9 @@ contract TestRequestCallbackMessageLibIdentities is Test {
     }
 
     function testApprovedDeposits(uint128 assetAmount, uint128 pricePoolPerAsset) public pure {
-        RequestCallbackMessageLib.ApprovedDeposits memory a =
-            RequestCallbackMessageLib.ApprovedDeposits({assetAmount: assetAmount, pricePoolPerAsset: pricePoolPerAsset});
+        RequestCallbackMessageLib.ApprovedDeposits memory a = RequestCallbackMessageLib.ApprovedDeposits({
+            assetAmount: assetAmount, pricePoolPerAsset: pricePoolPerAsset
+        });
         RequestCallbackMessageLib.ApprovedDeposits memory b = a.serialize().deserializeApprovedDeposits();
 
         assertEq(a.assetAmount, b.assetAmount);
@@ -55,9 +56,7 @@ contract TestRequestCallbackMessageLibIdentities is Test {
 
     function testRevokedShares(uint128 assetAmount, uint128 shareAmount, uint128 pricePoolPerShare) public pure {
         RequestCallbackMessageLib.RevokedShares memory a = RequestCallbackMessageLib.RevokedShares({
-            assetAmount: assetAmount,
-            shareAmount: shareAmount,
-            pricePoolPerShare: pricePoolPerShare
+            assetAmount: assetAmount, shareAmount: shareAmount, pricePoolPerShare: pricePoolPerShare
         });
         RequestCallbackMessageLib.RevokedShares memory b = a.serialize().deserializeRevokedShares();
 

--- a/test/hooks/mocks/MockSnapshotHook.sol
+++ b/test/hooks/mocks/MockSnapshotHook.sol
@@ -10,9 +10,9 @@ contract MockSnapshotHook is ISnapshotHook {
     mapping(
         PoolId
             => mapping(
-                ShareClassId
-                    => mapping(uint16 fromCentrifugeId => mapping(uint16 toCentrifugeId => uint256 amountTransferred))
-            )
+            ShareClassId
+                => mapping(uint16 fromCentrifugeId => mapping(uint16 toCentrifugeId => uint256 amountTransferred))
+        )
     ) public transfers;
 
     function onSync(PoolId poolId, ShareClassId scId, uint16 centrifugeId) external {

--- a/test/hooks/unit/BaseTransferHook.t.sol
+++ b/test/hooks/unit/BaseTransferHook.t.sol
@@ -42,7 +42,13 @@ contract TestableBaseTransferHook is BaseTransferHook {
         address deployer
     ) BaseTransferHook(root_, redeemSource_, depositTarget_, crosschainSource_, deployer) {}
 
-    function checkERC20Transfer(address from, address to, uint256, /* value */ HookData calldata hookData)
+    function checkERC20Transfer(
+        address from,
+        address to,
+        uint256,
+        /* value */
+        HookData calldata hookData
+    )
         public
         view
         override
@@ -393,8 +399,9 @@ contract BaseTransferHookTestMember is BaseTransferHookTestBase {
 
 contract BaseTransferHookTestUpdateRestriction is BaseTransferHookTestBase {
     function testUpdateRestrictionMember() public {
-        UpdateRestrictionMessageLib.UpdateRestrictionMember memory memberUpdate = UpdateRestrictionMessageLib
-            .UpdateRestrictionMember({user: bytes32(bytes20(user1)), validUntil: FUTURE_TIMESTAMP});
+        UpdateRestrictionMessageLib.UpdateRestrictionMember memory memberUpdate = UpdateRestrictionMessageLib.UpdateRestrictionMember({
+            user: bytes32(bytes20(user1)), validUntil: FUTURE_TIMESTAMP
+        });
 
         bytes memory payload = UpdateRestrictionMessageLib.serialize(memberUpdate);
 
@@ -444,8 +451,9 @@ contract BaseTransferHookTestUpdateRestriction is BaseTransferHookTestBase {
     }
 
     function testUpdateRestrictionUnauthorized() public {
-        UpdateRestrictionMessageLib.UpdateRestrictionMember memory memberUpdate = UpdateRestrictionMessageLib
-            .UpdateRestrictionMember({user: bytes32(bytes20(user1)), validUntil: FUTURE_TIMESTAMP});
+        UpdateRestrictionMessageLib.UpdateRestrictionMember memory memberUpdate = UpdateRestrictionMessageLib.UpdateRestrictionMember({
+            user: bytes32(bytes20(user1)), validUntil: FUTURE_TIMESTAMP
+        });
 
         bytes memory payload = UpdateRestrictionMessageLib.serialize(memberUpdate);
 

--- a/test/hub/integration/BaseTest.sol
+++ b/test/hub/integration/BaseTest.sol
@@ -77,10 +77,7 @@ contract BaseTest is HubDeployer, Test {
     function setUp() public virtual {
         // Deployment
         CommonInput memory input = CommonInput({
-            centrifugeId: CHAIN_CP,
-            adminSafe: adminSafe,
-            maxBatchGasLimit: uint128(GAS) * 100,
-            version: bytes32(0)
+            centrifugeId: CHAIN_CP, adminSafe: adminSafe, maxBatchGasLimit: uint128(GAS) * 100, version: bytes32(0)
         });
 
         HubActionBatcher batcher = new HubActionBatcher();

--- a/test/hub/mocks/MockVaults.sol
+++ b/test/hub/mocks/MockVaults.sol
@@ -44,25 +44,23 @@ contract MockVaults is Test, Auth, IAdapter {
         handler.handle(
             sourceChainId,
             MessageLib.Request(
-                poolId.raw(),
-                scId.raw(),
-                assetId.raw(),
-                RequestMessageLib.DepositRequest({investor: investor, amount: amount}).serialize()
-            ).serialize()
+                    poolId.raw(),
+                    scId.raw(),
+                    assetId.raw(),
+                    RequestMessageLib.DepositRequest({investor: investor, amount: amount}).serialize()
+                ).serialize()
         );
     }
 
-    function requestRedeem(PoolId poolId, ShareClassId scId, AssetId assetId, bytes32 investor, uint128 amount)
-        public
-    {
+    function requestRedeem(PoolId poolId, ShareClassId scId, AssetId assetId, bytes32 investor, uint128 amount) public {
         handler.handle(
             sourceChainId,
             MessageLib.Request(
-                poolId.raw(),
-                scId.raw(),
-                assetId.raw(),
-                RequestMessageLib.RedeemRequest({investor: investor, amount: amount}).serialize()
-            ).serialize()
+                    poolId.raw(),
+                    scId.raw(),
+                    assetId.raw(),
+                    RequestMessageLib.RedeemRequest({investor: investor, amount: amount}).serialize()
+                ).serialize()
         );
     }
 
@@ -70,11 +68,11 @@ contract MockVaults is Test, Auth, IAdapter {
         handler.handle(
             sourceChainId,
             MessageLib.Request(
-                poolId.raw(),
-                scId.raw(),
-                assetId.raw(),
-                RequestMessageLib.CancelDepositRequest({investor: investor}).serialize()
-            ).serialize()
+                    poolId.raw(),
+                    scId.raw(),
+                    assetId.raw(),
+                    RequestMessageLib.CancelDepositRequest({investor: investor}).serialize()
+                ).serialize()
         );
     }
 
@@ -82,11 +80,11 @@ contract MockVaults is Test, Auth, IAdapter {
         handler.handle(
             sourceChainId,
             MessageLib.Request(
-                poolId.raw(),
-                scId.raw(),
-                assetId.raw(),
-                RequestMessageLib.CancelRedeemRequest({investor: investor}).serialize()
-            ).serialize()
+                    poolId.raw(),
+                    scId.raw(),
+                    assetId.raw(),
+                    RequestMessageLib.CancelRedeemRequest({investor: investor}).serialize()
+                ).serialize()
         );
     }
 
@@ -116,16 +114,16 @@ contract MockVaults is Test, Auth, IAdapter {
         handler.handle(
             sourceChainId,
             MessageLib.UpdateHoldingAmount({
-                poolId: poolId.raw(),
-                scId: scId.raw(),
-                assetId: assetId.raw(),
-                amount: amount,
-                pricePerUnit: pricePoolPerAsset.raw(),
-                timestamp: 0,
-                isIncrease: isIncrease,
-                isSnapshot: isSnapshot,
-                nonce: nonce
-            }).serialize()
+                    poolId: poolId.raw(),
+                    scId: scId.raw(),
+                    assetId: assetId.raw(),
+                    amount: amount,
+                    pricePerUnit: pricePoolPerAsset.raw(),
+                    timestamp: 0,
+                    isIncrease: isIncrease,
+                    isSnapshot: isSnapshot,
+                    nonce: nonce
+                }).serialize()
         );
     }
 
@@ -140,14 +138,14 @@ contract MockVaults is Test, Auth, IAdapter {
         handler.handle(
             sourceChainId,
             MessageLib.UpdateShares({
-                poolId: poolId.raw(),
-                scId: scId.raw(),
-                shares: amount,
-                timestamp: 0,
-                isIssuance: isIssuance,
-                isSnapshot: isSnapshot,
-                nonce: nonce
-            }).serialize()
+                    poolId: poolId.raw(),
+                    scId: scId.raw(),
+                    shares: amount,
+                    timestamp: 0,
+                    isIssuance: isIssuance,
+                    isSnapshot: isSnapshot,
+                    nonce: nonce
+                }).serialize()
         );
     }
 

--- a/test/integration/EndToEnd.t.sol
+++ b/test/integration/EndToEnd.t.sol
@@ -360,7 +360,8 @@ contract EndToEndUtils is EndToEndDeployment {
         vaultAddr = address(spoke.spoke.vault(poolId, shareClassId, assetId, spoke.asyncRequestManager));
         if (vaultAddr == address(0)) {
             vm.startPrank(poolManager);
-            hub.hub.updateVault(
+            hub.hub
+            .updateVault(
                 poolId, shareClassId, assetId, spoke.asyncVaultFactory, VaultUpdateKind.DeployAndLink, EXTRA_GAS
             );
             vm.stopPrank();
@@ -379,9 +380,8 @@ contract EndToEndFlows is EndToEndUtils {
 
     function _updateRestrictionMemberMsg(address addr) internal pure returns (bytes memory) {
         return UpdateRestrictionMessageLib.UpdateRestrictionMember({
-            user: addr.toBytes32(),
-            validUntil: type(uint64).max
-        }).serialize();
+                user: addr.toBytes32(), validUntil: type(uint64).max
+            }).serialize();
     }
 
     function _updateContractSyncDepositMaxReserveMsg(AssetId assetId, uint128 maxReserve)
@@ -390,9 +390,8 @@ contract EndToEndFlows is EndToEndUtils {
         returns (bytes memory)
     {
         return UpdateContractMessageLib.UpdateContractSyncDepositMaxReserve({
-            assetId: assetId.raw(),
-            maxReserve: maxReserve
-        }).serialize();
+                assetId: assetId.raw(), maxReserve: maxReserve
+            }).serialize();
     }
 
     //----------------------------------------------------------------------------------------------
@@ -443,7 +442,8 @@ contract EndToEndFlows is EndToEndUtils {
         hub.hub.notifyPool(poolId, spoke.centrifugeId);
         hub.hub.notifyShareClass(poolId, shareClassId, spoke.centrifugeId, hookAddress.toBytes32());
 
-        hub.hub.initializeHolding(
+        hub.hub
+        .initializeHolding(
             poolId,
             shareClassId,
             assetId,
@@ -453,15 +453,15 @@ contract EndToEndFlows is EndToEndUtils {
             GAIN_ACCOUNT,
             LOSS_ACCOUNT
         );
-        hub.hub.setRequestManager(
+        hub.hub
+        .setRequestManager(
             poolId,
             spoke.centrifugeId,
             IHubRequestManager(hub.batchRequestManager),
             address(spoke.asyncRequestManager).toBytes32()
         );
-        hub.hub.updateBalanceSheetManager(
-            spoke.centrifugeId, poolId, address(spoke.asyncRequestManager).toBytes32(), true
-        );
+        hub.hub
+        .updateBalanceSheetManager(spoke.centrifugeId, poolId, address(spoke.asyncRequestManager).toBytes32(), true);
         hub.hub.updateBalanceSheetManager(spoke.centrifugeId, poolId, address(spoke.syncManager).toBytes32(), true);
         hub.hub.updateBalanceSheetManager(spoke.centrifugeId, poolId, BSM.toBytes32(), true);
 
@@ -619,7 +619,8 @@ contract EndToEndFlows is EndToEndUtils {
         vm.startPrank(poolManager);
         uint32 depositEpochId = hub.batchRequestManager.nowDepositEpoch(shareClassId, assetId);
         D18 pricePoolPerAsset = hub.hub.pricePoolPerAsset(poolId, shareClassId, assetId);
-        hub.hub.callRequestManager(
+        hub.hub
+        .callRequestManager(
             poolId,
             assetId.centrifugeId(),
             abi.encodeCall(
@@ -631,7 +632,8 @@ contract EndToEndFlows is EndToEndUtils {
         vm.startPrank(poolManager);
         uint32 issueEpochId = hub.batchRequestManager.nowIssueEpoch(shareClassId, assetId);
         (, D18 sharePrice) = hub.shareClassManager.metrics(shareClassId);
-        hub.hub.callRequestManager(
+        hub.hub
+        .callRequestManager(
             poolId,
             assetId.centrifugeId(),
             abi.encodeCall(
@@ -652,7 +654,10 @@ contract EndToEndFlows is EndToEndUtils {
     ) internal {
         vm.startPrank(ANY);
         vm.deal(ANY, GAS);
-        hub.batchRequestManager.notifyDeposit{value: GAS}(
+        hub.batchRequestManager
+        .notifyDeposit{
+            value: GAS
+        }(
             poolId,
             shareClassId,
             assetId,
@@ -706,11 +711,13 @@ contract EndToEndFlows is EndToEndUtils {
         // Check if vault already exists (for live tests)
         address existingVault = _getAsyncVault(spoke, poolId, shareClassId, assetId);
         if (existingVault == address(0)) {
-            hub.hub.updateVault(
+            hub.hub
+            .updateVault(
                 poolId, shareClassId, assetId, spoke.syncDepositVaultFactory, VaultUpdateKind.DeployAndLink, EXTRA_GAS
             );
         }
-        hub.hub.updateContract(
+        hub.hub
+        .updateContract(
             poolId,
             shareClassId,
             spoke.centrifugeId,
@@ -785,9 +792,8 @@ contract EndToEndFlows is EndToEndUtils {
         address poolManager
     ) internal {
         vm.startPrank(poolManager);
-        hub.hub.updateRestriction(
-            poolId, shareClassId, spoke.centrifugeId, _updateRestrictionMemberMsg(investor), EXTRA_GAS
-        );
+        hub.hub
+        .updateRestriction(poolId, shareClassId, spoke.centrifugeId, _updateRestrictionMemberMsg(investor), EXTRA_GAS);
     }
 
     function _processAsyncRedeemApproval(
@@ -801,7 +807,8 @@ contract EndToEndFlows is EndToEndUtils {
         vm.startPrank(poolManager);
         uint32 redeemEpochId = hub.batchRequestManager.nowRedeemEpoch(shareClassId, assetId);
         D18 pricePoolPerAsset = hub.hub.pricePoolPerAsset(poolId, shareClassId, assetId);
-        hub.hub.callRequestManager(
+        hub.hub
+        .callRequestManager(
             poolId,
             assetId.centrifugeId(),
             abi.encodeCall(
@@ -812,7 +819,8 @@ contract EndToEndFlows is EndToEndUtils {
 
         uint32 revokeEpochId = hub.batchRequestManager.nowRevokeEpoch(shareClassId, assetId);
         (, D18 sharePrice) = hub.shareClassManager.metrics(shareClassId);
-        hub.hub.callRequestManager(
+        hub.hub
+        .callRequestManager(
             poolId,
             assetId.centrifugeId(),
             abi.encodeCall(
@@ -833,7 +841,10 @@ contract EndToEndFlows is EndToEndUtils {
     ) internal {
         vm.startPrank(ANY);
         vm.deal(ANY, GAS);
-        hub.batchRequestManager.notifyRedeem{value: GAS}(
+        hub.batchRequestManager
+        .notifyRedeem{
+            value: GAS
+        }(
             poolId,
             shareClassId,
             assetId,

--- a/test/integration/Integration.t.sol
+++ b/test/integration/Integration.t.sol
@@ -110,9 +110,8 @@ contract CentrifugeIntegrationTestWithUtils is CentrifugeIntegrationTest {
         returns (bytes memory)
     {
         return UpdateContractMessageLib.UpdateContractSyncDepositMaxReserve({
-            assetId: assetId.raw(),
-            maxReserve: maxReserve
-        }).serialize();
+                assetId: assetId.raw(), maxReserve: maxReserve
+            }).serialize();
     }
 }
 

--- a/test/integration/MaliciousVaultAttack.t.sol
+++ b/test/integration/MaliciousVaultAttack.t.sol
@@ -82,7 +82,8 @@ contract MaliciousVaultAttackTest is EndToEndFlows {
 
         /// A malicious vault can be added but will not acquire any privilege
         vm.startPrank(FM);
-        h.hub.updateVault(
+        h.hub
+        .updateVault(
             POOL_A, SC_1, s.usdcId, bytes32(bytes20(address(maliciousFactory))), VaultUpdateKind.DeployAndLink, 0
         );
 

--- a/test/integration/ThreeChainEndToEnd.t.sol
+++ b/test/integration/ThreeChainEndToEnd.t.sol
@@ -28,7 +28,6 @@ enum CrossChainDirection {
     WithIntermediaryHub, // C -> A -> B (Hub is on A)
     FromHub, // C => A -> B (Hub is on A)
     ToHub // C -> A => B (Hub is on A)
-
 }
 
 /// @title  Three Chain End-to-End Test
@@ -129,9 +128,10 @@ contract ThreeChainEndToEndDeployment is EndToEndFlows {
         }
 
         vm.prank(INVESTOR_A);
-        sB.spoke.crosschainTransferShares{value: GAS}(
-            sC.centrifugeId, POOL_A, SC_1, INVESTOR_A.toBytes32(), amount, HOOK_GAS, HOOK_GAS
-        );
+        sB.spoke
+        .crosschainTransferShares{
+            value: GAS
+        }(sC.centrifugeId, POOL_A, SC_1, INVESTOR_A.toBytes32(), amount, HOOK_GAS, HOOK_GAS);
         assertEq(shareTokenB.balanceOf(INVESTOR_A), 0, "Shares should be burned on chain B");
         assertEq(
             h.snapshotHook.transfers(POOL_A, SC_1, sB.centrifugeId, sC.centrifugeId), amount, "Snapshot hook not called"
@@ -144,11 +144,11 @@ contract ThreeChainEndToEndDeployment is EndToEndFlows {
         if (direction == CrossChainDirection.WithIntermediaryHub) {
             assertEq(shareTokenC.balanceOf(INVESTOR_A), 0, "Share transfer not executed due to unpaid message");
             bytes memory message = MessageLib.ExecuteTransferShares({
-                poolId: PoolId.unwrap(POOL_A),
-                scId: ShareClassId.unwrap(SC_1),
-                receiver: INVESTOR_A.toBytes32(),
-                amount: amount
-            }).serialize();
+                    poolId: PoolId.unwrap(POOL_A),
+                    scId: ShareClassId.unwrap(SC_1),
+                    receiver: INVESTOR_A.toBytes32(),
+                    amount: amount
+                }).serialize();
 
             // A: Repay for unpaid ExecuteTransferShares message on A to trigger sending it to C if A != C
             vm.expectEmit(true, false, false, false);

--- a/test/managers/integration/MerkleProofManager.t.sol
+++ b/test/managers/integration/MerkleProofManager.t.sol
@@ -64,9 +64,8 @@ abstract contract MerkleProofManagerBaseTest is BaseTest {
             POOL_A,
             defaultTypedShareClassId,
             UpdateRestrictionMessageLib.UpdateRestrictionMember({
-                user: address(this).toBytes32(),
-                validUntil: MAX_UINT64
-            }).serialize()
+                    user: address(this).toBytes32(), validUntil: MAX_UINT64
+                }).serialize()
         );
 
         manager = new MerkleProofManager(POOL_A, address(spoke));
@@ -369,7 +368,9 @@ contract MerkleProofManagerFailureTests is MerkleProofManagerBaseTest {
                     decoder: address(decoder),
                     target: address(balanceSheet),
                     selector: BalanceSheet.withdraw.selector,
-                    addresses: abi.encodePacked(POOL_A, defaultTypedShareClassId, address(erc20), makeAddr("otherTarget")),
+                    addresses: abi.encodePacked(
+                        POOL_A, defaultTypedShareClassId, address(erc20), makeAddr("otherTarget")
+                    ),
                     valueNonZero: false
                 }),
                 proofs[0]
@@ -476,7 +477,12 @@ contract MerkleProofManagerSuccessTests is MerkleProofManagerBaseTest {
             decoder: address(decoder),
             target: address(balanceSheet),
             targetData: abi.encodeWithSelector(
-                BalanceSheet.deposit.selector, POOL_A, defaultTypedShareClassId, address(erc20), erc20TokenId, depositAmount
+                BalanceSheet.deposit.selector,
+                POOL_A,
+                defaultTypedShareClassId,
+                address(erc20),
+                erc20TokenId,
+                depositAmount
             ),
             value: 0,
             proof: proofs[2]

--- a/test/managers/integration/OnOfframpManager.t.sol
+++ b/test/managers/integration/OnOfframpManager.t.sol
@@ -60,9 +60,8 @@ abstract contract OnOfframpManagerBaseTest is BaseTest {
             POOL_A,
             defaultTypedShareClassId,
             UpdateRestrictionMessageLib.UpdateRestrictionMember({
-                user: address(this).toBytes32(),
-                validUntil: MAX_UINT64
-            }).serialize()
+                    user: address(this).toBytes32(), validUntil: MAX_UINT64
+                }).serialize()
         );
 
         factory = new OnOfframpManagerFactory(address(contractUpdater), balanceSheet);
@@ -89,11 +88,8 @@ contract OnOfframpManagerIntegrationTest is OnOfframpManagerBaseTest {
             POOL_A,
             defaultTypedShareClassId,
             UpdateContractMessageLib.UpdateContractUpdateAddress({
-                kind: bytes32("onramp"),
-                assetId: defaultAssetId,
-                what: bytes32(""),
-                isEnabled: true
-            }).serialize()
+                    kind: bytes32("onramp"), assetId: defaultAssetId, what: bytes32(""), isEnabled: true
+                }).serialize()
         );
 
         // Enable relayer
@@ -102,11 +98,8 @@ contract OnOfframpManagerIntegrationTest is OnOfframpManagerBaseTest {
             POOL_A,
             defaultTypedShareClassId,
             UpdateContractMessageLib.UpdateContractUpdateAddress({
-                kind: bytes32("relayer"),
-                assetId: 0,
-                what: relayer.toBytes32(),
-                isEnabled: true
-            }).serialize()
+                    kind: bytes32("relayer"), assetId: 0, what: relayer.toBytes32(), isEnabled: true
+                }).serialize()
         );
 
         // Enable offramp destination
@@ -115,11 +108,8 @@ contract OnOfframpManagerIntegrationTest is OnOfframpManagerBaseTest {
             POOL_A,
             defaultTypedShareClassId,
             UpdateContractMessageLib.UpdateContractUpdateAddress({
-                kind: bytes32("offramp"),
-                assetId: defaultAssetId,
-                what: receiver.toBytes32(),
-                isEnabled: true
-            }).serialize()
+                    kind: bytes32("offramp"), assetId: defaultAssetId, what: receiver.toBytes32(), isEnabled: true
+                }).serialize()
         );
 
         // Set manager permissions

--- a/test/managers/unit/OnOfframpManager.t.sol
+++ b/test/managers/unit/OnOfframpManager.t.sol
@@ -89,8 +89,9 @@ contract OnOfframpManagerTest is Test {
     }
 
     function _mockBalanceSheetDeposit(uint128 amount, bool shouldRevert, bytes memory revertData) internal {
-        bytes memory callData =
-            abi.encodeWithSelector(IBalanceSheet.deposit.selector, POOL_A, SC_1, address(erc20), ERC20_TOKEN_ID, amount);
+        bytes memory callData = abi.encodeWithSelector(
+            IBalanceSheet.deposit.selector, POOL_A, SC_1, address(erc20), ERC20_TOKEN_ID, amount
+        );
 
         if (shouldRevert) {
             vm.mockCallRevert(address(balanceSheet), callData, revertData);
@@ -135,10 +136,7 @@ contract OnOfframpManagerTest is Test {
             SC_1,
             UpdateContractMessageLib.serialize(
                 UpdateContractMessageLib.UpdateContractUpdateAddress({
-                    kind: bytes32("onramp"),
-                    assetId: DEFAULT_ASSET_ID,
-                    what: bytes32(""),
-                    isEnabled: true
+                    kind: bytes32("onramp"), assetId: DEFAULT_ASSET_ID, what: bytes32(""), isEnabled: true
                 })
             )
         );
@@ -151,10 +149,7 @@ contract OnOfframpManagerTest is Test {
             SC_1,
             UpdateContractMessageLib.serialize(
                 UpdateContractMessageLib.UpdateContractUpdateAddress({
-                    kind: bytes32("relayer"),
-                    assetId: 0,
-                    what: relayer_.toBytes32(),
-                    isEnabled: true
+                    kind: bytes32("relayer"), assetId: 0, what: relayer_.toBytes32(), isEnabled: true
                 })
             )
         );
@@ -167,10 +162,7 @@ contract OnOfframpManagerTest is Test {
             SC_1,
             UpdateContractMessageLib.serialize(
                 UpdateContractMessageLib.UpdateContractUpdateAddress({
-                    kind: bytes32("offramp"),
-                    assetId: DEFAULT_ASSET_ID,
-                    what: receiver_.toBytes32(),
-                    isEnabled: true
+                    kind: bytes32("offramp"), assetId: DEFAULT_ASSET_ID, what: receiver_.toBytes32(), isEnabled: true
                 })
             )
         );
@@ -183,10 +175,7 @@ contract OnOfframpManagerTest is Test {
             SC_1,
             UpdateContractMessageLib.serialize(
                 UpdateContractMessageLib.UpdateContractUpdateAddress({
-                    kind: bytes32("offramp"),
-                    assetId: DEFAULT_ASSET_ID,
-                    what: receiver_.toBytes32(),
-                    isEnabled: false
+                    kind: bytes32("offramp"), assetId: DEFAULT_ASSET_ID, what: receiver_.toBytes32(), isEnabled: false
                 })
             )
         );
@@ -206,10 +195,7 @@ contract OnOfframpManagerUpdateContractFailureTests is OnOfframpManagerTest {
             SC_1,
             UpdateContractMessageLib.serialize(
                 UpdateContractMessageLib.UpdateContractUpdateAddress({
-                    kind: bytes32("onramp"),
-                    assetId: DEFAULT_ASSET_ID,
-                    what: bytes32(""),
-                    isEnabled: true
+                    kind: bytes32("onramp"), assetId: DEFAULT_ASSET_ID, what: bytes32(""), isEnabled: true
                 })
             )
         );
@@ -223,10 +209,7 @@ contract OnOfframpManagerUpdateContractFailureTests is OnOfframpManagerTest {
             SC_1,
             UpdateContractMessageLib.serialize(
                 UpdateContractMessageLib.UpdateContractUpdateAddress({
-                    kind: bytes32("onramp"),
-                    assetId: DEFAULT_ASSET_ID,
-                    what: bytes32(""),
-                    isEnabled: true
+                    kind: bytes32("onramp"), assetId: DEFAULT_ASSET_ID, what: bytes32(""), isEnabled: true
                 })
             )
         );
@@ -242,10 +225,7 @@ contract OnOfframpManagerUpdateContractFailureTests is OnOfframpManagerTest {
             wrongScId,
             UpdateContractMessageLib.serialize(
                 UpdateContractMessageLib.UpdateContractUpdateAddress({
-                    kind: bytes32("onramp"),
-                    assetId: DEFAULT_ASSET_ID,
-                    what: bytes32(""),
-                    isEnabled: true
+                    kind: bytes32("onramp"), assetId: DEFAULT_ASSET_ID, what: bytes32(""), isEnabled: true
                 })
             )
         );
@@ -264,10 +244,7 @@ contract OnOfframpManagerUpdateContractFailureTests is OnOfframpManagerTest {
             SC_1,
             UpdateContractMessageLib.serialize(
                 UpdateContractMessageLib.UpdateContractUpdateAddress({
-                    kind: bytes32("onramp"),
-                    assetId: DEFAULT_ASSET_ID,
-                    what: bytes32(""),
-                    isEnabled: true
+                    kind: bytes32("onramp"), assetId: DEFAULT_ASSET_ID, what: bytes32(""), isEnabled: true
                 })
             )
         );
@@ -286,10 +263,7 @@ contract OnOfframpManagerUpdateContractFailureTests is OnOfframpManagerTest {
             SC_1,
             UpdateContractMessageLib.serialize(
                 UpdateContractMessageLib.UpdateContractUpdateAddress({
-                    kind: bytes32("offramp"),
-                    assetId: DEFAULT_ASSET_ID,
-                    what: receiver.toBytes32(),
-                    isEnabled: true
+                    kind: bytes32("offramp"), assetId: DEFAULT_ASSET_ID, what: receiver.toBytes32(), isEnabled: true
                 })
             )
         );
@@ -303,10 +277,7 @@ contract OnOfframpManagerUpdateContractFailureTests is OnOfframpManagerTest {
             SC_1,
             UpdateContractMessageLib.serialize(
                 UpdateContractMessageLib.UpdateContractUpdateAddress({
-                    kind: bytes32("unknown"),
-                    assetId: DEFAULT_ASSET_ID,
-                    what: bytes32(""),
-                    isEnabled: true
+                    kind: bytes32("unknown"), assetId: DEFAULT_ASSET_ID, what: bytes32(""), isEnabled: true
                 })
             )
         );
@@ -383,10 +354,7 @@ contract OnOfframpManagerDepositSuccessTests is OnOfframpManagerTest {
             SC_1,
             UpdateContractMessageLib.serialize(
                 UpdateContractMessageLib.UpdateContractUpdateAddress({
-                    kind: bytes32("onramp"),
-                    assetId: DEFAULT_ASSET_ID,
-                    what: bytes32(""),
-                    isEnabled: false
+                    kind: bytes32("onramp"), assetId: DEFAULT_ASSET_ID, what: bytes32(""), isEnabled: false
                 })
             )
         );

--- a/test/misc/mocks/MockERC6909.sol
+++ b/test/misc/mocks/MockERC6909.sol
@@ -12,11 +12,11 @@ contract MockERC6909 is IERC6909MetadataExt, IERC6909Fungible {
         return uint8(tokenId);
     }
 
-    function name(uint256 /*tokenId*/ ) external pure returns (string memory) {
+    function name(uint256 /*tokenId*/) external pure returns (string memory) {
         return "mocked name";
     }
 
-    function symbol(uint256 /*tokenId*/ ) external pure returns (string memory) {
+    function symbol(uint256 /*tokenId*/) external pure returns (string memory) {
         return "mocked symbol";
     }
 

--- a/test/misc/unit/EIP712Lib.t.sol
+++ b/test/misc/unit/EIP712Lib.t.sol
@@ -10,8 +10,9 @@ contract EIP712LibTest is Test {
         bytes32 nameHash = keccak256(bytes("TestContract"));
         bytes32 versionHash = keccak256(bytes("1"));
 
-        bytes32 expectedDomainSeparator =
-            keccak256(abi.encode(EIP712Lib.EIP712_DOMAIN_TYPEHASH, nameHash, versionHash, block.chainid, address(this)));
+        bytes32 expectedDomainSeparator = keccak256(
+            abi.encode(EIP712Lib.EIP712_DOMAIN_TYPEHASH, nameHash, versionHash, block.chainid, address(this))
+        );
 
         bytes32 calculatedDomainSeparator = EIP712Lib.calculateDomainSeparator(nameHash, versionHash);
         assertEq(calculatedDomainSeparator, expectedDomainSeparator);

--- a/test/misc/unit/libraries/PricingLib.t.sol
+++ b/test/misc/unit/libraries/PricingLib.t.sol
@@ -192,8 +192,9 @@ contract ConvertWithReciprocalPriceTest is PricingLibBaseTest {
         uint256 expectedUp = MathLib.mulDiv(
             baseAmount * 10 ** quoteDecimals, 1e18, 10 ** baseDecimals * price.raw(), MathLib.Rounding.Up
         );
-        uint256 result =
-            PricingLib.convertWithReciprocalPrice(baseAmount, baseDecimals, quoteDecimals, price, MathLib.Rounding.Down);
+        uint256 result = PricingLib.convertWithReciprocalPrice(
+            baseAmount, baseDecimals, quoteDecimals, price, MathLib.Rounding.Down
+        );
         assertGe(result, underestimate, "convertWithReciprocalPrice should be at least as large as underestimate");
         assertEq(result, expectedDown, "convertWithReciprocalPrice failed");
         assertApproxEqAbs(expectedDown, expectedUp, 1, "Rounding diff should be at most one");
@@ -208,8 +209,9 @@ contract ConvertWithReciprocalPriceEdgeCasesTest is PricingLibBaseTest {
 
     function testEdgeCaseWithReciprocalPriceMinBaseAmount() public view {
         D18 price = d18(1e18 - 1);
-        uint256 result =
-            PricingLib.convertWithReciprocalPrice(baseAmount, baseDecimals, quoteDecimals, price, MathLib.Rounding.Down);
+        uint256 result = PricingLib.convertWithReciprocalPrice(
+            baseAmount, baseDecimals, quoteDecimals, price, MathLib.Rounding.Down
+        );
         uint256 expected = price.reciprocalMulUint256(amountWithoutPrice, MathLib.Rounding.Down);
         assertEq(result, expected);
         assertEq(expected, amountWithoutPrice);
@@ -217,8 +219,9 @@ contract ConvertWithReciprocalPriceEdgeCasesTest is PricingLibBaseTest {
 
     function testEdgeCaseWithReciprocalPriceSmallestPrice() public view {
         D18 price = d18(1);
-        uint256 result =
-            PricingLib.convertWithReciprocalPrice(baseAmount, baseDecimals, quoteDecimals, price, MathLib.Rounding.Down);
+        uint256 result = PricingLib.convertWithReciprocalPrice(
+            baseAmount, baseDecimals, quoteDecimals, price, MathLib.Rounding.Down
+        );
         uint256 expected = price.reciprocalMulUint256(amountWithoutPrice, MathLib.Rounding.Down);
         assertEq(result, expected);
         assertEq(expected, 1e28);
@@ -226,13 +229,15 @@ contract ConvertWithReciprocalPriceEdgeCasesTest is PricingLibBaseTest {
 
     function testEdgeCaseWithReciprocalPriceSmallestPriceToZero() public view {
         D18 price = d18(1e28 + 1);
-        uint256 result =
-            PricingLib.convertWithReciprocalPrice(baseAmount, baseDecimals, quoteDecimals, price, MathLib.Rounding.Down);
+        uint256 result = PricingLib.convertWithReciprocalPrice(
+            baseAmount, baseDecimals, quoteDecimals, price, MathLib.Rounding.Down
+        );
         assertEq(result, 0, "Reciprocal rounding edge case (smallest price to result in 0) failed");
 
         price = d18(1e28);
-        result =
-            PricingLib.convertWithReciprocalPrice(baseAmount, baseDecimals, quoteDecimals, price, MathLib.Rounding.Down);
+        result = PricingLib.convertWithReciprocalPrice(
+            baseAmount, baseDecimals, quoteDecimals, price, MathLib.Rounding.Down
+        );
         assertEq(result, 1, "Reciprocal rounding edge case (smallest price to result in 1) failed");
     }
 
@@ -615,12 +620,10 @@ contract PoolToAssetAmountTest is PricingLibBaseTest {
             uint256(poolAmount).mulDiv(10 ** assetDecimals, 10 ** POOL_DECIMALS, MathLib.Rounding.Down),
             MathLib.Rounding.Down
         );
-        uint256 expectedDown = uint256(poolAmount).mulDiv(
-            10 ** (assetDecimals + 18), 10 ** POOL_DECIMALS * pricePoolPerAsset.raw(), MathLib.Rounding.Down
-        );
-        uint256 expectedUp = uint256(poolAmount).mulDiv(
-            10 ** (assetDecimals + 18), 10 ** POOL_DECIMALS * pricePoolPerAsset.raw(), MathLib.Rounding.Up
-        );
+        uint256 expectedDown = uint256(poolAmount)
+            .mulDiv(10 ** (assetDecimals + 18), 10 ** POOL_DECIMALS * pricePoolPerAsset.raw(), MathLib.Rounding.Down);
+        uint256 expectedUp = uint256(poolAmount)
+            .mulDiv(10 ** (assetDecimals + 18), 10 ** POOL_DECIMALS * pricePoolPerAsset.raw(), MathLib.Rounding.Up);
 
         uint256 result = PricingLib.poolToAssetAmount(
             poolAmount, POOL_DECIMALS, assetDecimals, pricePoolPerAsset, MathLib.Rounding.Down
@@ -672,7 +675,9 @@ contract CalcPriceAssetPerShareTest is Test {
     function _assertPrice(uint256 shares, uint256 assets, uint128 expected, MathLib.Rounding rounding) internal view {
         D18 calculated = shares == 0
             ? d18(0)
-            : PricingLib.calculatePriceAssetPerShare(shareToken, shares.toUint128(), asset, 0, assets.toUint128(), rounding);
+            : PricingLib.calculatePriceAssetPerShare(
+                shareToken, shares.toUint128(), asset, 0, assets.toUint128(), rounding
+            );
         assertEq(calculated.raw(), expected);
     }
 

--- a/test/spoke/integration/AssetShareConversion.t.sol
+++ b/test/spoke/integration/AssetShareConversion.t.sol
@@ -42,8 +42,8 @@ contract AssetShareConversionTest is BaseTest {
         assertEq(shareToken.totalSupply(), 100000000000000000000);
         assertEq(vault.totalAssets(), 100000000);
         assertEq(vault.convertToShares(100000000), 100000000000000000000); // share class tokens have 12 more decimals
-            // than
-            // assets
+        // than
+        // assets
         assertEq(vault.convertToAssets(vault.convertToShares(100000000000000000000)), 100000000000000000000);
         assertEq(vault.pricePerShare(), 1e6);
 
@@ -52,8 +52,8 @@ contract AssetShareConversionTest is BaseTest {
 
         assertEq(vault.totalAssets(), 120000000);
         assertEq(vault.convertToShares(120000000), 100000000000000000000); // share class tokens have 12 more decimals
-            // than
-            // assets
+        // than
+        // assets
         assertEq(vault.convertToAssets(vault.convertToShares(120000000000000000000)), 120000000000000000000);
         assertEq(vault.pricePerShare(), 1.2e6);
 
@@ -64,7 +64,7 @@ contract AssetShareConversionTest is BaseTest {
         //       we now have 2 * 1.2 = 2.4 units of assets per share
         assertEq(vault.totalAssets(), 240000000);
         assertEq(vault.convertToShares(240000000), 100000000000000000000); // share class tokens have 12 more decimals
-            // than
+        // than
         // assets
         assertEq(vault.convertToAssets(vault.convertToShares(240000000000000000000)), 240000000000000000000);
         assertEq(vault.pricePerShare(), 2.4e6);

--- a/test/spoke/integration/BaseTest.sol
+++ b/test/spoke/integration/BaseTest.sol
@@ -25,7 +25,9 @@ import {IVaultFactory} from "../../../src/spoke/factories/interfaces/IVaultFacto
 import {AsyncVault} from "../../../src/vaults/AsyncVault.sol";
 
 import {
-    ExtendedSpokeDeployer, ExtendedSpokeActionBatcher, CommonInput
+    ExtendedSpokeDeployer,
+    ExtendedSpokeActionBatcher,
+    CommonInput
 } from "../../../script/ExtendedSpokeDeployer.s.sol";
 
 import {MockCentrifugeChain} from "../mocks/MockCentrifugeChain.sol";

--- a/test/spoke/mocks/MockCentrifugeChain.sol
+++ b/test/spoke/mocks/MockCentrifugeChain.sol
@@ -52,12 +52,12 @@ contract MockCentrifugeChain is Test {
 
         execute(
             MessageLib.UpdateVault({
-                poolId: poolId,
-                scId: scId,
-                assetId: vaultDetails.assetId.raw(),
-                vaultOrFactory: bytes32(bytes20(vault)),
-                kind: uint8(VaultUpdateKind.Unlink)
-            }).serialize()
+                    poolId: poolId,
+                    scId: scId,
+                    assetId: vaultDetails.assetId.raw(),
+                    vaultOrFactory: bytes32(bytes20(vault)),
+                    kind: uint8(VaultUpdateKind.Unlink)
+                }).serialize()
         );
     }
 
@@ -66,12 +66,12 @@ contract MockCentrifugeChain is Test {
 
         execute(
             MessageLib.UpdateVault({
-                poolId: poolId,
-                scId: scId,
-                vaultOrFactory: bytes32(bytes20(vault)),
-                assetId: vaultDetails.assetId.raw(),
-                kind: uint8(VaultUpdateKind.Link)
-            }).serialize()
+                    poolId: poolId,
+                    scId: scId,
+                    vaultOrFactory: bytes32(bytes20(vault)),
+                    assetId: vaultDetails.assetId.raw(),
+                    kind: uint8(VaultUpdateKind.Link)
+                }).serialize()
         );
     }
 
@@ -80,14 +80,13 @@ contract MockCentrifugeChain is Test {
 
         execute(
             MessageLib.UpdateContract({
-                poolId: poolId,
-                scId: scId,
-                target: bytes32(bytes20(address(syncManager))),
-                payload: UpdateContractMessageLib.UpdateContractSyncDepositMaxReserve({
-                    assetId: vaultDetails.assetId.raw(),
-                    maxReserve: maxReserve
+                    poolId: poolId,
+                    scId: scId,
+                    target: bytes32(bytes20(address(syncManager))),
+                    payload: UpdateContractMessageLib.UpdateContractSyncDepositMaxReserve({
+                            assetId: vaultDetails.assetId.raw(), maxReserve: maxReserve
+                        }).serialize()
                 }).serialize()
-            }).serialize()
         );
     }
 
@@ -103,14 +102,14 @@ contract MockCentrifugeChain is Test {
     ) public {
         execute(
             MessageLib.NotifyShareClass({
-                poolId: poolId,
-                scId: scId,
-                name: tokenName,
-                symbol: tokenSymbol.toBytes32(),
-                decimals: decimals,
-                salt: salt,
-                hook: bytes32(bytes20(hook))
-            }).serialize()
+                    poolId: poolId,
+                    scId: scId,
+                    name: tokenName,
+                    symbol: tokenSymbol.toBytes32(),
+                    decimals: decimals,
+                    salt: salt,
+                    hook: bytes32(bytes20(hook))
+                }).serialize()
         );
 
         updateMemberPoolEscrow(poolId, scId);
@@ -135,14 +134,14 @@ contract MockCentrifugeChain is Test {
     ) public {
         execute(
             MessageLib.NotifyShareClass({
-                poolId: poolId,
-                scId: scId,
-                name: tokenName,
-                symbol: tokenSymbol.toBytes32(),
-                decimals: decimals,
-                salt: keccak256(abi.encodePacked(poolId, scId)),
-                hook: bytes32(bytes20(hook))
-            }).serialize()
+                    poolId: poolId,
+                    scId: scId,
+                    name: tokenName,
+                    symbol: tokenSymbol.toBytes32(),
+                    decimals: decimals,
+                    salt: keccak256(abi.encodePacked(poolId, scId)),
+                    hook: bytes32(bytes20(hook))
+                }).serialize()
         );
 
         updateMemberPoolEscrow(poolId, scId);
@@ -151,10 +150,11 @@ contract MockCentrifugeChain is Test {
     function updateMember(uint64 poolId, bytes16 scId, address user, uint64 validUntil) public {
         execute(
             MessageLib.UpdateRestriction({
-                poolId: poolId,
-                scId: scId,
-                payload: UpdateRestrictionMessageLib.UpdateRestrictionMember(user.toBytes32(), validUntil).serialize()
-            }).serialize()
+                    poolId: poolId,
+                    scId: scId,
+                    payload: UpdateRestrictionMessageLib.UpdateRestrictionMember(user.toBytes32(), validUntil)
+                        .serialize()
+                }).serialize()
         );
     }
 
@@ -163,11 +163,8 @@ contract MockCentrifugeChain is Test {
     {
         execute(
             MessageLib.NotifyShareMetadata({
-                poolId: poolId,
-                scId: scId,
-                name: tokenName,
-                symbol: tokenSymbol.toBytes32()
-            }).serialize()
+                    poolId: poolId, scId: scId, name: tokenName, symbol: tokenSymbol.toBytes32()
+                }).serialize()
         );
     }
 
@@ -187,12 +184,8 @@ contract MockCentrifugeChain is Test {
     {
         execute(
             MessageLib.NotifyPricePoolPerAsset({
-                poolId: poolId,
-                scId: scId,
-                assetId: assetId,
-                price: price,
-                timestamp: computedAt
-            }).serialize()
+                    poolId: poolId, scId: scId, assetId: assetId, price: price, timestamp: computedAt
+                }).serialize()
         );
     }
 
@@ -207,32 +200,32 @@ contract MockCentrifugeChain is Test {
     function freeze(uint64 poolId, bytes16 scId, address user) public {
         execute(
             MessageLib.UpdateRestriction({
-                poolId: poolId,
-                scId: scId,
-                payload: UpdateRestrictionMessageLib.UpdateRestrictionFreeze(user.toBytes32()).serialize()
-            }).serialize()
+                    poolId: poolId,
+                    scId: scId,
+                    payload: UpdateRestrictionMessageLib.UpdateRestrictionFreeze(user.toBytes32()).serialize()
+                }).serialize()
         );
     }
 
     function unfreeze(uint64 poolId, bytes16 scId, address user) public {
         execute(
             MessageLib.UpdateRestriction({
-                poolId: poolId,
-                scId: scId,
-                payload: UpdateRestrictionMessageLib.UpdateRestrictionUnfreeze(user.toBytes32()).serialize()
-            }).serialize()
+                    poolId: poolId,
+                    scId: scId,
+                    payload: UpdateRestrictionMessageLib.UpdateRestrictionUnfreeze(user.toBytes32()).serialize()
+                }).serialize()
         );
     }
 
     function recoverTokens(address target, address token, uint256 tokenId, address to, uint256 amount) public {
         execute(
             MessageLib.RecoverTokens({
-                target: bytes32(bytes20(target)),
-                token: bytes32(bytes20(token)),
-                tokenId: tokenId,
-                to: bytes32(bytes20(to)),
-                amount: amount
-            }).serialize()
+                    target: bytes32(bytes20(target)),
+                    token: bytes32(bytes20(token)),
+                    tokenId: tokenId,
+                    to: bytes32(bytes20(to)),
+                    amount: amount
+                }).serialize()
         );
     }
 
@@ -252,16 +245,16 @@ contract MockCentrifugeChain is Test {
 
         execute(
             MessageLib.RequestCallback(
-                poolId,
-                scId,
-                assetId,
-                RequestCallbackMessageLib.FulfilledDepositRequest({
-                    investor: investor,
-                    fulfilledAssetAmount: fulfilledAssetAmount,
-                    fulfilledShareAmount: fulfilledShareAmount,
-                    cancelledAssetAmount: cancelledAssetAmount
-                }).serialize()
-            ).serialize()
+                    poolId,
+                    scId,
+                    assetId,
+                    RequestCallbackMessageLib.FulfilledDepositRequest({
+                            investor: investor,
+                            fulfilledAssetAmount: fulfilledAssetAmount,
+                            fulfilledShareAmount: fulfilledShareAmount,
+                            cancelledAssetAmount: cancelledAssetAmount
+                        }).serialize()
+                ).serialize()
         );
     }
 
@@ -279,16 +272,16 @@ contract MockCentrifugeChain is Test {
         isRevokedShares(poolId, scId, assetId, fulfilledAssetAmount, fulfilledShareAmount, d18(1, 1));
         execute(
             MessageLib.RequestCallback(
-                poolId,
-                scId,
-                assetId,
-                RequestCallbackMessageLib.FulfilledRedeemRequest({
-                    investor: investor,
-                    fulfilledAssetAmount: fulfilledAssetAmount,
-                    fulfilledShareAmount: fulfilledShareAmount,
-                    cancelledShareAmount: cancelledShareAmount
-                }).serialize()
-            ).serialize()
+                    poolId,
+                    scId,
+                    assetId,
+                    RequestCallbackMessageLib.FulfilledRedeemRequest({
+                            investor: investor,
+                            fulfilledAssetAmount: fulfilledAssetAmount,
+                            fulfilledShareAmount: fulfilledShareAmount,
+                            cancelledShareAmount: cancelledShareAmount
+                        }).serialize()
+                ).serialize()
         );
     }
 
@@ -298,14 +291,13 @@ contract MockCentrifugeChain is Test {
     {
         execute(
             MessageLib.RequestCallback(
-                poolId,
-                scId,
-                assetId,
-                RequestCallbackMessageLib.ApprovedDeposits({
-                    assetAmount: assets,
-                    pricePoolPerAsset: pricePoolPerAsset.raw()
-                }).serialize()
-            ).serialize()
+                    poolId,
+                    scId,
+                    assetId,
+                    RequestCallbackMessageLib.ApprovedDeposits({
+                            assetAmount: assets, pricePoolPerAsset: pricePoolPerAsset.raw()
+                        }).serialize()
+                ).serialize()
         );
     }
 
@@ -315,12 +307,13 @@ contract MockCentrifugeChain is Test {
     {
         execute(
             MessageLib.RequestCallback(
-                poolId,
-                scId,
-                assetId,
-                RequestCallbackMessageLib.IssuedShares({shareAmount: shares, pricePoolPerShare: pricePoolPerShare.raw()})
-                    .serialize()
-            ).serialize()
+                    poolId,
+                    scId,
+                    assetId,
+                    RequestCallbackMessageLib.IssuedShares({
+                            shareAmount: shares, pricePoolPerShare: pricePoolPerShare.raw()
+                        }).serialize()
+                ).serialize()
         );
     }
 
@@ -335,15 +328,13 @@ contract MockCentrifugeChain is Test {
     ) public {
         execute(
             MessageLib.RequestCallback(
-                poolId,
-                scId,
-                assetId,
-                RequestCallbackMessageLib.RevokedShares({
-                    assetAmount: assets,
-                    shareAmount: shareAmount,
-                    pricePoolPerShare: pricePoolPerShare.raw()
-                }).serialize()
-            ).serialize()
+                    poolId,
+                    scId,
+                    assetId,
+                    RequestCallbackMessageLib.RevokedShares({
+                            assetAmount: assets, shareAmount: shareAmount, pricePoolPerShare: pricePoolPerShare.raw()
+                        }).serialize()
+                ).serialize()
         );
     }
 

--- a/test/spoke/unit/BalanceSheet.t.sol
+++ b/test/spoke/unit/BalanceSheet.t.sol
@@ -164,10 +164,7 @@ contract BalanceSheetTest is Test {
                 SC_1,
                 assetId,
                 ISpokeMessageSender.UpdateData({
-                    netAmount: amount,
-                    isIncrease: isDeposit,
-                    isSnapshot: isSnapshot,
-                    nonce: nonce
+                    netAmount: amount, isIncrease: isDeposit, isSnapshot: isSnapshot, nonce: nonce
                 }),
                 price,
                 EXTRA_GAS
@@ -184,10 +181,7 @@ contract BalanceSheetTest is Test {
                 POOL_A,
                 SC_1,
                 ISpokeMessageSender.UpdateData({
-                    netAmount: delta,
-                    isIncrease: isPositive,
-                    isSnapshot: isSnapshot,
-                    nonce: nonce
+                    netAmount: delta, isIncrease: isPositive, isSnapshot: isSnapshot, nonce: nonce
                 }),
                 EXTRA_GAS
             ),

--- a/test/spoke/unit/Spoke.t.sol
+++ b/test/spoke/unit/Spoke.t.sol
@@ -287,9 +287,9 @@ contract SpokeTestCrosschainTransferShares is SpokeTest {
     function testErrShareTokenDoesNotExists() public {
         vm.prank(ANY);
         vm.expectRevert(ISpoke.ShareTokenDoesNotExist.selector);
-        spoke.crosschainTransferShares{value: GAS}(
-            LOCAL_CENTRIFUGE_ID, POOL_A, SC_1, RECEIVER.toBytes32(), AMOUNT, 0, 0
-        );
+        spoke.crosschainTransferShares{
+            value: GAS
+        }(LOCAL_CENTRIFUGE_ID, POOL_A, SC_1, RECEIVER.toBytes32(), AMOUNT, 0, 0);
     }
 
     function testErrLocalTransferNotAllowed() public {
@@ -297,9 +297,9 @@ contract SpokeTestCrosschainTransferShares is SpokeTest {
 
         vm.prank(ANY);
         vm.expectRevert(ISpoke.LocalTransferNotAllowed.selector);
-        spoke.crosschainTransferShares{value: GAS}(
-            LOCAL_CENTRIFUGE_ID, POOL_A, SC_1, RECEIVER.toBytes32(), AMOUNT, 0, 0
-        );
+        spoke.crosschainTransferShares{
+            value: GAS
+        }(LOCAL_CENTRIFUGE_ID, POOL_A, SC_1, RECEIVER.toBytes32(), AMOUNT, 0, 0);
     }
 
     function testErrCrossChainTransferNotAllowed() public {
@@ -309,9 +309,9 @@ contract SpokeTestCrosschainTransferShares is SpokeTest {
 
         vm.prank(ANY);
         vm.expectRevert(ISpoke.CrossChainTransferNotAllowed.selector);
-        spoke.crosschainTransferShares{value: GAS}(
-            REMOTE_CENTRIFUGE_ID, POOL_A, SC_1, RECEIVER.toBytes32(), AMOUNT, 0, 0
-        );
+        spoke.crosschainTransferShares{
+            value: GAS
+        }(REMOTE_CENTRIFUGE_ID, POOL_A, SC_1, RECEIVER.toBytes32(), AMOUNT, 0, 0);
     }
 
     function testErrNotEnoughGas() public {
@@ -338,9 +338,9 @@ contract SpokeTestCrosschainTransferShares is SpokeTest {
 
         vm.prank(ANY);
         vm.expectRevert(ISpoke.NotEnoughGas.selector);
-        spoke.crosschainTransferShares{value: GAS - 1}(
-            REMOTE_CENTRIFUGE_ID, POOL_A, SC_1, RECEIVER.toBytes32(), AMOUNT, 0
-        );
+        spoke.crosschainTransferShares{
+            value: GAS - 1
+        }(REMOTE_CENTRIFUGE_ID, POOL_A, SC_1, RECEIVER.toBytes32(), AMOUNT, 0);
     }
 
     function testCrossChainTransfer() public {
@@ -369,9 +369,9 @@ contract SpokeTestCrosschainTransferShares is SpokeTest {
         vm.prank(ANY);
         vm.expectEmit();
         emit ISpoke.InitiateTransferShares(REMOTE_CENTRIFUGE_ID, POOL_A, SC_1, ANY, RECEIVER.toBytes32(), AMOUNT);
-        spoke.crosschainTransferShares{value: GAS}(
-            REMOTE_CENTRIFUGE_ID, POOL_A, SC_1, RECEIVER.toBytes32(), AMOUNT, 0, 0
-        );
+        spoke.crosschainTransferShares{
+            value: GAS
+        }(REMOTE_CENTRIFUGE_ID, POOL_A, SC_1, RECEIVER.toBytes32(), AMOUNT, 0, 0);
     }
 }
 

--- a/test/spoke/unit/libraries/UpdateContractMessageLib.t.sol
+++ b/test/spoke/unit/libraries/UpdateContractMessageLib.t.sol
@@ -31,8 +31,9 @@ contract TestUpdateContractMessageLibIdentities is Test {
     }
 
     function testUpdateContractUpdateAddress(bytes32 kind, uint128 assetId, bytes32 what, bool isEnabled) public pure {
-        UpdateContractMessageLib.UpdateContractUpdateAddress memory a = UpdateContractMessageLib
-            .UpdateContractUpdateAddress({kind: kind, assetId: assetId, what: what, isEnabled: isEnabled});
+        UpdateContractMessageLib.UpdateContractUpdateAddress memory a = UpdateContractMessageLib.UpdateContractUpdateAddress({
+            kind: kind, assetId: assetId, what: what, isEnabled: isEnabled
+        });
         UpdateContractMessageLib.UpdateContractUpdateAddress memory b =
             UpdateContractMessageLib.deserializeUpdateContractUpdateAddress(a.serialize());
 

--- a/test/vaults/integration/AsyncRequestManager.t.sol
+++ b/test/vaults/integration/AsyncRequestManager.t.sol
@@ -35,8 +35,9 @@ contract AsyncRequestManagerHarness is AsyncRequestManager {
         }
 
         if (address(vault) == address(0)) {
-            return
-                PricingLib.calculatePriceAssetPerShare(address(0), shares, address(0), 0, assets, MathLib.Rounding.Down);
+            return PricingLib.calculatePriceAssetPerShare(
+                address(0), shares, address(0), 0, assets, MathLib.Rounding.Down
+            );
         }
 
         VaultDetails memory vaultDetails = spoke.vaultDetails(vault);

--- a/test/vaults/integration/AsyncRequestManager.t.sol
+++ b/test/vaults/integration/AsyncRequestManager.t.sol
@@ -34,6 +34,7 @@ contract AsyncRequestManagerHarness is AsyncRequestManager {
             return d18(0);
         }
 
+        // forgefmt: disable-next-item
         if (address(vault) == address(0)) {
             return PricingLib.calculatePriceAssetPerShare(
                 address(0), shares, address(0), 0, assets, MathLib.Rounding.Down

--- a/test/vaults/integration/Deposit.t.sol
+++ b/test/vaults/integration/Deposit.t.sol
@@ -64,7 +64,7 @@ contract DepositTest is BaseTest {
 
         assertEq(vault.isPermissioned(self), false);
         centrifugeChain.updateMember(vault.poolId().raw(), vault.scId().raw(), self, type(uint64).max); // add user as
-            // member
+        // member
         assertEq(vault.isPermissioned(self), true);
 
         // will fail - user not member: can not receive share class
@@ -345,7 +345,7 @@ contract DepositTest is BaseTest {
         erc20.mint(self, amount);
 
         centrifugeChain.updateMember(vault.poolId().raw(), vault.scId().raw(), self, type(uint64).max); // add user as
-            // member
+        // member
         erc20.approve(vault_, amount); // add allowance
         vault.requestDeposit(amount, self, self);
 
@@ -399,7 +399,7 @@ contract DepositTest is BaseTest {
 
         erc20.mint(self, amount);
         centrifugeChain.updateMember(vault.poolId().raw(), vault.scId().raw(), self, type(uint64).max); // add user as
-            // member
+        // member
         erc20.approve(vault_, amount); // add allowance
         vault.requestDeposit(amount, self, self);
 
@@ -417,7 +417,7 @@ contract DepositTest is BaseTest {
         assertEq(shareToken.balanceOf(address(globalEscrow)), sharePayout);
 
         centrifugeChain.updateMember(vault.poolId().raw(), vault.scId().raw(), receiver, type(uint64).max); // add
-            // receiver
+        // receiver
 
         address router = makeAddr("router");
 
@@ -770,7 +770,7 @@ contract DepositTest is BaseTest {
 
         erc20.mint(investor, amount);
         centrifugeChain.updateMember(vault.poolId().raw(), vault.scId().raw(), investor, type(uint64).max); // add user
-            // as
+        // as
 
         vm.startPrank(investor);
         erc20.approve(vault_, amount);

--- a/test/vaults/unit/BatchRequestManager.t.sol
+++ b/test/vaults/unit/BatchRequestManager.t.sol
@@ -179,14 +179,14 @@ abstract contract BatchRequestManagerBaseTest is Test {
         returns (uint128)
     {
         return pricePoolPerShare.reciprocalMulUint256(
-            PricingLib.convertWithPrice(
-                depositAmountAsset,
-                IHubRegistry(address(hubRegistryMock)).decimals(assetId),
-                IHubRegistry(address(hubRegistryMock)).decimals(poolId),
-                _pricePoolPerAsset(assetId)
-            ),
-            MathLib.Rounding.Down
-        ).toUint128();
+                PricingLib.convertWithPrice(
+                    depositAmountAsset,
+                    IHubRegistry(address(hubRegistryMock)).decimals(assetId),
+                    IHubRegistry(address(hubRegistryMock)).decimals(poolId),
+                    _pricePoolPerAsset(assetId)
+                ),
+                MathLib.Rounding.Down
+            ).toUint128();
     }
 
     function _pricePoolPerAsset(AssetId assetId) internal pure returns (D18) {
@@ -223,10 +223,7 @@ abstract contract BatchRequestManagerBaseTest is Test {
         assertEq(lastUpdate, expected.lastUpdate, "Mismatch: Redeem UserOrder.lastUpdate");
     }
 
-    function _assertQueuedRedeemRequestEq(AssetId asset, bytes32 investor_, QueuedOrder memory expected)
-        internal
-        view
-    {
+    function _assertQueuedRedeemRequestEq(AssetId asset, bytes32 investor_, QueuedOrder memory expected) internal view {
         (bool isCancelling, uint128 amount) = batchRequestManager.queuedRedeemRequest(scId, asset, investor_);
 
         assertEq(isCancelling, expected.isCancelling, "isCancelling redeem mismatch");
@@ -707,9 +704,11 @@ contract BatchRequestManagerRedeemsNonTransientTest is BatchRequestManagerBaseTe
         // Note: Epoch state is tracked internally and tested through other assertions
     }
 
-    function testRevokeSharesSingleEpoch(uint128 navPoolPerShare_, uint128 fuzzRedeemShares, uint128 fuzzApprovedShares)
-        public
-    {
+    function testRevokeSharesSingleEpoch(
+        uint128 navPoolPerShare_,
+        uint128 fuzzRedeemShares,
+        uint128 fuzzApprovedShares
+    ) public {
         D18 navPoolPerShare = d18(uint128(bound(navPoolPerShare_, 1e14, type(uint128).max / 1e18)));
         _redeem(fuzzRedeemShares, fuzzApprovedShares, navPoolPerShare.raw());
 


### PR DESCRIPTION
Fixes CI lint and CI test after foundry upgrade that happened around merging #606. 

### Changes

1. Apply `forge fmt` with the latest foundry version (two lines had to be disabled due to being non-deterministic, alternated after each fmt between two states)
2. Fix compiler warnings in `IdentityValuation.getPrice`

### CI Error description

CI uses latest version `forge 1.3.6-nightly (d6daa0ac83 2025-09-25T08:01:37.285831000Z)` to which you should upgrade 

```bash
foundryup nightly 
foundryup -u nightly
```