### PR TITLE
Idea: Allow nested withBatch calls for composibility

### DIFF
--- a/src/core/Gateway.sol
+++ b/src/core/Gateway.sol
@@ -260,9 +260,10 @@ contract Gateway is Auth, Recoverable, IGateway {
 
     /// @inheritdoc IGateway
     function withBatch(bytes memory data, address refund) external payable {
-        _startBatching();
-        _batcher = msg.sender;
+        bool wasBatching = isBatching;
+        if (!wasBatching) _startBatching();
 
+        _batcher = msg.sender;
         (bool success, bytes memory returnData) = msg.sender.call(data);
         if (!success) {
             uint256 length = returnData.length;
@@ -276,7 +277,7 @@ contract Gateway is Auth, Recoverable, IGateway {
         // Force the user to call lockCallback()
         require(address(_batcher) == address(0), CallbackWasNotLocked());
 
-        _endBatching(refund);
+        if (!wasBatching) _endBatching(refund);
     }
 
     /// @inheritdoc IGateway

--- a/test/core/unit/Gateway.t.sol
+++ b/test/core/unit/Gateway.t.sol
@@ -876,7 +876,8 @@ contract IntegrationMock is Test {
     }
 
     function _nested() external payable {
-        gateway.withBatch(abi.encodeWithSelector(this._nested.selector), address(0));
+        assertEq(gateway.lockCallback(), address(this));
+        gateway.withBatch(abi.encodeWithSelector(this._success.selector, false, 2), address(0));
     }
 
     function _emptyError() external payable {
@@ -916,12 +917,6 @@ contract GatewayTestWithBatch is GatewayTest {
         integration = new IntegrationMock(gateway);
     }
 
-    function testErrAlreadyBatching() public {
-        vm.prank(ANY);
-        vm.expectRevert(IGateway.AlreadyBatching.selector);
-        integration.callNested(REFUND);
-    }
-
     function testErrCallFailedWithEmptyRevert() public {
         vm.prank(ANY);
         vm.expectRevert(IGateway.CallFailedWithEmptyRevert.selector);
@@ -941,6 +936,13 @@ contract GatewayTestWithBatch is GatewayTest {
 
         assertEq(integration.wasCalled(), true);
         assertEq(REFUND.balance, 1234);
+    }
+
+    function testWithCallbackNested() public {
+        vm.prank(ANY);
+        integration.callNested(REFUND);
+
+        assertEq(integration.wasCalled(), true);
     }
 }
 


### PR DESCRIPTION
Just a simple and minor change that allows integrations to call other integrations that already use `withBatch`, which I think is super great for composability and UX. For example, it allows:

- IntegrationA.withBatch()
  - callback
    - IntegrationB.withBatch()
      - callback
    - IntegrationC.withBatch()
      - callback
  
The entire above schema can be batched in just one batch instead of reverting when `integrationB` is called (due to nested batches).

### How does it works?

If `withBatch` is called, and the `Gateway` was already batching, it will just skip `_startBatching` and `_endBatching` to continue batching by the previous `withBatch` or `multicall`.
