### PR TITLE
ref: unify price variants

### DIFF
--- a/script/TestData.s.sol
+++ b/script/TestData.s.sol
@@ -111,7 +111,7 @@ contract TestData is FullDeployer {
         hub.updateHubManager(state.poolId, admin, true);
         state.scId = shareClassManager.previewNextShareClassId(state.poolId);
 
-        D18 navPerShare = d18(1, 1);
+        D18 pricePoolPerShare = d18(1, 1);
 
         hub.setPoolMetadata(state.poolId, bytes("Testing pool"));
         hub.addShareClass(state.poolId, "Tokenized MMF", "MMF", bytes32(bytes("1")));
@@ -158,7 +158,7 @@ contract TestData is FullDeployer {
             msg.sender
         );
 
-        hub.updateSharePrice(state.poolId, state.scId, navPerShare);
+        hub.updateSharePrice(state.poolId, state.scId, pricePoolPerShare);
         hub.notifySharePrice(state.poolId, state.scId, centrifugeId, msg.sender);
         hub.notifyAssetPrice(state.poolId, state.scId, assetId, msg.sender);
 
@@ -277,7 +277,7 @@ contract TestData is FullDeployer {
         hub.updateHubManager(poolId, admin, true);
         ShareClassId scId = shareClassManager.previewNextShareClassId(poolId);
 
-        D18 navPerShare = d18(1, 1);
+        D18 pricePoolPerShare = d18(1, 1);
 
         hub.setPoolMetadata(poolId, bytes("Testing pool"));
         hub.addShareClass(poolId, "RWA Portfolio", "RWA", bytes32(bytes("2")));
@@ -319,7 +319,7 @@ contract TestData is FullDeployer {
             msg.sender
         );
 
-        hub.updateSharePrice(poolId, scId, navPerShare);
+        hub.updateSharePrice(poolId, scId, pricePoolPerShare);
         hub.notifySharePrice(poolId, scId, centrifugeId, msg.sender);
         hub.notifyAssetPrice(poolId, scId, assetId, msg.sender);
 

--- a/src/common/MessageDispatcher.sol
+++ b/src/common/MessageDispatcher.sol
@@ -172,14 +172,16 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
     }
 
     /// @inheritdoc IHubMessageSender
-    function sendNotifyPricePoolPerShare(uint16 chainId, PoolId poolId, ShareClassId scId, D18 price, address refund)
-        external
-        payable
-        auth
-    {
+    function sendNotifyPricePoolPerShare(
+        uint16 chainId,
+        PoolId poolId,
+        ShareClassId scId,
+        D18 pricePoolPerShare,
+        address refund
+    ) external payable auth {
         uint64 timestamp = block.timestamp.toUint64();
         if (chainId == localCentrifugeId) {
-            spoke.updatePricePoolPerShare(poolId, scId, price, timestamp);
+            spoke.updatePricePoolPerShare(poolId, scId, pricePoolPerShare, timestamp);
             _refund(refund);
         } else {
             _send(
@@ -187,7 +189,7 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
                 MessageLib.NotifyPricePoolPerShare({
                     poolId: poolId.raw(),
                     scId: scId.raw(),
-                    price: price.raw(),
+                    price: pricePoolPerShare.raw(),
                     timestamp: timestamp
                 }).serialize(),
                 0,
@@ -197,14 +199,16 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
     }
 
     /// @inheritdoc IHubMessageSender
-    function sendNotifyPricePoolPerAsset(PoolId poolId, ShareClassId scId, AssetId assetId, D18 price, address refund)
-        external
-        payable
-        auth
-    {
+    function sendNotifyPricePoolPerAsset(
+        PoolId poolId,
+        ShareClassId scId,
+        AssetId assetId,
+        D18 pricePoolPerAsset,
+        address refund
+    ) external payable auth {
         uint64 timestamp = block.timestamp.toUint64();
         if (assetId.centrifugeId() == localCentrifugeId) {
-            spoke.updatePricePoolPerAsset(poolId, scId, assetId, price, timestamp);
+            spoke.updatePricePoolPerAsset(poolId, scId, assetId, pricePoolPerAsset, timestamp);
             _refund(refund);
         } else {
             _send(
@@ -213,7 +217,7 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
                     poolId: poolId.raw(),
                     scId: scId.raw(),
                     assetId: assetId.raw(),
-                    price: price.raw(),
+                    price: pricePoolPerAsset.raw(),
                     timestamp: timestamp
                 }).serialize(),
                 0,
@@ -521,7 +525,7 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
                     scId: scId.raw(),
                     assetId: assetId.raw(),
                     amount: data.netAmount,
-                    pricePerUnit: pricePoolPerAsset.raw(),
+                    pricePoolPerAsset: pricePoolPerAsset.raw(),
                     timestamp: uint64(block.timestamp),
                     isIncrease: data.isIncrease,
                     isSnapshot: data.isSnapshot,

--- a/src/common/MessageProcessor.sol
+++ b/src/common/MessageProcessor.sol
@@ -188,7 +188,7 @@ contract MessageProcessor is Auth, IMessageProcessor {
                 ShareClassId.wrap(m.scId),
                 AssetId.wrap(m.assetId),
                 m.amount,
-                D18.wrap(m.pricePerUnit),
+                D18.wrap(m.pricePoolPerAsset),
                 m.isIncrease,
                 m.isSnapshot,
                 m.nonce

--- a/src/common/interfaces/IGatewaySenders.sol
+++ b/src/common/interfaces/IGatewaySenders.sol
@@ -72,7 +72,7 @@ interface IHubMessageSender is ILocalCentrifugeId {
         uint16 chainId,
         PoolId poolId,
         ShareClassId scId,
-        D18 pricePerShare,
+        D18 pricePoolPerShare,
         address refund
     ) external payable;
 
@@ -81,7 +81,7 @@ interface IHubMessageSender is ILocalCentrifugeId {
         PoolId poolId,
         ShareClassId scId,
         AssetId assetId,
-        D18 pricePerShare,
+        D18 pricePoolPerAsset,
         address refund
     ) external payable;
 

--- a/src/common/libraries/MessageLib.sol
+++ b/src/common/libraries/MessageLib.sol
@@ -696,7 +696,7 @@ library MessageLib {
         bytes16 scId;
         uint128 assetId;
         uint128 amount;
-        uint128 pricePerUnit;
+        uint128 pricePoolPerAsset;
         uint64 timestamp;
         bool isIncrease;
         bool isSnapshot;
@@ -711,7 +711,7 @@ library MessageLib {
             scId: data.toBytes16(9),
             assetId: data.toUint128(25),
             amount: data.toUint128(41),
-            pricePerUnit: data.toUint128(57),
+            pricePoolPerAsset: data.toUint128(57),
             timestamp: data.toUint64(73),
             isIncrease: data.toBool(81),
             isSnapshot: data.toBool(82),
@@ -726,7 +726,7 @@ library MessageLib {
             t.scId,
             t.assetId,
             t.amount,
-            t.pricePerUnit,
+            t.pricePoolPerAsset,
             t.timestamp,
             t.isIncrease,
             t.isSnapshot,

--- a/src/hub/Hub.sol
+++ b/src/hub/Hub.sol
@@ -317,10 +317,10 @@ contract Hub is BatchedMulticall, Auth, Recoverable, IHub, IHubRequestManagerCal
     }
 
     /// @inheritdoc IHub
-    function updateSharePrice(PoolId poolId, ShareClassId scId, D18 navPoolPerShare) public payable {
+    function updateSharePrice(PoolId poolId, ShareClassId scId, D18 pricePoolPerShare) public payable {
         _isManager(poolId);
 
-        shareClassManager.updateSharePrice(poolId, scId, navPoolPerShare);
+        shareClassManager.updateSharePrice(poolId, scId, pricePoolPerShare);
     }
 
     /// @inheritdoc IHub

--- a/src/hub/ShareClassManager.sol
+++ b/src/hub/ShareClassManager.sol
@@ -47,12 +47,12 @@ contract ShareClassManager is Auth, IShareClassManager {
     }
 
     /// @inheritdoc IShareClassManager
-    function updateSharePrice(PoolId poolId, ShareClassId scId_, D18 navPoolPerShare) external auth {
+    function updateSharePrice(PoolId poolId, ShareClassId scId_, D18 pricePoolPerShare) external auth {
         require(exists(poolId, scId_), ShareClassNotFound());
 
         ShareClassMetrics storage m = metrics[scId_];
-        m.navPerShare = navPoolPerShare;
-        emit UpdateShareClass(poolId, scId_, navPoolPerShare);
+        m.pricePoolPerShare = pricePoolPerShare;
+        emit UpdateShareClass(poolId, scId_, pricePoolPerShare);
     }
 
     /// @inheritdoc IShareClassManager

--- a/src/hub/interfaces/IShareClassManager.sol
+++ b/src/hub/interfaces/IShareClassManager.sol
@@ -19,7 +19,7 @@ struct ShareClassMetrics {
     /// @dev Total number of shares
     uint128 totalIssuance;
     /// @dev The latest net asset value per share class token
-    D18 navPerShare;
+    D18 pricePoolPerShare;
 }
 
 interface IShareClassManager {
@@ -28,7 +28,7 @@ interface IShareClassManager {
         PoolId indexed poolId, ShareClassId indexed scId, uint32 indexed index, string name, string symbol, bytes32 salt
     );
     event UpdateMetadata(PoolId indexed poolId, ShareClassId indexed scId, string name, string symbol);
-    event UpdateShareClass(PoolId indexed poolId, ShareClassId indexed scId, D18 navPoolPerShare);
+    event UpdateShareClass(PoolId indexed poolId, ShareClassId indexed scId, D18 pricePoolPerShare);
     event RemoteIssueShares(
         uint16 indexed centrifugeId, PoolId indexed poolId, ShareClassId indexed scId, uint128 amount
     );

--- a/src/managers/hub/SimplePriceManager.sol
+++ b/src/managers/hub/SimplePriceManager.sol
@@ -111,20 +111,20 @@ contract SimplePriceManager is ISimplePriceManager, Auth {
         metrics_.issuance = metrics_.issuance + issuance - networkMetrics_.issuance;
         metrics_.netAssetValue = metrics_.netAssetValue + netAssetValue - networkMetrics_.netAssetValue;
 
-        D18 price = _navPerShare(poolId);
+        D18 pricePoolPerShare = _pricePoolPerShare(poolId);
 
         networkMetrics_.netAssetValue = netAssetValue;
         networkMetrics_.issuance = issuance;
 
         uint16[] storage networks_ = _networks[poolId];
         uint256 networkCount = networks_.length;
-        hub.updateSharePrice(poolId, scId, price);
+        hub.updateSharePrice(poolId, scId, pricePoolPerShare);
 
         for (uint256 i; i < networkCount; i++) {
             hub.notifySharePrice(poolId, scId, networks_[i], address(0));
         }
 
-        emit Update(poolId, scId, metrics_.netAssetValue, metrics_.issuance, price);
+        emit Update(poolId, scId, metrics_.netAssetValue, metrics_.issuance, pricePoolPerShare);
     }
 
     /// @inheritdoc INAVHook
@@ -157,7 +157,7 @@ contract SimplePriceManager is ISimplePriceManager, Auth {
     // Helpers
     //----------------------------------------------------------------------------------------------
 
-    function _navPerShare(PoolId poolId) internal view returns (D18) {
+    function _pricePoolPerShare(PoolId poolId) internal view returns (D18) {
         Metrics memory metrics_ = metrics[poolId];
         return metrics_.issuance == 0 ? d18(1, 1) : d18(metrics_.netAssetValue) / d18(metrics_.issuance);
     }

--- a/src/managers/hub/interfaces/ISimplePriceManager.sol
+++ b/src/managers/hub/interfaces/ISimplePriceManager.sol
@@ -9,7 +9,9 @@ import {PoolId} from "../../../common/types/PoolId.sol";
 import {ShareClassId} from "../../../common/types/ShareClassId.sol";
 
 interface ISimplePriceManager is INAVHook {
-    event Update(PoolId indexed poolId, ShareClassId scId, uint128 newNAV, uint128 newIssuance, D18 newSharePrice);
+    event Update(
+        PoolId indexed poolId, ShareClassId scId, uint128 newNAV, uint128 newIssuance, D18 newPricePoolPerShare
+    );
     event Transfer(
         PoolId indexed poolId,
         ShareClassId scId,

--- a/src/vaults/BatchRequestManager.sol
+++ b/src/vaults/BatchRequestManager.sol
@@ -276,7 +276,7 @@ contract BatchRequestManager is Auth, ReentrancyProtection, IBatchRequestManager
         ShareClassId scId_,
         AssetId depositAssetId,
         uint32 nowIssueEpochId,
-        D18 navPoolPerShare,
+        D18 pricePoolPerShare,
         uint128 extraGasLimit,
         address refund
     ) external payable authOrManager(poolId) {
@@ -287,15 +287,15 @@ contract BatchRequestManager is Auth, ReentrancyProtection, IBatchRequestManager
         );
 
         EpochInvestAmounts storage epochAmounts = epochInvestAmounts[scId_][depositAssetId][nowIssueEpochId];
-        epochAmounts.navPoolPerShare = navPoolPerShare;
+        epochAmounts.pricePoolPerShare = pricePoolPerShare;
 
-        uint128 issuedShareAmount = navPoolPerShare.isNotZero()
+        uint128 issuedShareAmount = pricePoolPerShare.isNotZero()
             ? PricingLib.assetToShareAmount(
                 epochAmounts.approvedAssetAmount,
                 hubRegistry.decimals(depositAssetId),
                 hubRegistry.decimals(poolId),
                 epochAmounts.pricePoolPerAsset,
-                navPoolPerShare,
+                pricePoolPerShare,
                 MathLib.Rounding.Down
             )
             : 0;
@@ -308,15 +308,15 @@ contract BatchRequestManager is Auth, ReentrancyProtection, IBatchRequestManager
             scId_,
             depositAssetId,
             nowIssueEpochId,
-            navPoolPerShare,
+            pricePoolPerShare,
             epochAmounts.pricePoolPerAsset.isNotZero()
-                ? PricingLib.priceAssetPerShare(epochAmounts.navPoolPerShare, epochAmounts.pricePoolPerAsset)
+                ? PricingLib.priceAssetPerShare(epochAmounts.pricePoolPerShare, epochAmounts.pricePoolPerAsset)
                 : d18(0),
             issuedShareAmount
         );
 
         bytes memory callback =
-            RequestCallbackMessageLib.IssuedShares(issuedShareAmount, navPoolPerShare.raw()).serialize();
+            RequestCallbackMessageLib.IssuedShares(issuedShareAmount, pricePoolPerShare.raw()).serialize();
         hub.requestCallback{value: msg.value}(poolId, scId_, depositAssetId, callback, extraGasLimit, refund);
     }
 
@@ -326,7 +326,7 @@ contract BatchRequestManager is Auth, ReentrancyProtection, IBatchRequestManager
         ShareClassId scId_,
         AssetId payoutAssetId,
         uint32 nowRevokeEpochId,
-        D18 navPoolPerShare,
+        D18 pricePoolPerShare,
         uint128 extraGasLimit,
         address refund
     ) external payable authOrManager(poolId) {
@@ -337,17 +337,17 @@ contract BatchRequestManager is Auth, ReentrancyProtection, IBatchRequestManager
         );
 
         EpochRedeemAmounts storage epochAmounts = epochRedeemAmounts[scId_][payoutAssetId][nowRevokeEpochId];
-        epochAmounts.navPoolPerShare = navPoolPerShare;
+        epochAmounts.pricePoolPerShare = pricePoolPerShare;
 
         // NOTE: shares and pool currency have the same decimals - no conversion needed!
-        uint128 payoutPoolAmount = navPoolPerShare.mulUint128(epochAmounts.approvedShareAmount, MathLib.Rounding.Down);
+        uint128 payoutPoolAmount = pricePoolPerShare.mulUint128(epochAmounts.approvedShareAmount, MathLib.Rounding.Down);
 
         uint128 payoutAssetAmount = epochAmounts.pricePoolPerAsset.isNotZero()
             ? PricingLib.shareToAssetAmount(
                 epochAmounts.approvedShareAmount,
                 hubRegistry.decimals(poolId),
                 hubRegistry.decimals(payoutAssetId),
-                epochAmounts.navPoolPerShare,
+                epochAmounts.pricePoolPerShare,
                 epochAmounts.pricePoolPerAsset,
                 MathLib.Rounding.Down
             )
@@ -363,9 +363,9 @@ contract BatchRequestManager is Auth, ReentrancyProtection, IBatchRequestManager
             scId_,
             payoutAssetId,
             nowRevokeEpochId,
-            navPoolPerShare,
+            pricePoolPerShare,
             epochAmounts.pricePoolPerAsset.isNotZero()
-                ? PricingLib.priceAssetPerShare(epochAmounts.navPoolPerShare, epochAmounts.pricePoolPerAsset)
+                ? PricingLib.priceAssetPerShare(epochAmounts.pricePoolPerShare, epochAmounts.pricePoolPerAsset)
                 : d18(0),
             epochAmounts.approvedShareAmount,
             payoutAssetAmount,
@@ -373,7 +373,7 @@ contract BatchRequestManager is Auth, ReentrancyProtection, IBatchRequestManager
         );
 
         bytes memory callback = RequestCallbackMessageLib.RevokedShares(
-            payoutAssetAmount, revokedShareAmount, navPoolPerShare.raw()
+            payoutAssetAmount, revokedShareAmount, pricePoolPerShare.raw()
         ).serialize();
         hub.requestCallback{value: msg.value}(poolId, scId_, payoutAssetId, callback, extraGasLimit, refund);
     }
@@ -495,13 +495,13 @@ contract BatchRequestManager is Auth, ReentrancyProtection, IBatchRequestManager
         // tokens corresponding to the approved share amount (instead of equality). I.e., it is possible for an epoch to
         // have an excess of a share class tokens which cannot be claimed by anyone.
         if (paymentAssetAmount > 0) {
-            payoutShareAmount = epochAmounts.navPoolPerShare.isNotZero()
+            payoutShareAmount = epochAmounts.pricePoolPerShare.isNotZero()
                 ? PricingLib.assetToShareAmount(
                     paymentAssetAmount,
                     hubRegistry.decimals(depositAssetId),
                     hubRegistry.decimals(poolId),
                     epochAmounts.pricePoolPerAsset,
-                    epochAmounts.navPoolPerShare,
+                    epochAmounts.pricePoolPerShare,
                     MathLib.Rounding.Down
                 )
                 : 0;
@@ -611,7 +611,7 @@ contract BatchRequestManager is Auth, ReentrancyProtection, IBatchRequestManager
                     paymentShareAmount,
                     hubRegistry.decimals(poolId),
                     hubRegistry.decimals(payoutAssetId),
-                    epochAmounts.navPoolPerShare,
+                    epochAmounts.pricePoolPerShare,
                     epochAmounts.pricePoolPerAsset,
                     MathLib.Rounding.Down
                 )

--- a/src/vaults/interfaces/IBatchRequestManager.sol
+++ b/src/vaults/interfaces/IBatchRequestManager.sol
@@ -14,14 +14,14 @@ import {IHubRequestManager, IHubRequestManagerNotifications} from "../../hub/int
 /// @param approvedAssetAmount The amount of assets which was approved by the Fund Manager
 /// @param pendingAssetAmount The amount of assets for which issuance was pending by the Fund Manager
 /// @param pricePoolPerAsset The price of 1 pool currency token in terms of asset tokens at the time of approval
-/// @param navPoolPerShare The price of 1 pool currency token in terms of share class tokens at the time of issuance
+/// @param pricePoolPerShare The price of 1 pool currency token in terms of share class tokens at the time of issuance
 /// @param issuedAt The timestamp when shares were issued
 struct EpochInvestAmounts {
     uint128 approvedPoolAmount;
     uint128 approvedAssetAmount;
     uint128 pendingAssetAmount;
     D18 pricePoolPerAsset;
-    D18 navPoolPerShare;
+    D18 pricePoolPerShare;
     uint64 issuedAt;
 }
 
@@ -29,14 +29,14 @@ struct EpochInvestAmounts {
 /// @param approvedShareAmount The amount of share class tokens which was approved by the Fund Manager for payout
 /// @param pendingShareAmount The amount of share class tokens for which payout was pending by the Fund Manager
 /// @param pricePoolPerAsset The price of 1 pool currency token in terms of asset tokens at the time of approval
-/// @param navPoolPerShare The price of 1 pool currency token in terms of share class tokens at the time of revocation
+/// @param pricePoolPerShare The price of 1 pool currency token in terms of share class tokens at the time of revocation
 /// @param payoutAssetAmount The amount of payout assets to claim by redeeming share class tokens
 /// @param revokedAt The timestamp when shares were revoked
 struct EpochRedeemAmounts {
     uint128 approvedShareAmount;
     uint128 pendingShareAmount;
     D18 pricePoolPerAsset;
-    D18 navPoolPerShare;
+    D18 pricePoolPerShare;
     uint128 payoutAssetAmount;
     uint64 revokedAt;
 }
@@ -104,7 +104,7 @@ interface IBatchRequestManager is IHubRequestManager, IHubRequestManagerNotifica
         ShareClassId indexed shareClassId,
         AssetId indexed assetId,
         uint32 epochId,
-        D18 navPoolPerShare,
+        D18 pricePoolPerShare,
         D18 priceAssetPerShare,
         uint128 issuedShareAmount
     );
@@ -114,7 +114,7 @@ interface IBatchRequestManager is IHubRequestManager, IHubRequestManagerNotifica
         ShareClassId indexed shareClassId,
         AssetId indexed assetId,
         uint32 epochId,
-        D18 navPoolPerShare,
+        D18 pricePoolPerShare,
         D18 priceAssetPerShare,
         uint128 approvedShareAmount,
         uint128 payoutAssetAmount,
@@ -242,7 +242,7 @@ interface IBatchRequestManager is IHubRequestManager, IHubRequestManagerNotifica
         ShareClassId scId,
         AssetId depositAssetId,
         uint32 nowIssueEpochId,
-        D18 navPoolPerShare,
+        D18 pricePoolPerShare,
         uint128 extraGasLimit,
         address refund
     ) external payable;
@@ -252,7 +252,7 @@ interface IBatchRequestManager is IHubRequestManager, IHubRequestManagerNotifica
         ShareClassId scId,
         AssetId payoutAssetId,
         uint32 nowRevokeEpochId,
-        D18 navPoolPerShare,
+        D18 pricePoolPerShare,
         uint128 extraGasLimit,
         address refund
     ) external payable;
@@ -307,7 +307,7 @@ interface IBatchRequestManager is IHubRequestManager, IHubRequestManagerNotifica
             uint128 approvedAssetAmount,
             uint128 approvedPoolAmount,
             D18 pricePoolPerAsset,
-            D18 navPoolPerShare,
+            D18 pricePoolPerShare,
             uint64 issuedAt
         );
 
@@ -318,7 +318,7 @@ interface IBatchRequestManager is IHubRequestManager, IHubRequestManagerNotifica
             uint128 approvedShareAmount,
             uint128 pendingShareAmount,
             D18 pricePoolPerAsset,
-            D18 navPoolPerShare,
+            D18 pricePoolPerShare,
             uint128 payoutAssetAmount,
             uint64 revokedAt
         );

--- a/test/common/unit/libraries/MessageLib.t.sol
+++ b/test/common/unit/libraries/MessageLib.t.sol
@@ -516,7 +516,7 @@ contract TestMessageLibIdentities is Test {
         bytes16 scId,
         uint128 assetId,
         uint128 amount,
-        uint128 pricePerUnit,
+        uint128 pricePoolPerAsset,
         uint64 timestamp,
         bool isIncrease,
         bool isSnapshot,
@@ -527,7 +527,7 @@ contract TestMessageLibIdentities is Test {
             scId: scId,
             assetId: assetId,
             amount: amount,
-            pricePerUnit: pricePerUnit,
+            pricePoolPerAsset: pricePoolPerAsset,
             timestamp: timestamp,
             isIncrease: isIncrease,
             isSnapshot: isSnapshot,
@@ -540,7 +540,7 @@ contract TestMessageLibIdentities is Test {
         assertEq(a.scId, b.scId);
         assertEq(a.assetId, b.assetId);
         assertEq(a.amount, b.amount);
-        assertEq(a.pricePerUnit, b.pricePerUnit);
+        assertEq(a.pricePoolPerAsset, b.pricePoolPerAsset);
         assertEq(a.timestamp, b.timestamp);
         assertEq(a.isIncrease, b.isIncrease);
         assertEq(a.isSnapshot, b.isSnapshot);

--- a/test/hub/mocks/MockVaults.sol
+++ b/test/hub/mocks/MockVaults.sol
@@ -120,7 +120,7 @@ contract MockVaults is Test, Auth, IAdapter {
                 scId: scId.raw(),
                 assetId: assetId.raw(),
                 amount: amount,
-                pricePerUnit: pricePoolPerAsset.raw(),
+                pricePoolPerAsset: pricePoolPerAsset.raw(),
                 timestamp: 0,
                 isIncrease: isIncrease,
                 isSnapshot: isSnapshot,

--- a/test/hub/unit/ShareClassManager.t.sol
+++ b/test/hub/unit/ShareClassManager.t.sol
@@ -130,9 +130,9 @@ contract ShareClassManagerSimpleTest is ShareClassManagerBaseTest {
     }
 
     function testDefaultGetShareClassNavPerShare() public view {
-        (uint128 totalIssuance, D18 navPerShare) = shareClass.metrics(scId);
+        (uint128 totalIssuance, D18 pricePoolPerShare) = shareClass.metrics(scId);
         assertEq(totalIssuance, 0);
-        assertEq(navPerShare.raw(), 0);
+        assertEq(pricePoolPerShare.raw(), 0);
     }
 
     function testExistence() public view {
@@ -197,9 +197,9 @@ contract ShareClassManagerSimpleTest is ShareClassManagerBaseTest {
         emit IShareClassManager.RemoteIssueShares(centrifugeId, poolId, scId, amount);
         shareClass.updateShares(centrifugeId, poolId, scId, amount, true);
 
-        (uint128 totalIssuance_, D18 navPerShareMetric) = shareClass.metrics(scId);
+        (uint128 totalIssuance_, D18 pricePoolPerShareMetric) = shareClass.metrics(scId);
         assertEq(totalIssuance_, amount);
-        assertEq(navPerShareMetric.raw(), 0, "navPerShare metric should not be updated");
+        assertEq(pricePoolPerShareMetric.raw(), 0, "pricePoolPerShare metric should not be updated");
     }
 
     function testDecreaseShareClassIssuance(uint128 amount) public {
@@ -209,9 +209,9 @@ contract ShareClassManagerSimpleTest is ShareClassManagerBaseTest {
         emit IShareClassManager.RemoteRevokeShares(centrifugeId, poolId, scId, amount);
         shareClass.updateShares(centrifugeId, poolId, scId, amount, false);
 
-        (uint128 totalIssuance_, D18 navPerShareMetric) = shareClass.metrics(scId);
+        (uint128 totalIssuance_, D18 pricePoolPerShareMetric) = shareClass.metrics(scId);
         assertEq(totalIssuance_, 0, "TotalIssuance should be reset");
-        assertEq(navPerShareMetric.raw(), 0, "navPerShare metric should not be updated");
+        assertEq(pricePoolPerShareMetric.raw(), 0, "pricePoolPerShare metric should not be updated");
     }
 }
 

--- a/test/vaults/unit/BatchRequestManager.t.sol
+++ b/test/vaults/unit/BatchRequestManager.t.sol
@@ -193,11 +193,11 @@ abstract contract BatchRequestManagerBaseTest is Test {
 
     function _extractIssueSharesEvent()
         internal
-        returns (uint128 issuedShares, D18 navPoolPerShare, D18 priceAssetPerShare)
+        returns (uint128 issuedShares, D18 pricePoolPerShare, D18 priceAssetPerShare)
     {
         bytes memory data = _extractEventData(IBatchRequestManager.IssueShares.selector);
-        (, navPoolPerShare, priceAssetPerShare, issuedShares) = abi.decode(data, (uint32, D18, D18, uint128));
-        return (issuedShares, navPoolPerShare, priceAssetPerShare);
+        (, pricePoolPerShare, priceAssetPerShare, issuedShares) = abi.decode(data, (uint32, D18, D18, uint128));
+        return (issuedShares, pricePoolPerShare, priceAssetPerShare);
     }
 
     function _extractRevokeSharesEvent()
@@ -206,14 +206,14 @@ abstract contract BatchRequestManagerBaseTest is Test {
             uint128 revokedShares,
             uint128 payoutAssetAmount,
             uint128 payoutPoolAmount,
-            D18 navPoolPerShare,
+            D18 pricePoolPerShare,
             D18 priceAssetPerShare
         )
     {
         bytes memory data = _extractEventData(IBatchRequestManager.RevokeShares.selector);
-        (, navPoolPerShare, priceAssetPerShare, revokedShares, payoutAssetAmount, payoutPoolAmount) =
+        (, pricePoolPerShare, priceAssetPerShare, revokedShares, payoutAssetAmount, payoutPoolAmount) =
             abi.decode(data, (uint32, D18, D18, uint128, uint128, uint128));
-        return (revokedShares, payoutAssetAmount, payoutPoolAmount, navPoolPerShare, priceAssetPerShare);
+        return (revokedShares, payoutAssetAmount, payoutPoolAmount, pricePoolPerShare, priceAssetPerShare);
     }
 
     function _extractApproveDepositsEvent()
@@ -285,7 +285,7 @@ abstract contract BatchRequestManagerBaseTest is Test {
             uint128 approvedAssetAmount,
             uint128 approvedPoolAmount,
             D18 pricePoolPerAsset,
-            D18 navPoolPerShare,
+            D18 pricePoolPerShare,
             uint64 issuedAt
         ) = batchRequestManager.epochInvestAmounts(scId, assetId, epochId);
 
@@ -295,7 +295,9 @@ abstract contract BatchRequestManagerBaseTest is Test {
         assertEq(
             pricePoolPerAsset.raw(), expected.pricePoolPerAsset.raw(), "Mismatch: EpochInvestAmount.pricePoolPerAsset"
         );
-        assertEq(navPoolPerShare.raw(), expected.navPoolPerShare.raw(), "Mismatch: EpochInvestAmount.navPoolPerShare");
+        assertEq(
+            pricePoolPerShare.raw(), expected.pricePoolPerShare.raw(), "Mismatch: EpochInvestAmount.pricePoolPerShare"
+        );
         assertEq(issuedAt, expected.issuedAt, "Mismatch: EpochInvestAmount.issuedAt");
     }
 
@@ -307,7 +309,7 @@ abstract contract BatchRequestManagerBaseTest is Test {
             uint128 approvedShareAmount,
             uint128 pendingShareAmount,
             D18 pricePoolPerAsset,
-            D18 navPoolPerShare,
+            D18 pricePoolPerShare,
             uint128 payoutAssetAmount,
             uint64 revokedAt
         ) = batchRequestManager.epochRedeemAmounts(scId, assetId, epochId);
@@ -318,7 +320,9 @@ abstract contract BatchRequestManagerBaseTest is Test {
         assertEq(
             pricePoolPerAsset.raw(), expected.pricePoolPerAsset.raw(), "Mismatch: EpochRedeemAmount.pricePoolPerAsset"
         );
-        assertEq(navPoolPerShare.raw(), expected.navPoolPerShare.raw(), "Mismatch: EpochRedeemAmount.navPoolPerShare");
+        assertEq(
+            pricePoolPerShare.raw(), expected.pricePoolPerShare.raw(), "Mismatch: EpochRedeemAmount.pricePoolPerShare"
+        );
         assertEq(revokedAt, expected.revokedAt, "Mismatch: EpochRedeemAmount.revokedAt");
     }
 
@@ -548,27 +552,27 @@ contract BatchRequestManagerDepositsNonTransientTest is BatchRequestManagerBaseT
     }
 
     function testIssueSharesSingleEpoch(
-        uint128 navPoolPerShare_,
+        uint128 pricePoolPerShare_,
         uint128 fuzzDepositAmountUsdc,
         uint128 fuzzApprovedAmountUsdc
     ) public {
-        D18 navPoolPerShare = d18(uint128(bound(navPoolPerShare_, 1e14, type(uint128).max / 1e18)));
+        D18 pricePoolPerShare = d18(uint128(bound(pricePoolPerShare_, 1e14, type(uint128).max / 1e18)));
         (, uint128 approvedAmount,) = _depositAndApproveWithFuzzBounds(fuzzDepositAmountUsdc, fuzzApprovedAmountUsdc);
 
-        uint128 expectedIssuedShares = _calcSharesIssued(USDC, approvedAmount, navPoolPerShare);
+        uint128 expectedIssuedShares = _calcSharesIssued(USDC, approvedAmount, pricePoolPerShare);
 
         vm.recordLogs();
         batchRequestManager.issueShares{value: COST}(
-            poolId, scId, USDC, _nowIssue(USDC), navPoolPerShare, SHARE_HOOK_GAS, REFUND
+            poolId, scId, USDC, _nowIssue(USDC), pricePoolPerShare, SHARE_HOOK_GAS, REFUND
         );
 
         (uint128 actualIssuedShares, D18 eventNav,) = _extractIssueSharesEvent();
         assertEq(actualIssuedShares, expectedIssuedShares, "Issued shares mismatch");
-        assertEq(eventNav.raw(), navPoolPerShare.raw(), "NAV in event mismatch");
+        assertEq(eventNav.raw(), pricePoolPerShare.raw(), "NAV in event mismatch");
         {
             (,,,, D18 storedNav, uint64 issuedAt) =
                 batchRequestManager.epochInvestAmounts(scId, USDC, _nowIssue(USDC) - 1);
-            assertEq(storedNav.raw(), navPoolPerShare.raw(), "Stored NAV mismatch");
+            assertEq(storedNav.raw(), pricePoolPerShare.raw(), "Stored NAV mismatch");
             assertGt(issuedAt, 0, "Issuance timestamp not set");
         }
 
@@ -600,12 +604,12 @@ contract BatchRequestManagerDepositsNonTransientTest is BatchRequestManagerBaseT
         vm.expectRevert(IBatchRequestManager.IssuanceRequired.selector);
         batchRequestManager.claimDeposit(poolId, scId, investor, USDC);
 
-        D18 navPoolPerShare = d18(11, 10);
+        D18 pricePoolPerShare = d18(11, 10);
         batchRequestManager.issueShares{value: COST}(
-            poolId, scId, USDC, _nowIssue(USDC), navPoolPerShare, SHARE_HOOK_GAS, REFUND
+            poolId, scId, USDC, _nowIssue(USDC), pricePoolPerShare, SHARE_HOOK_GAS, REFUND
         );
 
-        uint128 expectedShares = _calcSharesIssued(USDC, approvedAmountUsdc, navPoolPerShare);
+        uint128 expectedShares = _calcSharesIssued(USDC, approvedAmountUsdc, pricePoolPerShare);
 
         vm.expectEmit();
         emit IBatchRequestManager.ClaimDeposit(
@@ -631,11 +635,11 @@ contract BatchRequestManagerDepositsNonTransientTest is BatchRequestManagerBaseT
     }
 
     function testClaimDepositSingleEpoch(
-        uint128 navPoolPerShare_,
+        uint128 pricePoolPerShare_,
         uint128 fuzzDepositAmountUsdc,
         uint128 fuzzApprovedAmountUsdc
     ) public {
-        D18 navPoolPerShare = d18(uint128(bound(navPoolPerShare_, 1e14, type(uint128).max / 1e18)));
+        D18 pricePoolPerShare = d18(uint128(bound(pricePoolPerShare_, 1e14, type(uint128).max / 1e18)));
         (uint128 depositAmountUsdc, uint128 approvedAmountUsdc,) =
             _depositAndApproveWithFuzzBounds(fuzzDepositAmountUsdc, fuzzApprovedAmountUsdc);
 
@@ -643,10 +647,10 @@ contract BatchRequestManagerDepositsNonTransientTest is BatchRequestManagerBaseT
         batchRequestManager.claimDeposit(poolId, scId, investor, USDC);
 
         batchRequestManager.issueShares{value: COST}(
-            poolId, scId, USDC, _nowIssue(USDC), navPoolPerShare, SHARE_HOOK_GAS, REFUND
+            poolId, scId, USDC, _nowIssue(USDC), pricePoolPerShare, SHARE_HOOK_GAS, REFUND
         );
 
-        uint128 expectedShares = _calcSharesIssued(USDC, approvedAmountUsdc, navPoolPerShare);
+        uint128 expectedShares = _calcSharesIssued(USDC, approvedAmountUsdc, pricePoolPerShare);
 
         vm.expectEmit();
         emit IBatchRequestManager.ClaimDeposit(
@@ -888,25 +892,27 @@ contract BatchRequestManagerRedeemsNonTransientTest is BatchRequestManagerBaseTe
         // Note: Epoch state is tracked internally and tested through other assertions
     }
 
-    function testRevokeSharesSingleEpoch(uint128 navPoolPerShare_, uint128 fuzzRedeemShares, uint128 fuzzApprovedShares)
-        public
-    {
-        D18 navPoolPerShare = d18(uint128(bound(navPoolPerShare_, 1e14, type(uint128).max / 1e18)));
+    function testRevokeSharesSingleEpoch(
+        uint128 pricePoolPerShare_,
+        uint128 fuzzRedeemShares,
+        uint128 fuzzApprovedShares
+    ) public {
+        D18 pricePoolPerShare = d18(uint128(bound(pricePoolPerShare_, 1e14, type(uint128).max / 1e18)));
         (, uint128 approvedShares,,) =
-            _redeemAndApproveWithFuzzBounds(fuzzRedeemShares, fuzzApprovedShares, navPoolPerShare.raw());
+            _redeemAndApproveWithFuzzBounds(fuzzRedeemShares, fuzzApprovedShares, pricePoolPerShare.raw());
 
         vm.recordLogs();
         batchRequestManager.revokeShares{value: COST}(
-            poolId, scId, USDC, _nowRevoke(USDC), navPoolPerShare, SHARE_HOOK_GAS, REFUND
+            poolId, scId, USDC, _nowRevoke(USDC), pricePoolPerShare, SHARE_HOOK_GAS, REFUND
         );
 
         (uint128 revokedShares, uint128 payoutAsset, uint128 payoutPool, D18 eventNav,) = _extractRevokeSharesEvent();
 
         assertEq(revokedShares, approvedShares, "Revoked shares should match approved");
-        assertEq(eventNav.raw(), navPoolPerShare.raw(), "NAV in event mismatch");
+        assertEq(eventNav.raw(), pricePoolPerShare.raw(), "NAV in event mismatch");
 
         // Calculate and verify expected amounts
-        uint128 expectedPayoutPool = navPoolPerShare.mulUint128(approvedShares, MathLib.Rounding.Down);
+        uint128 expectedPayoutPool = pricePoolPerShare.mulUint128(approvedShares, MathLib.Rounding.Down);
         uint128 expectedPayoutAsset = _intoAssetAmount(USDC, expectedPayoutPool);
         assertEq(payoutAsset, expectedPayoutAsset, "Payout asset amount mismatch");
         assertEq(payoutPool, expectedPayoutPool, "Payout pool amount mismatch");
@@ -914,7 +920,7 @@ contract BatchRequestManagerRedeemsNonTransientTest is BatchRequestManagerBaseTe
         {
             (,,, D18 storedNav, uint128 storedPayoutAsset, uint64 revokedAt) =
                 batchRequestManager.epochRedeemAmounts(scId, USDC, _nowRevoke(USDC) - 1);
-            assertEq(storedNav.raw(), navPoolPerShare.raw(), "Stored NAV mismatch");
+            assertEq(storedNav.raw(), pricePoolPerShare.raw(), "Stored NAV mismatch");
             assertEq(storedPayoutAsset, payoutAsset, "Stored payout mismatch");
             assertGt(revokedAt, 0, "Revocation timestamp not set");
         }
@@ -937,7 +943,7 @@ contract BatchRequestManagerRedeemsNonTransientTest is BatchRequestManagerBaseTe
     function testFullClaimRedeemSingleEpoch() public {
         uint128 approvedShares = 100 * DENO_POOL;
         uint128 redeemShares = approvedShares;
-        D18 navPoolPerShare = d18(11, 10);
+        D18 pricePoolPerShare = d18(11, 10);
 
         batchRequestManager.requestRedeem(poolId, scId, redeemShares, investor, USDC);
         batchRequestManager.approveRedeems(
@@ -948,11 +954,11 @@ contract BatchRequestManagerRedeemsNonTransientTest is BatchRequestManagerBaseTe
         batchRequestManager.claimRedeem(poolId, scId, investor, USDC);
 
         batchRequestManager.revokeShares{value: COST}(
-            poolId, scId, USDC, _nowRevoke(USDC), navPoolPerShare, SHARE_HOOK_GAS, REFUND
+            poolId, scId, USDC, _nowRevoke(USDC), pricePoolPerShare, SHARE_HOOK_GAS, REFUND
         );
 
         uint128 expectedAssetAmount =
-            _intoAssetAmount(USDC, navPoolPerShare.mulUint128(approvedShares, MathLib.Rounding.Down));
+            _intoAssetAmount(USDC, pricePoolPerShare.mulUint128(approvedShares, MathLib.Rounding.Down));
 
         vm.expectEmit();
         emit IBatchRequestManager.ClaimRedeem(
@@ -1585,7 +1591,7 @@ contract BatchRequestManagerMultiEpochTest is BatchRequestManagerBaseTest {
     function testClaimDepositSkippedEpochsNoPayout(uint8 skippedEpochs) public {
         vm.assume(skippedEpochs > 0);
 
-        D18 navPoolPerShare = d18(1e18);
+        D18 pricePoolPerShare = d18(1e18);
         uint128 approvedAmountUsdc = 1;
         uint32 lastUpdate = _nowDeposit(USDC);
 
@@ -1599,7 +1605,7 @@ contract BatchRequestManagerMultiEpochTest is BatchRequestManagerBaseTest {
                 poolId, scId, USDC, _nowDeposit(USDC), approvedAmountUsdc, _pricePoolPerAsset(USDC), REFUND
             );
             batchRequestManager.issueShares{value: COST}(
-                poolId, scId, USDC, _nowIssue(USDC), navPoolPerShare, SHARE_HOOK_GAS, REFUND
+                poolId, scId, USDC, _nowIssue(USDC), pricePoolPerShare, SHARE_HOOK_GAS, REFUND
             );
         }
 
@@ -1663,8 +1669,8 @@ contract BatchRequestManagerMultiEpochTest is BatchRequestManagerBaseTest {
         batchRequestManager.claimDeposit(poolId, scId, investor, USDC);
     }
 
-    function testClaimDepositManyEpochs(uint128 navPoolPerShare_, uint128 depositAmountUsdc_, uint8 epochs) public {
-        D18 poolPerShare = d18(uint128(bound(navPoolPerShare_, 1e10, type(uint128).max / 1e18)));
+    function testClaimDepositManyEpochs(uint128 pricePoolPerShare_, uint128 depositAmountUsdc_, uint8 epochs) public {
+        D18 poolPerShare = d18(uint128(bound(pricePoolPerShare_, 1e10, type(uint128).max / 1e18)));
         epochs = uint8(bound(epochs, 3, 50));
         uint128 depositAmountUsdc = uint128(bound(depositAmountUsdc_, MIN_REQUEST_AMOUNT_USDC, MAX_REQUEST_AMOUNT_USDC));
         vm.assume(depositAmountUsdc % epochs == 0);
@@ -1711,7 +1717,7 @@ contract BatchRequestManagerMultiEpochTest is BatchRequestManagerBaseTest {
     function testClaimRedeemSkippedEpochsNoPayout(uint8 skippedEpochs) public {
         vm.assume(skippedEpochs > 0);
 
-        D18 navPoolPerShare = d18(1e18);
+        D18 pricePoolPerShare = d18(1e18);
         uint128 approvedShares = 1;
         uint32 lastUpdate = _nowRedeem(USDC);
 
@@ -1725,7 +1731,7 @@ contract BatchRequestManagerMultiEpochTest is BatchRequestManagerBaseTest {
                 poolId, scId, USDC, _nowRedeem(USDC), approvedShares, _pricePoolPerAsset(USDC)
             );
             batchRequestManager.revokeShares{value: COST}(
-                poolId, scId, USDC, _nowRevoke(USDC), navPoolPerShare, SHARE_HOOK_GAS, REFUND
+                poolId, scId, USDC, _nowRevoke(USDC), pricePoolPerShare, SHARE_HOOK_GAS, REFUND
             );
         }
 
@@ -1782,8 +1788,8 @@ contract BatchRequestManagerMultiEpochTest is BatchRequestManagerBaseTest {
         _assertRedeemRequestEq(USDC, investor, UserOrder(0, 2 + uint32(skippedEpochs)));
     }
 
-    function testClaimRedeemManyEpochs(uint128 navPoolPerShare_, uint128 totalRedeemShares_, uint8 epochs) public {
-        D18 poolPerShare = d18(uint128(bound(navPoolPerShare_, 1e15, type(uint128).max / 1e18)));
+    function testClaimRedeemManyEpochs(uint128 pricePoolPerShare_, uint128 totalRedeemShares_, uint8 epochs) public {
+        D18 poolPerShare = d18(uint128(bound(pricePoolPerShare_, 1e15, type(uint128).max / 1e18)));
         epochs = uint8(bound(epochs, 3, 50));
         uint128 totalRedeemShares =
             uint128(bound(totalRedeemShares_, MIN_REQUEST_AMOUNT_SHARES, MAX_REQUEST_AMOUNT_SHARES));
@@ -2217,9 +2223,9 @@ contract BatchRequestManagerZeroAmountTest is BatchRequestManagerBaseTest {
             poolId, scId, USDC, _nowIssue(USDC), d18(0), SHARE_HOOK_GAS, REFUND
         );
 
-        (,, uint128 approvedPoolAmount,, D18 navPoolPerShare, uint64 issuedAt) =
+        (,, uint128 approvedPoolAmount,, D18 pricePoolPerShare, uint64 issuedAt) =
             batchRequestManager.epochInvestAmounts(scId, USDC, 1);
-        assertEq(navPoolPerShare.raw(), 0, "NAV should be zero");
+        assertEq(pricePoolPerShare.raw(), 0, "NAV should be zero");
         assertEq(issuedAt, 1, "Should be issued at epoch 1");
         assertGt(approvedPoolAmount, 0, "Should have approved amount");
     }
@@ -2247,9 +2253,9 @@ contract BatchRequestManagerZeroAmountTest is BatchRequestManagerBaseTest {
             poolId, scId, USDC, _nowRevoke(USDC), d18(0), SHARE_HOOK_GAS, REFUND
         );
 
-        (,,, D18 navPoolPerShare, uint128 payoutAssetAmount, uint64 revokedAt) =
+        (,,, D18 pricePoolPerShare, uint128 payoutAssetAmount, uint64 revokedAt) =
             batchRequestManager.epochRedeemAmounts(scId, USDC, 1);
-        assertEq(navPoolPerShare.raw(), 0, "NAV should be zero");
+        assertEq(pricePoolPerShare.raw(), 0, "NAV should be zero");
         assertEq(payoutAssetAmount, 0, "Payout should be zero");
         assertEq(revokedAt, 1, "Should be revoked at epoch 1");
     }
@@ -2282,10 +2288,10 @@ contract BatchRequestManagerZeroAmountTest is BatchRequestManagerBaseTest {
             poolId, scId, USDC, _nowIssue(USDC), d18(1), SHARE_HOOK_GAS, REFUND
         );
 
-        (,,, D18 pricePoolPerAsset, D18 navPoolPerShare, uint64 issuedAt) =
+        (,,, D18 pricePoolPerAsset, D18 pricePoolPerShare, uint64 issuedAt) =
             batchRequestManager.epochInvestAmounts(scId, USDC, 1);
         assertEq(pricePoolPerAsset.raw(), 0, "Price should be zero");
-        assertEq(navPoolPerShare.raw(), 1, "NAV should be stored as 1 raw");
+        assertEq(pricePoolPerShare.raw(), 1, "NAV should be stored as 1 raw");
         assertEq(issuedAt, 1, "Should be issued at epoch 1");
     }
 


### PR DESCRIPTION
Ref: https://kflabs.slack.com/archives/C07PG2EUR9C/p1756726761595099?thread_ts=1756721915.894519&cid=C07PG2EUR9C

### Product requirements

* Standardize naming convention for price variables across the codebase to distinguish between share class prices and asset prices

### Design notes

* Renamed `navPoolPerShare` to `pricePoolPerShare` throughout the codebase for clarity and consistency
* Renamed `pricePerUnit` to `pricePoolPerAsset` in message serialization to be more explicit about price direction
* Changes affect Hub, ShareClassManager, MessageDispatcher, BatchRequestManager, and all related interfaces
* No functional changes, purely a naming refactor to improve code readability and reduce ambiguity between price types