### PR TITLE
Removing shortcuts

### DIFF
--- a/test/integration/recon-end-to-end/CryticSanity.sol
+++ b/test/integration/recon-end-to-end/CryticSanity.sol
@@ -51,455 +51,455 @@ contract CryticSanity is Test, TargetFunctions, FoundryAsserts {
     }
 
     /// === SANITY CHECKS === ///
-    function test_shortcut_deployNewTokenPoolAndShare_deposit() public {
-        shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
+    // function test_shortcut_deployNewTokenPoolAndShare_deposit() public {
+    //     shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
 
-        spoke_updateMember(type(uint64).max);
+    //     spoke_updateMember(type(uint64).max);
 
-        vault_requestDeposit(1e18, 0);
-    }
+    //     vault_requestDeposit(1e18, 0);
+    // }
 
-    function test_vault_deposit_and_fulfill() public {
-        shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
+    // function test_vault_deposit_and_fulfill() public {
+    //     shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
 
-        // price needs to be set in valuation before calling updatePricePoolPerShare
-        transientValuation_setPrice_clamped(1e18);
+    //     // price needs to be set in valuation before calling updatePricePoolPerShare
+    //     transientValuation_setPrice_clamped(1e18);
 
-        hub_notifyAssetPrice();
-        hub_notifySharePrice_clamped();
+    //     hub_notifyAssetPrice();
+    //     hub_notifySharePrice_clamped();
 
-        spoke_updateMember(type(uint64).max);
+    //     spoke_updateMember(type(uint64).max);
 
-        vault_requestDeposit(1e18, 0);
+    //     vault_requestDeposit(1e18, 0);
 
-        // Set price again after request (critical!)
-        transientValuation_setPrice_clamped(1e18);
+    //     // Set price again after request (critical!)
+    //     transientValuation_setPrice_clamped(1e18);
 
-        uint32 depositEpoch = nowDepositEpoch();
-        hub_approveDeposits(depositEpoch, 1e18);
-        hub_issueShares(depositEpoch, 1e18);
+    //     uint32 depositEpoch = nowDepositEpoch();
+    //     hub_approveDeposits(depositEpoch, 1e18);
+    //     hub_issueShares(depositEpoch, 1e18);
 
-        hub_notifyDeposit(MAX_CLAIMS);
+    //     hub_notifyDeposit(MAX_CLAIMS);
 
-        vault_deposit(1e18);
-    }
+    //     vault_deposit(1e18);
+    // }
 
-    function test_vault_deposit_and_fulfill_sync() public {
-        shortcut_deployNewTokenPoolAndShare(18, 12, false, false, false, false);
-        IBaseVault vault = IBaseVault(_getVault());
+    // function test_vault_deposit_and_fulfill_sync() public {
+    //     shortcut_deployNewTokenPoolAndShare(18, 12, false, false, false, false);
+    //     IBaseVault vault = IBaseVault(_getVault());
 
-        // price needs to be set in valuation before calling updatePricePoolPerShare
-        transientValuation_setPrice_clamped(1e18);
-        hub_updateSharePrice(
-            vault.poolId().raw(),
-            uint128(vault.scId().raw()),
-            1e18
-        );
+    //     // price needs to be set in valuation before calling updatePricePoolPerShare
+    //     transientValuation_setPrice_clamped(1e18);
+    //     hub_updateSharePrice(
+    //         vault.poolId().raw(),
+    //         uint128(vault.scId().raw()),
+    //         1e18
+    //     );
 
-        hub_notifyAssetPrice();
-        hub_notifySharePrice_clamped();
+    //     hub_notifyAssetPrice();
+    //     hub_notifySharePrice_clamped();
 
-        spoke_updateMember(type(uint64).max);
+    //     spoke_updateMember(type(uint64).max);
 
-        vault_deposit(1e18);
-    }
+    //     vault_deposit(1e18);
+    // }
 
-    function test_vault_deposit_and_fulfill_shortcut() public {
-        shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
+    // function test_vault_deposit_and_fulfill_shortcut() public {
+    //     shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
 
-        shortcut_deposit_and_claim(1e18, 1e18, 1e18, 1e18, 0);
-    }
+    //     shortcut_deposit_and_claim(1e18, 1e18, 1e18, 1e18, 0);
+    // }
 
-    function test_vault_deposit_and_redeem() public {
-        shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
+    // function test_vault_deposit_and_redeem() public {
+    //     shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
 
-        transientValuation_setPrice_clamped(1e18);
+    //     transientValuation_setPrice_clamped(1e18);
 
-        hub_notifySharePrice_clamped();
-        hub_notifyAssetPrice();
-        spoke_updateMember(type(uint64).max);
+    //     hub_notifySharePrice_clamped();
+    //     hub_notifyAssetPrice();
+    //     spoke_updateMember(type(uint64).max);
 
-        vault_requestDeposit(1e18, 0);
+    //     vault_requestDeposit(1e18, 0);
 
-        transientValuation_setPrice_clamped(1e18);
+    //     transientValuation_setPrice_clamped(1e18);
 
-        uint32 depositEpoch = nowDepositEpoch();
-        hub_approveDeposits(depositEpoch, 1e18);
-        hub_issueShares(depositEpoch, 1e18);
+    //     uint32 depositEpoch = nowDepositEpoch();
+    //     hub_approveDeposits(depositEpoch, 1e18);
+    //     hub_issueShares(depositEpoch, 1e18);
 
-        // need to call claimDeposit first to mint the shares
-        hub_notifyDeposit(MAX_CLAIMS);
+    //     // need to call claimDeposit first to mint the shares
+    //     hub_notifyDeposit(MAX_CLAIMS);
 
-        vault_deposit(1e18);
+    //     vault_deposit(1e18);
 
-        vault_requestRedeem(1e18, 0);
+    //     vault_requestRedeem(1e18, 0);
 
-        uint32 redeemEpoch = nowRedeemEpoch();
-        hub_approveRedeems(redeemEpoch, 1e18);
-        hub_revokeShares(redeemEpoch, 1e18);
+    //     uint32 redeemEpoch = nowRedeemEpoch();
+    //     hub_approveRedeems(redeemEpoch, 1e18);
+    //     hub_revokeShares(redeemEpoch, 1e18);
 
-        hub_notifyRedeem(MAX_CLAIMS);
+    //     hub_notifyRedeem(MAX_CLAIMS);
 
-        vault_withdraw(1e18, 0);
-    }
+    //     vault_withdraw(1e18, 0);
+    // }
 
-    function test_vault_deposit_shortcut() public {
-        shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
+    // function test_vault_deposit_shortcut() public {
+    //     shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
 
-        shortcut_deposit_and_claim(1e18, 1e18, 1e18, 1e18, 0);
-    }
+    //     shortcut_deposit_and_claim(1e18, 1e18, 1e18, 1e18, 0);
+    // }
 
-    function test_vault_redeem_and_fulfill_shortcut() public {
-        shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
+    // function test_vault_redeem_and_fulfill_shortcut() public {
+    //     shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
 
-        shortcut_deposit_and_claim(1e18, 1e18, 1e18, 1e18, 0);
+    //     shortcut_deposit_and_claim(1e18, 1e18, 1e18, 1e18, 0);
 
-        shortcut_redeem_and_claim(1e18, 1e18, 0);
-    }
+    //     shortcut_redeem_and_claim(1e18, 1e18, 0);
+    // }
 
-    function test_vault_redeem_and_fulfill_shortcut_clamped() public {
-        shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
+    // function test_vault_redeem_and_fulfill_shortcut_clamped() public {
+    //     shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
 
-        shortcut_deposit_and_claim(1e18, 1e18, 1e18, 1e18, 0);
+    //     shortcut_deposit_and_claim(1e18, 1e18, 1e18, 1e18, 0);
 
-        shortcut_withdraw_and_claim_clamped(1e18 - 1, 1e18, 0);
-    }
+    //     shortcut_withdraw_and_claim_clamped(1e18 - 1, 1e18, 0);
+    // }
 
-    function test_shortcut_cancel_redeem_clamped() public {
-        shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
+    // function test_shortcut_cancel_redeem_clamped() public {
+    //     shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
 
-        shortcut_deposit_and_claim(1e18, 1e18, 1e18, 1e18, 0);
+    //     shortcut_deposit_and_claim(1e18, 1e18, 1e18, 1e18, 0);
 
-        shortcut_cancel_redeem_clamped(1e18 - 1, 1e18, 0);
-    }
+    //     shortcut_cancel_redeem_clamped(1e18 - 1, 1e18, 0);
+    // }
 
-    function test_shortcut_deposit_and_cancel() public {
-        shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
+    // function test_shortcut_deposit_and_cancel() public {
+    //     shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
 
-        shortcut_deposit_and_cancel(1e18, 1e18, 1e18, 1e18, 0);
-    }
+    //     shortcut_deposit_and_cancel(1e18, 1e18, 1e18, 1e18, 0);
+    // }
 
-    function test_shortcut_deposit_and_cancel_notify() public {
-        shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
+    // function test_shortcut_deposit_and_cancel_notify() public {
+    //     shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
 
-        shortcut_request_deposit(1e18, 1e18, 1e18, 0);
+    //     shortcut_request_deposit(1e18, 1e18, 1e18, 0);
 
-        uint32 _nowDepositEpoch = nowDepositEpoch();
-        hub_approveDeposits(_nowDepositEpoch, 5e17);
-        hub_issueShares(_nowDepositEpoch, 5e17);
+    //     uint32 _nowDepositEpoch = nowDepositEpoch();
+    //     hub_approveDeposits(_nowDepositEpoch, 5e17);
+    //     hub_issueShares(_nowDepositEpoch, 5e17);
 
-        vault_cancelDepositRequest();
+    //     vault_cancelDepositRequest();
 
-        hub_notifyDeposit(1);
-    }
+    //     hub_notifyDeposit(1);
+    // }
 
-    function test_shortcut_deposit_queue_cancel() public {
-        shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
+    // function test_shortcut_deposit_queue_cancel() public {
+    //     shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
 
-        shortcut_deposit_queue_cancel(1e18, 1e18, 1e18, 5e17, 1e18, 0);
+    //     shortcut_deposit_queue_cancel(1e18, 1e18, 1e18, 5e17, 1e18, 0);
 
-        hub_notifyDeposit(1);
-    }
+    //     hub_notifyDeposit(1);
+    // }
 
-    function test_shortcut_deposit_cancel_claim() public {
-        shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
+    // function test_shortcut_deposit_cancel_claim() public {
+    //     shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
 
-        shortcut_deposit_cancel_claim(1e18, 1e18, 1e18, 1e18, 0);
-    }
+    //     shortcut_deposit_cancel_claim(1e18, 1e18, 1e18, 1e18, 0);
+    // }
 
-    function test_shortcut_cancel_redeem_claim_clamped() public {
-        shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
+    // function test_shortcut_cancel_redeem_claim_clamped() public {
+    //     shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
 
-        shortcut_deposit_and_claim(1e18, 1e18, 1e18, 1e18, 0);
+    //     shortcut_deposit_and_claim(1e18, 1e18, 1e18, 1e18, 0);
 
-        shortcut_cancel_redeem_claim_clamped(1e18 - 1, 1e18, 0);
-    }
+    //     shortcut_cancel_redeem_claim_clamped(1e18 - 1, 1e18, 0);
+    // }
 
-    function test_shortcut_deployNewTokenPoolAndShare_change_price() public {
-        shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
+    // function test_shortcut_deployNewTokenPoolAndShare_change_price() public {
+    //     shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
 
-        transientValuation_setPrice_clamped(1e18);
+    //     transientValuation_setPrice_clamped(1e18);
 
-        hub_notifySharePrice_clamped();
-        hub_notifyAssetPrice();
-        spoke_updateMember(type(uint64).max);
-    }
+    //     hub_notifySharePrice_clamped();
+    //     hub_notifyAssetPrice();
+    //     spoke_updateMember(type(uint64).max);
+    // }
 
-    function test_shortcut_deployNewTokenPoolAndShare_only() public {
-        shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
-    }
+    // function test_shortcut_deployNewTokenPoolAndShare_only() public {
+    //     shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
+    // }
 
-    function test_mint_sync_shortcut() public {
-        shortcut_deployNewTokenPoolAndShare(18, 12, false, false, false, false);
+    // function test_mint_sync_shortcut() public {
+    //     shortcut_deployNewTokenPoolAndShare(18, 12, false, false, false, false);
 
-        shortcut_mint_sync(1e18, 1e18);
-    }
+    //     shortcut_mint_sync(1e18, 1e18);
+    // }
 
-    function test_deposit_sync_shortcut() public {
-        shortcut_deployNewTokenPoolAndShare(18, 12, false, false, false, false);
+    // function test_deposit_sync_shortcut() public {
+    //     shortcut_deployNewTokenPoolAndShare(18, 12, false, false, false, false);
 
-        shortcut_deposit_sync(1e18, 1e18);
-    }
+    //     shortcut_deposit_sync(1e18, 1e18);
+    // }
 
-    function test_balanceSheet_deposit() public {
-        // Deploy new token, pool and share class with default decimals
-        shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
+    // function test_balanceSheet_deposit() public {
+    //     // Deploy new token, pool and share class with default decimals
+    //     shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
 
-        // price needs to be set in valuation before calling updatePricePoolPerShare
-        transientValuation_setPrice_clamped(1e18);
+    //     // price needs to be set in valuation before calling updatePricePoolPerShare
+    //     transientValuation_setPrice_clamped(1e18);
 
-        hub_notifyAssetPrice();
-        hub_notifySharePrice_clamped();
-        // Set up test values
-        uint256 tokenId = 0; // For ERC20
-        uint128 depositAmount = 1e18;
+    //     hub_notifyAssetPrice();
+    //     hub_notifySharePrice_clamped();
+    //     // Set up test values
+    //     uint256 tokenId = 0; // For ERC20
+    //     uint128 depositAmount = 1e18;
 
-        asset_approve(address(balanceSheet), depositAmount);
-        // Call balanceSheet_deposit with test values
-        balanceSheet_deposit(tokenId, depositAmount);
-    }
+    //     asset_approve(address(balanceSheet), depositAmount);
+    //     // Call balanceSheet_deposit with test values
+    //     balanceSheet_deposit(tokenId, depositAmount);
+    // }
 
-    // forge test --match-test test_hub_updateHoldingValue_liability_branch -vvv
-    function test_hub_updateHoldingValue_liability_branch() public {
-        // Setup: Deploy a new pool and share class with liability holding
-        shortcut_deployNewTokenPoolAndShare(18, 18, false, false, true, true);
+    // // forge test --match-test test_hub_updateHoldingValue_liability_branch -vvv
+    // function test_hub_updateHoldingValue_liability_branch() public {
+    //     // Setup: Deploy a new pool and share class with liability holding
+    //     shortcut_deployNewTokenPoolAndShare(18, 18, false, false, true, true);
 
-        IBaseVault vault = IBaseVault(_getVault());
-        PoolId poolId = vault.poolId();
-        ShareClassId scId = vault.scId();
-        AssetId assetId = _getAssetId();
+    //     IBaseVault vault = IBaseVault(_getVault());
+    //     PoolId poolId = vault.poolId();
+    //     ShareClassId scId = vault.scId();
+    //     AssetId assetId = _getAssetId();
 
-        console2.log("Pool and share class with liability holding deployed");
+    //     console2.log("Pool and share class with liability holding deployed");
 
-        // Verify that the holding is marked as a liability
-        bool isLiab = holdings.isLiability(poolId, scId, assetId);
-        assertTrue(isLiab, "Holding should be marked as liability");
-        console2.log("Verified holding is marked as liability:", isLiab);
+    //     // Verify that the holding is marked as a liability
+    //     bool isLiab = holdings.isLiability(poolId, scId, assetId);
+    //     assertTrue(isLiab, "Holding should be marked as liability");
+    //     console2.log("Verified holding is marked as liability:", isLiab);
 
-        // Set a price using transient valuation if needed for value updates
-        transientValuation_setPrice_clamped(1e18);
-        console2.log("Set initial price to 1e18");
+    //     // Set a price using transient valuation if needed for value updates
+    //     transientValuation_setPrice_clamped(1e18);
+    //     console2.log("Set initial price to 1e18");
 
-        // Notify the system about the asset and share prices
-        hub_notifyAssetPrice();
-        hub_notifySharePrice_clamped();
-        console2.log("Notified asset and share prices");
+    //     // Notify the system about the asset and share prices
+    //     hub_notifyAssetPrice();
+    //     hub_notifySharePrice_clamped();
+    //     console2.log("Notified asset and share prices");
 
-        // Deposit assets directly to the balance sheet to affect holding value
-        uint256 tokenId = 0; // For ERC20
-        uint128 depositAmount = 1e18;
+    //     // Deposit assets directly to the balance sheet to affect holding value
+    //     uint256 tokenId = 0; // For ERC20
+    //     uint128 depositAmount = 1e18;
 
-        // Approve the balance sheet to spend our assets
-        asset_approve(address(balanceSheet), depositAmount);
-        console2.log("Approved balance sheet to spend assets");
+    //     // Approve the balance sheet to spend our assets
+    //     asset_approve(address(balanceSheet), depositAmount);
+    //     console2.log("Approved balance sheet to spend assets");
 
-        // Deposit assets to the balance sheet
-        balanceSheet_deposit(tokenId, depositAmount);
-        console2.log("Deposited", depositAmount, "assets to balance sheet");
+    //     // Deposit assets to the balance sheet
+    //     balanceSheet_deposit(tokenId, depositAmount);
+    //     console2.log("Deposited", depositAmount, "assets to balance sheet");
 
-        // Submit the queued assets to actually affect the holding value
-        balanceSheet_submitQueuedAssets(0);
-        console2.log("Submitted queued assets to balance sheet");
+    //     // Submit the queued assets to actually affect the holding value
+    //     balanceSheet_submitQueuedAssets(0);
+    //     console2.log("Submitted queued assets to balance sheet");
 
-        // Call hub_updateHoldingValue - this should reach the liability branch
-        // The Holdings.update() function will use the valuation to get a quote
-        // and update the holding value, with the liability flag being true
-        hub_updateHoldingValue();
-        console2.log("Called hub_updateHoldingValue for liability holding");
+    //     // Call hub_updateHoldingValue - this should reach the liability branch
+    //     // The Holdings.update() function will use the valuation to get a quote
+    //     // and update the holding value, with the liability flag being true
+    //     hub_updateHoldingValue();
+    //     console2.log("Called hub_updateHoldingValue for liability holding");
 
-        // Get holding value after update
-        uint128 holdingValue = holdings.value(poolId, scId, assetId);
-        console2.log("Holding value after update:", holdingValue);
+    //     // Get holding value after update
+    //     uint128 holdingValue = holdings.value(poolId, scId, assetId);
+    //     console2.log("Holding value after update:", holdingValue);
 
-        // Verify the holding value is now nonzero
-        assertTrue(
-            holdingValue > 0,
-            "Holding value should be nonzero after deposit"
-        );
+    //     // Verify the holding value is now nonzero
+    //     assertTrue(
+    //         holdingValue > 0,
+    //         "Holding value should be nonzero after deposit"
+    //     );
 
-        // Change price to demonstrate that the liability branch works with value changes
-        transientValuation_setPrice_clamped(2e18);
-        console2.log("Changed price to 2e18");
+    //     // Change price to demonstrate that the liability branch works with value changes
+    //     transientValuation_setPrice_clamped(2e18);
+    //     console2.log("Changed price to 2e18");
 
-        // Call hub_updateHoldingValue again
-        hub_updateHoldingValue();
-        console2.log("Called hub_updateHoldingValue again after price change");
+    //     // Call hub_updateHoldingValue again
+    //     hub_updateHoldingValue();
+    //     console2.log("Called hub_updateHoldingValue again after price change");
 
-        // Get final holding value
-        uint128 finalValue = holdings.value(poolId, scId, assetId);
-        console2.log("Final holding value:", finalValue);
+    //     // Get final holding value
+    //     uint128 finalValue = holdings.value(poolId, scId, assetId);
+    //     console2.log("Final holding value:", finalValue);
 
-        // Verify the final holding value is still nonzero
-        assertTrue(finalValue > 0, "Final holding value should remain nonzero");
+    //     // Verify the final holding value is still nonzero
+    //     assertTrue(finalValue > 0, "Final holding value should remain nonzero");
 
-        // Verify the holding is still marked as a liability
-        bool stillLiab = holdings.isLiability(poolId, scId, assetId);
-        assertTrue(stillLiab, "Holding should still be marked as liability");
+    //     // Verify the holding is still marked as a liability
+    //     bool stillLiab = holdings.isLiability(poolId, scId, assetId);
+    //     assertTrue(stillLiab, "Holding should still be marked as liability");
 
-        console2.log(
-            "Test completed: hub_updateHoldingValue successfully reached liability branch"
-        );
-    }
+    //     console2.log(
+    //         "Test completed: hub_updateHoldingValue successfully reached liability branch"
+    //     );
+    // }
 
-    // forge test --match-test test_shortcut_liability_vs_regular_holding -vvv
-    function test_shortcut_liability_vs_regular_holding() public {
-        // Test 1: Deploy with regular holding (isLiability = false)
-        shortcut_deployNewTokenPoolAndShare(18, 18, false, false, true, false);
+    // // forge test --match-test test_shortcut_liability_vs_regular_holding -vvv
+    // function test_shortcut_liability_vs_regular_holding() public {
+    //     // Test 1: Deploy with regular holding (isLiability = false)
+    //     shortcut_deployNewTokenPoolAndShare(18, 18, false, false, true, false);
 
-        IBaseVault vault1 = IBaseVault(_getVault());
-        PoolId poolId1 = vault1.poolId();
-        ShareClassId scId1 = vault1.scId();
-        AssetId assetId1 = _getAssetId();
+    //     IBaseVault vault1 = IBaseVault(_getVault());
+    //     PoolId poolId1 = vault1.poolId();
+    //     ShareClassId scId1 = vault1.scId();
+    //     AssetId assetId1 = _getAssetId();
 
-        // Verify it's NOT a liability
-        bool isLiab1 = holdings.isLiability(poolId1, scId1, assetId1);
-        assertFalse(
-            isLiab1,
-            "Regular holding should NOT be marked as liability"
-        );
-        console2.log("Regular holding verified - isLiability:", isLiab1);
+    //     // Verify it's NOT a liability
+    //     bool isLiab1 = holdings.isLiability(poolId1, scId1, assetId1);
+    //     assertFalse(
+    //         isLiab1,
+    //         "Regular holding should NOT be marked as liability"
+    //     );
+    //     console2.log("Regular holding verified - isLiability:", isLiab1);
 
-        // Reset for second test (this is a simple demonstration)
-        // In a real fuzzing scenario, you'd typically have separate test functions
-        console2.log(
-            "Test completed: Both regular and liability holdings work correctly"
-        );
-    }
+    //     // Reset for second test (this is a simple demonstration)
+    //     // In a real fuzzing scenario, you'd typically have separate test functions
+    //     console2.log(
+    //         "Test completed: Both regular and liability holdings work correctly"
+    //     );
+    // }
 
-    function test_balanceSheet_issue_basic() public {
-        // Setup infrastructure
-        shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
+    // function test_balanceSheet_issue_basic() public {
+    //     // Setup infrastructure
+    //     shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
 
-        // Set prices
-        transientValuation_setPrice_clamped(1e18);
-        hub_notifyAssetPrice();
-        hub_notifySharePrice_clamped();
-        spoke_updateMember(type(uint64).max);
+    //     // Set prices
+    //     transientValuation_setPrice_clamped(1e18);
+    //     hub_notifyAssetPrice();
+    //     hub_notifySharePrice_clamped();
+    //     spoke_updateMember(type(uint64).max);
 
-        // Issue shares - verify no revert
-        balanceSheet_issue(100e18);
-    }
+    //     // Issue shares - verify no revert
+    //     balanceSheet_issue(100e18);
+    // }
 
-    function test_balanceSheet_revoke_basic() public {
-        // Setup infrastructure
-        shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
+    // function test_balanceSheet_revoke_basic() public {
+    //     // Setup infrastructure
+    //     shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
 
-        // Set prices
-        transientValuation_setPrice_clamped(1e18);
-        hub_notifyAssetPrice();
-        hub_notifySharePrice_clamped();
-        spoke_updateMember(type(uint64).max);
+    //     // Set prices
+    //     transientValuation_setPrice_clamped(1e18);
+    //     hub_notifyAssetPrice();
+    //     hub_notifySharePrice_clamped();
+    //     spoke_updateMember(type(uint64).max);
 
-        // Issue shares first
-        balanceSheet_issue(200e18);
-
-        // Approve and revoke
-        IBaseVault vault = IBaseVault(_getVault());
-        vm.startPrank(_getActor());
-        spoke.shareToken(vault.poolId(), vault.scId()).approve(
-            address(balanceSheet),
-            type(uint256).max
-        );
-        vm.stopPrank();
-
-        balanceSheet_revoke(100e18);
-    }
-
-    function test_balanceSheet_withdraw_basic() public {
-        // Setup infrastructure
-        shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
-
-        // Set prices
-        transientValuation_setPrice_clamped(1e18);
-        hub_notifyAssetPrice();
-        hub_notifySharePrice_clamped();
-
-        // Deposit first
-        asset_approve(address(balanceSheet), 200e18);
-        balanceSheet_deposit(0, 200e18);
-
-        // Withdraw
-        balanceSheet_withdraw(0, 100e18);
-    }
-
-    function test_balanceSheet_submitQueuedShares_basic() public {
-        // Setup infrastructure
-        shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
-
-        // Set prices
-        transientValuation_setPrice_clamped(1e18);
-        hub_notifyAssetPrice();
-        hub_notifySharePrice_clamped();
-        spoke_updateMember(type(uint64).max);
-
-        // Queue some shares
-        balanceSheet_issue(100e18);
-
-        // Submit queued shares
-        balanceSheet_submitQueuedShares(0);
-    }
-
-    function test_balanceSheet_submitQueuedAssets_basic() public {
-        // Setup infrastructure
-        shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
-
-        // Set prices
-        transientValuation_setPrice_clamped(1e18);
-        hub_notifyAssetPrice();
-        hub_notifySharePrice_clamped();
-
-        // Queue some assets
-        asset_approve(address(balanceSheet), 100e18);
-        balanceSheet_deposit(0, 100e18);
-
-        // Submit queued assets
-        balanceSheet_submitQueuedAssets(0);
-    }
-
-    function test_queue_issue_revoke_sequence() public {
-        // Setup infrastructure
-        shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
-
-        // Set prices
-        transientValuation_setPrice_clamped(1e18);
-        hub_notifyAssetPrice();
-        hub_notifySharePrice_clamped();
-        spoke_updateMember(type(uint64).max);
-
-        // Issue initial batch
-        balanceSheet_issue(200e18);
-
-        // Approve for revocations
-        IBaseVault vault = IBaseVault(_getVault());
-        vm.startPrank(_getActor());
-        spoke.shareToken(vault.poolId(), vault.scId()).approve(
-            address(balanceSheet),
-            type(uint256).max
-        );
-        vm.stopPrank();
-
-        // Execute sequence
-        balanceSheet_revoke(50e18);
-        balanceSheet_issue(75e18);
-        balanceSheet_revoke(100e18);
-    }
-
-    function test_queue_deposit_withdraw_sequence() public {
-        // Setup infrastructure
-        shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
-
-        // Set prices
-        transientValuation_setPrice_clamped(1e18);
-        hub_notifyAssetPrice();
-        hub_notifySharePrice_clamped();
-        spoke_updateMember(type(uint64).max);
-
-        // Approve for all operations
-        asset_approve(address(balanceSheet), 1000e18);
-
-        // Execute sequence
-        balanceSheet_deposit(0, 200e18);
-        balanceSheet_withdraw(0, 50e18);
-        balanceSheet_deposit(0, 100e18);
-    }
+    //     // Issue shares first
+    //     balanceSheet_issue(200e18);
+
+    //     // Approve and revoke
+    //     IBaseVault vault = IBaseVault(_getVault());
+    //     vm.startPrank(_getActor());
+    //     spoke.shareToken(vault.poolId(), vault.scId()).approve(
+    //         address(balanceSheet),
+    //         type(uint256).max
+    //     );
+    //     vm.stopPrank();
+
+    //     balanceSheet_revoke(100e18);
+    // }
+
+    // function test_balanceSheet_withdraw_basic() public {
+    //     // Setup infrastructure
+    //     shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
+
+    //     // Set prices
+    //     transientValuation_setPrice_clamped(1e18);
+    //     hub_notifyAssetPrice();
+    //     hub_notifySharePrice_clamped();
+
+    //     // Deposit first
+    //     asset_approve(address(balanceSheet), 200e18);
+    //     balanceSheet_deposit(0, 200e18);
+
+    //     // Withdraw
+    //     balanceSheet_withdraw(0, 100e18);
+    // }
+
+    // function test_balanceSheet_submitQueuedShares_basic() public {
+    //     // Setup infrastructure
+    //     shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
+
+    //     // Set prices
+    //     transientValuation_setPrice_clamped(1e18);
+    //     hub_notifyAssetPrice();
+    //     hub_notifySharePrice_clamped();
+    //     spoke_updateMember(type(uint64).max);
+
+    //     // Queue some shares
+    //     balanceSheet_issue(100e18);
+
+    //     // Submit queued shares
+    //     balanceSheet_submitQueuedShares(0);
+    // }
+
+    // function test_balanceSheet_submitQueuedAssets_basic() public {
+    //     // Setup infrastructure
+    //     shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
+
+    //     // Set prices
+    //     transientValuation_setPrice_clamped(1e18);
+    //     hub_notifyAssetPrice();
+    //     hub_notifySharePrice_clamped();
+
+    //     // Queue some assets
+    //     asset_approve(address(balanceSheet), 100e18);
+    //     balanceSheet_deposit(0, 100e18);
+
+    //     // Submit queued assets
+    //     balanceSheet_submitQueuedAssets(0);
+    // }
+
+    // function test_queue_issue_revoke_sequence() public {
+    //     // Setup infrastructure
+    //     shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
+
+    //     // Set prices
+    //     transientValuation_setPrice_clamped(1e18);
+    //     hub_notifyAssetPrice();
+    //     hub_notifySharePrice_clamped();
+    //     spoke_updateMember(type(uint64).max);
+
+    //     // Issue initial batch
+    //     balanceSheet_issue(200e18);
+
+    //     // Approve for revocations
+    //     IBaseVault vault = IBaseVault(_getVault());
+    //     vm.startPrank(_getActor());
+    //     spoke.shareToken(vault.poolId(), vault.scId()).approve(
+    //         address(balanceSheet),
+    //         type(uint256).max
+    //     );
+    //     vm.stopPrank();
+
+    //     // Execute sequence
+    //     balanceSheet_revoke(50e18);
+    //     balanceSheet_issue(75e18);
+    //     balanceSheet_revoke(100e18);
+    // }
+
+    // function test_queue_deposit_withdraw_sequence() public {
+    //     // Setup infrastructure
+    //     shortcut_deployNewTokenPoolAndShare(18, 12, false, false, true, false);
+
+    //     // Set prices
+    //     transientValuation_setPrice_clamped(1e18);
+    //     hub_notifyAssetPrice();
+    //     hub_notifySharePrice_clamped();
+    //     spoke_updateMember(type(uint64).max);
+
+    //     // Approve for all operations
+    //     asset_approve(address(balanceSheet), 1000e18);
+
+    //     // Execute sequence
+    //     balanceSheet_deposit(0, 200e18);
+    //     balanceSheet_withdraw(0, 50e18);
+    //     balanceSheet_deposit(0, 100e18);
+    // }
 }

--- a/test/integration/recon-end-to-end/TargetFunctions.sol
+++ b/test/integration/recon-end-to-end/TargetFunctions.sol
@@ -86,9 +86,6 @@ abstract contract TargetFunctions is
     // ═══════════════════════════════════════════════════════════════
     // SHORTCUT FUNCTIONS
     // ═══════════════════════════════════════════════════════════════
-    // ═══════════════════════════════════════════════════════════════
-    // SHORTCUT FUNCTIONS
-    // ═══════════════════════════════════════════════════════════════
     /// @dev This is the main system setup function done like this to explore more possible states
     /// @dev Deploy new asset, add asset to pool, deploy share class, deploy vault
     function shortcut_deployNewTokenPoolAndShare(
@@ -264,382 +261,382 @@ abstract contract TargetFunctions is
         return (_token, _shareToken, _vault, _assetId, _scId);
     }
 
-    function shortcut_request_deposit(
-        uint64 /* pricePoolPerShare */,
-        uint128 priceValuation,
-        uint256 amount,
-        uint256 toEntropy
-    ) public {
-        transientValuation_setPrice_clamped(priceValuation);
+    // function shortcut_request_deposit(
+    //     uint64 /* pricePoolPerShare */,
+    //     uint128 priceValuation,
+    //     uint256 amount,
+    //     uint256 toEntropy
+    // ) public {
+    //     transientValuation_setPrice_clamped(priceValuation);
 
-        hub_notifySharePrice_clamped();
-        hub_notifyAssetPrice();
-        spoke_updateMember(type(uint64).max);
+    //     hub_notifySharePrice_clamped();
+    //     hub_notifyAssetPrice();
+    //     spoke_updateMember(type(uint64).max);
 
-        vault_requestDeposit(amount, toEntropy);
-    }
+    //     vault_requestDeposit(amount, toEntropy);
+    // }
 
-    function shortcut_deposit_sync(uint256 assets, uint128 navPerShare) public {
-        IBaseVault vault = _getVault();
+    // function shortcut_deposit_sync(uint256 assets, uint128 navPerShare) public {
+    //     IBaseVault vault = _getVault();
 
-        transientValuation_setPrice_clamped(navPerShare);
-        hub_updateSharePrice(
-            vault.poolId().raw(),
-            uint128(vault.scId().raw()),
-            navPerShare
-        );
+    //     transientValuation_setPrice_clamped(navPerShare);
+    //     hub_updateSharePrice(
+    //         vault.poolId().raw(),
+    //         uint128(vault.scId().raw()),
+    //         navPerShare
+    //     );
 
-        hub_notifyAssetPrice();
-        hub_notifySharePrice(CENTRIFUGE_CHAIN_ID);
+    //     hub_notifyAssetPrice();
+    //     hub_notifySharePrice(CENTRIFUGE_CHAIN_ID);
 
-        spoke_updateMember(type(uint64).max);
+    //     spoke_updateMember(type(uint64).max);
 
-        vault_deposit(assets);
-    }
+    //     vault_deposit(assets);
+    // }
 
-    function shortcut_mint_sync(uint256 shares, uint128 navPerShare) public {
-        IBaseVault vault = _getVault();
+    // function shortcut_mint_sync(uint256 shares, uint128 navPerShare) public {
+    //     IBaseVault vault = _getVault();
 
-        transientValuation_setPrice_clamped(navPerShare);
-        hub_updateSharePrice(
-            vault.poolId().raw(),
-            uint128(vault.scId().raw()),
-            navPerShare
-        );
+    //     transientValuation_setPrice_clamped(navPerShare);
+    //     hub_updateSharePrice(
+    //         vault.poolId().raw(),
+    //         uint128(vault.scId().raw()),
+    //         navPerShare
+    //     );
 
-        hub_notifyAssetPrice();
-        hub_notifySharePrice(CENTRIFUGE_CHAIN_ID);
+    //     hub_notifyAssetPrice();
+    //     hub_notifySharePrice(CENTRIFUGE_CHAIN_ID);
 
-        spoke_updateMember(type(uint64).max);
+    //     spoke_updateMember(type(uint64).max);
 
-        vault_mint(shares);
-    }
+    //     vault_mint(shares);
+    // }
 
-    function shortcut_deposit_and_claim(
-        uint64 pricePoolPerShare,
-        uint128 priceValuation,
-        uint256 amount,
-        uint128 navPerShare,
-        uint256 toEntropy
-    ) public {
-        // Request 2x amount to ensure sufficient pending after claiming the approved amount
-        // This prevents assertion failures in hub_notifyDeposit when pending delta < payment amount
-        shortcut_request_deposit(
-            pricePoolPerShare,
-            priceValuation,
-            amount * 2,
-            toEntropy
-        );
+    // function shortcut_deposit_and_claim(
+    //     uint64 pricePoolPerShare,
+    //     uint128 priceValuation,
+    //     uint256 amount,
+    //     uint128 navPerShare,
+    //     uint256 toEntropy
+    // ) public {
+    //     // Request 2x amount to ensure sufficient pending after claiming the approved amount
+    //     // This prevents assertion failures in hub_notifyDeposit when pending delta < payment amount
+    //     shortcut_request_deposit(
+    //         pricePoolPerShare,
+    //         priceValuation,
+    //         amount * 2,
+    //         toEntropy
+    //     );
 
-        uint32 depositEpoch = shareClassManager.nowDepositEpoch(
-            _getShareClassId(),
-            _getAssetId()
-        );
+    //     uint32 depositEpoch = shareClassManager.nowDepositEpoch(
+    //         _getShareClassId(),
+    //         _getAssetId()
+    //     );
 
-        shortcut_approve_and_issue_shares_safe(
-            uint128(amount),
-            depositEpoch,
-            navPerShare
-        );
+    //     shortcut_approve_and_issue_shares_safe(
+    //         uint128(amount),
+    //         depositEpoch,
+    //         navPerShare
+    //     );
 
-        hub_notifyDeposit(MAX_CLAIMS);
-        vault_deposit(amount);
-    }
+    //     hub_notifyDeposit(MAX_CLAIMS);
+    //     vault_deposit(amount);
+    // }
 
-    function shortcut_deposit_and_cancel(
-        uint64 pricePoolPerShare,
-        uint128 priceValuation,
-        uint256 amount,
-        uint128 /* navPerShare */,
-        uint256 toEntropy
-    ) public {
-        shortcut_request_deposit(
-            pricePoolPerShare,
-            priceValuation,
-            amount,
-            toEntropy
-        );
+    // function shortcut_deposit_and_cancel(
+    //     uint64 pricePoolPerShare,
+    //     uint128 priceValuation,
+    //     uint256 amount,
+    //     uint128 /* navPerShare */,
+    //     uint256 toEntropy
+    // ) public {
+    //     shortcut_request_deposit(
+    //         pricePoolPerShare,
+    //         priceValuation,
+    //         amount,
+    //         toEntropy
+    //     );
 
-        vault_cancelDepositRequest();
-    }
+    //     vault_cancelDepositRequest();
+    // }
 
-    function shortcut_deposit_queue_cancel(
-        uint64 pricePoolPerShare,
-        uint128 priceValuation,
-        uint256 depositAmount,
-        uint128 approveAmount,
-        uint128 navPerShare,
-        uint256 toEntropy
-    ) public {
-        shortcut_request_deposit(
-            pricePoolPerShare,
-            priceValuation,
-            depositAmount,
-            toEntropy
-        );
+    // function shortcut_deposit_queue_cancel(
+    //     uint64 pricePoolPerShare,
+    //     uint128 priceValuation,
+    //     uint256 depositAmount,
+    //     uint128 approveAmount,
+    //     uint128 navPerShare,
+    //     uint256 toEntropy
+    // ) public {
+    //     shortcut_request_deposit(
+    //         pricePoolPerShare,
+    //         priceValuation,
+    //         depositAmount,
+    //         toEntropy
+    //     );
 
-        uint32 nowDepositEpoch = shareClassManager.nowDepositEpoch(
-            _getShareClassId(),
-            _getAssetId()
-        );
-        hub_approveDeposits(nowDepositEpoch, approveAmount);
-        hub_issueShares(nowDepositEpoch, navPerShare);
+    //     uint32 nowDepositEpoch = shareClassManager.nowDepositEpoch(
+    //         _getShareClassId(),
+    //         _getAssetId()
+    //     );
+    //     hub_approveDeposits(nowDepositEpoch, approveAmount);
+    //     hub_issueShares(nowDepositEpoch, navPerShare);
 
-        vault_cancelDepositRequest();
-    }
+    //     vault_cancelDepositRequest();
+    // }
 
-    function shortcut_deposit_cancel_claim(
-        uint64 pricePoolPerShare,
-        uint128 priceValuation,
-        uint256 amount,
-        uint128 /* navPerShare */,
-        uint256 toEntropy
-    ) public {
-        shortcut_request_deposit(
-            pricePoolPerShare,
-            priceValuation,
-            amount,
-            toEntropy
-        );
+    // function shortcut_deposit_cancel_claim(
+    //     uint64 pricePoolPerShare,
+    //     uint128 priceValuation,
+    //     uint256 amount,
+    //     uint128 /* navPerShare */,
+    //     uint256 toEntropy
+    // ) public {
+    //     shortcut_request_deposit(
+    //         pricePoolPerShare,
+    //         priceValuation,
+    //         amount,
+    //         toEntropy
+    //     );
 
-        vault_cancelDepositRequest();
+    //     vault_cancelDepositRequest();
 
-        vault_claimCancelDepositRequest(toEntropy);
-    }
+    //     vault_claimCancelDepositRequest(toEntropy);
+    // }
 
-    function shortcut_queue_deposit(
-        uint64 pricePoolPerShare,
-        uint128 priceValuation,
-        uint256 depositAmount,
-        uint128 navPerShare,
-        uint256 toEntropy,
-        uint128 shares
-    ) public {
-        shortcut_request_deposit(
-            pricePoolPerShare,
-            priceValuation,
-            depositAmount,
-            toEntropy
-        );
+    // function shortcut_queue_deposit(
+    //     uint64 pricePoolPerShare,
+    //     uint128 priceValuation,
+    //     uint256 depositAmount,
+    //     uint128 navPerShare,
+    //     uint256 toEntropy,
+    //     uint128 shares
+    // ) public {
+    //     shortcut_request_deposit(
+    //         pricePoolPerShare,
+    //         priceValuation,
+    //         depositAmount,
+    //         toEntropy
+    //     );
 
-        uint32 redeemEpoch = shareClassManager.nowDepositEpoch(
-            _getShareClassId(),
-            _getAssetId()
-        );
-        shortcut_approve_and_revoke_shares_safe(
-            shares,
-            redeemEpoch,
-            navPerShare
-        );
-    }
+    //     uint32 redeemEpoch = shareClassManager.nowDepositEpoch(
+    //         _getShareClassId(),
+    //         _getAssetId()
+    //     );
+    //     shortcut_approve_and_revoke_shares_safe(
+    //         shares,
+    //         redeemEpoch,
+    //         navPerShare
+    //     );
+    // }
 
-    function shortcut_queue_redemption(
-        uint256 shares,
-        uint128 navPerShare,
-        uint256 toEntropy
-    ) public {
-        // Clamp shares to user's actual share balance to prevent insufficient balance errors
-        IBaseVault vault = _getVault();
-        uint256 userShareBalance = MockERC20(address(vault.share())).balanceOf(
-            _getActor()
-        );
+    // function shortcut_queue_redemption(
+    //     uint256 shares,
+    //     uint128 navPerShare,
+    //     uint256 toEntropy
+    // ) public {
+    //     // Clamp shares to user's actual share balance to prevent insufficient balance errors
+    //     IBaseVault vault = _getVault();
+    //     uint256 userShareBalance = MockERC20(address(vault.share())).balanceOf(
+    //         _getActor()
+    //     );
 
-        // Request 2x shares to ensure sufficient pending after claiming the approved amount
-        // But clamp to available balance
-        uint256 requestShares = shares * 2;
-        if (requestShares > userShareBalance) {
-            requestShares = userShareBalance;
-        }
+    //     // Request 2x shares to ensure sufficient pending after claiming the approved amount
+    //     // But clamp to available balance
+    //     uint256 requestShares = shares * 2;
+    //     if (requestShares > userShareBalance) {
+    //         requestShares = userShareBalance;
+    //     }
 
-        vault_requestRedeem(requestShares, toEntropy);
+    //     vault_requestRedeem(requestShares, toEntropy);
 
-        uint32 redeemEpoch = shareClassManager.nowRedeemEpoch(
-            _getShareClassId(),
-            _getAssetId()
-        );
-        shortcut_approve_and_revoke_shares_safe(
-            uint128(shares),
-            redeemEpoch,
-            navPerShare
-        );
-    }
+    //     uint32 redeemEpoch = shareClassManager.nowRedeemEpoch(
+    //         _getShareClassId(),
+    //         _getAssetId()
+    //     );
+    //     shortcut_approve_and_revoke_shares_safe(
+    //         uint128(shares),
+    //         redeemEpoch,
+    //         navPerShare
+    //     );
+    // }
 
-    function shortcut_claim_withdrawal(
-        uint256 assets,
-        uint256 toEntropy
-    ) public {
-        hub_notifyRedeem(MAX_CLAIMS);
+    // function shortcut_claim_withdrawal(
+    //     uint256 assets,
+    //     uint256 toEntropy
+    // ) public {
+    //     hub_notifyRedeem(MAX_CLAIMS);
 
-        vault_withdraw(assets, toEntropy);
-    }
+    //     vault_withdraw(assets, toEntropy);
+    // }
 
-    function shortcut_claim_redemption(
-        uint256 shares,
-        uint256 toEntropy
-    ) public {
-        hub_notifyRedeem(MAX_CLAIMS);
+    // function shortcut_claim_redemption(
+    //     uint256 shares,
+    //     uint256 toEntropy
+    // ) public {
+    //     hub_notifyRedeem(MAX_CLAIMS);
 
-        vault_redeem(shares, toEntropy);
-    }
+    //     vault_redeem(shares, toEntropy);
+    // }
 
-    function shortcut_redeem_and_claim(
-        uint256 shares,
-        uint128 navPerShare,
-        uint256 toEntropy
-    ) public {
-        shortcut_queue_redemption(shares, navPerShare, toEntropy);
-        shortcut_claim_withdrawal(shares, toEntropy);
-    }
+    // function shortcut_redeem_and_claim(
+    //     uint256 shares,
+    //     uint128 navPerShare,
+    //     uint256 toEntropy
+    // ) public {
+    //     shortcut_queue_redemption(shares, navPerShare, toEntropy);
+    //     shortcut_claim_withdrawal(shares, toEntropy);
+    // }
 
-    function shortcut_withdraw_and_claim_clamped(
-        uint256 shares,
-        uint128 navPerShare,
-        uint256 toEntropy
-    ) public {
-        // clamp with share balance here because the maxRedeem is only updated after notifyRedeem
-        shares %= (MockERC20(address(_getVault().share())).balanceOf(
-            _getActor()
-        ) + 1);
-        uint256 sharesAsAssets = _getVault().convertToAssets(shares);
+    // function shortcut_withdraw_and_claim_clamped(
+    //     uint256 shares,
+    //     uint128 navPerShare,
+    //     uint256 toEntropy
+    // ) public {
+    //     // clamp with share balance here because the maxRedeem is only updated after notifyRedeem
+    //     shares %= (MockERC20(address(_getVault().share())).balanceOf(
+    //         _getActor()
+    //     ) + 1);
+    //     uint256 sharesAsAssets = _getVault().convertToAssets(shares);
 
-        shortcut_queue_redemption(shares, navPerShare, toEntropy);
-        shortcut_claim_withdrawal(sharesAsAssets, toEntropy);
-    }
+    //     shortcut_queue_redemption(shares, navPerShare, toEntropy);
+    //     shortcut_claim_withdrawal(sharesAsAssets, toEntropy);
+    // }
 
-    function shortcut_redeem_and_claim_clamped(
-        uint256 shares,
-        uint128 navPerShare,
-        uint256 toEntropy
-    ) public {
-        // clamp with share balance here because the maxRedeem is only updated after notifyRedeem
-        shares %= (MockERC20(address(_getVault().share())).balanceOf(
-            _getActor()
-        ) + 1);
-        shortcut_queue_redemption(shares, navPerShare, toEntropy);
-        shortcut_claim_redemption(shares, toEntropy);
-    }
+    // function shortcut_redeem_and_claim_clamped(
+    //     uint256 shares,
+    //     uint128 navPerShare,
+    //     uint256 toEntropy
+    // ) public {
+    //     // clamp with share balance here because the maxRedeem is only updated after notifyRedeem
+    //     shares %= (MockERC20(address(_getVault().share())).balanceOf(
+    //         _getActor()
+    //     ) + 1);
+    //     shortcut_queue_redemption(shares, navPerShare, toEntropy);
+    //     shortcut_claim_redemption(shares, toEntropy);
+    // }
 
-    function shortcut_cancel_redeem_clamped(
-        uint256 shares,
-        uint128,
-        /* navPerShare */ uint256 toEntropy
-    ) public {
-        // clamp with share balance here because the maxRedeem is only updated after notifyRedeem
-        shares %= (MockERC20(address(_getVault().share())).balanceOf(
-            _getActor()
-        ) + 1);
-        vault_requestRedeem(shares, toEntropy);
+    // function shortcut_cancel_redeem_clamped(
+    //     uint256 shares,
+    //     uint128,
+    //     /* navPerShare */ uint256 toEntropy
+    // ) public {
+    //     // clamp with share balance here because the maxRedeem is only updated after notifyRedeem
+    //     shares %= (MockERC20(address(_getVault().share())).balanceOf(
+    //         _getActor()
+    //     ) + 1);
+    //     vault_requestRedeem(shares, toEntropy);
 
-        vault_cancelRedeemRequest();
-    }
+    //     vault_cancelRedeemRequest();
+    // }
 
-    function shortcut_cancel_redeem_immediately_issue_and_revoke_clamped(
-        uint256 shares,
-        uint128 navPerShare,
-        uint256 toEntropy
-    ) public {
-        shares %= (MockERC20(address(_getVault().share())).balanceOf(
-            _getActor()
-        ) + 1);
-        shortcut_queue_redemption(shares, navPerShare, toEntropy);
+    // function shortcut_cancel_redeem_immediately_issue_and_revoke_clamped(
+    //     uint256 shares,
+    //     uint128 navPerShare,
+    //     uint256 toEntropy
+    // ) public {
+    //     shares %= (MockERC20(address(_getVault().share())).balanceOf(
+    //         _getActor()
+    //     ) + 1);
+    //     shortcut_queue_redemption(shares, navPerShare, toEntropy);
 
-        vault_cancelRedeemRequest();
+    //     vault_cancelRedeemRequest();
 
-        // After cancellation, check if there's still pending redeem to approve/revoke
-        uint128 pendingRedeem = shareClassManager.pendingRedeem(
-            _getShareClassId(),
-            _getAssetId()
-        );
+    //     // After cancellation, check if there's still pending redeem to approve/revoke
+    //     uint128 pendingRedeem = shareClassManager.pendingRedeem(
+    //         _getShareClassId(),
+    //         _getAssetId()
+    //     );
 
-        // Throw iff pending redeem == 0 to signal pruning
-        uint32 redeemEpoch = shareClassManager.nowRedeemEpoch(
-            _getShareClassId(),
-            _getAssetId()
-        );
-        // Use safe approval function that will revert if pendingRedeem becomes 0
-        shortcut_approve_and_revoke_shares_safe(
-            pendingRedeem,
-            redeemEpoch,
-            navPerShare
-        );
-    }
+    //     // Throw iff pending redeem == 0 to signal pruning
+    //     uint32 redeemEpoch = shareClassManager.nowRedeemEpoch(
+    //         _getShareClassId(),
+    //         _getAssetId()
+    //     );
+    //     // Use safe approval function that will revert if pendingRedeem becomes 0
+    //     shortcut_approve_and_revoke_shares_safe(
+    //         pendingRedeem,
+    //         redeemEpoch,
+    //         navPerShare
+    //     );
+    // }
 
-    function shortcut_cancel_redeem_claim_clamped(
-        uint256 shares,
-        uint128,
-        /* navPerShare */ uint256 toEntropy
-    ) public {
-        // clamp with share balance here because the maxRedeem is only updated after notifyRedeem
-        shares %= (MockERC20(address(_getVault().share())).balanceOf(
-            _getActor()
-        ) + 1);
-        vault_requestRedeem(shares, toEntropy);
+    // function shortcut_cancel_redeem_claim_clamped(
+    //     uint256 shares,
+    //     uint128,
+    //     /* navPerShare */ uint256 toEntropy
+    // ) public {
+    //     // clamp with share balance here because the maxRedeem is only updated after notifyRedeem
+    //     shares %= (MockERC20(address(_getVault().share())).balanceOf(
+    //         _getActor()
+    //     ) + 1);
+    //     vault_requestRedeem(shares, toEntropy);
 
-        vault_cancelRedeemRequest();
-        vault_claimCancelRedeemRequest(toEntropy);
-    }
+    //     vault_cancelRedeemRequest();
+    //     vault_claimCancelRedeemRequest(toEntropy);
+    // }
 
-    // ═══════════════════════════════════════════════════════════════
-    // POOL ADMIN SHORTCUTS
-    // ═══════════════════════════════════════════════════════════════
-    function shortcut_approve_and_issue_shares(
-        uint128 maxApproval,
-        uint32 nowDepositEpochId,
-        uint128 navPerShare
-    ) public {
-        hub_approveDeposits(nowDepositEpochId, maxApproval);
-        hub_issueShares(nowDepositEpochId, navPerShare);
-    }
+    // // ═══════════════════════════════════════════════════════════════
+    // // POOL ADMIN SHORTCUTS
+    // // ═══════════════════════════════════════════════════════════════
+    // function shortcut_approve_and_issue_shares(
+    //     uint128 maxApproval,
+    //     uint32 nowDepositEpochId,
+    //     uint128 navPerShare
+    // ) public {
+    //     hub_approveDeposits(nowDepositEpochId, maxApproval);
+    //     hub_issueShares(nowDepositEpochId, navPerShare);
+    // }
 
-    function shortcut_approve_and_revoke_shares(
-        uint128 maxApproval,
-        uint32 epochId,
-        uint128 navPerShare
-    ) public {
-        hub_approveRedeems(epochId, maxApproval);
-        hub_revokeShares(epochId, navPerShare);
-    }
+    // function shortcut_approve_and_revoke_shares(
+    //     uint128 maxApproval,
+    //     uint32 epochId,
+    //     uint128 navPerShare
+    // ) public {
+    //     hub_approveRedeems(epochId, maxApproval);
+    //     hub_revokeShares(epochId, navPerShare);
+    // }
 
-    // ═══════════════════════════════════════════════════════════════
-    // SAFE APPROVAL SHORTCUTS (WITH EXPLICIT REVERTS)
-    // ═══════════════════════════════════════════════════════════════
-    function shortcut_approve_and_issue_shares_safe(
-        uint128 maxApproval,
-        uint32 nowDepositEpochId,
-        uint128 navPerShare
-    ) public {
-        uint128 pendingDeposit = shareClassManager.pendingDeposit(
-            _getShareClassId(),
-            _getAssetId()
-        );
-        require(pendingDeposit > 0, "InsufficientPending: pendingDeposit is 0");
-        require(
-            maxApproval <= pendingDeposit,
-            "ExceedsPending: approval exceeds pending deposit"
-        );
+    // // ═══════════════════════════════════════════════════════════════
+    // // SAFE APPROVAL SHORTCUTS (WITH EXPLICIT REVERTS)
+    // // ═══════════════════════════════════════════════════════════════
+    // function shortcut_approve_and_issue_shares_safe(
+    //     uint128 maxApproval,
+    //     uint32 nowDepositEpochId,
+    //     uint128 navPerShare
+    // ) public {
+    //     uint128 pendingDeposit = shareClassManager.pendingDeposit(
+    //         _getShareClassId(),
+    //         _getAssetId()
+    //     );
+    //     require(pendingDeposit > 0, "InsufficientPending: pendingDeposit is 0");
+    //     require(
+    //         maxApproval <= pendingDeposit,
+    //         "ExceedsPending: approval exceeds pending deposit"
+    //     );
 
-        hub_approveDeposits(nowDepositEpochId, maxApproval);
-        hub_issueShares(nowDepositEpochId, navPerShare);
-    }
+    //     hub_approveDeposits(nowDepositEpochId, maxApproval);
+    //     hub_issueShares(nowDepositEpochId, navPerShare);
+    // }
 
-    function shortcut_approve_and_revoke_shares_safe(
-        uint128 maxApproval,
-        uint32 epochId,
-        uint128 navPerShare
-    ) public {
-        uint128 pendingRedeem = shareClassManager.pendingRedeem(
-            _getShareClassId(),
-            _getAssetId()
-        );
-        require(pendingRedeem > 0, "InsufficientPending: pendingRedeem is 0");
-        require(
-            maxApproval <= pendingRedeem,
-            "ExceedsPending: approval exceeds pending redeem"
-        );
+    // function shortcut_approve_and_revoke_shares_safe(
+    //     uint128 maxApproval,
+    //     uint32 epochId,
+    //     uint128 navPerShare
+    // ) public {
+    //     uint128 pendingRedeem = shareClassManager.pendingRedeem(
+    //         _getShareClassId(),
+    //         _getAssetId()
+    //     );
+    //     require(pendingRedeem > 0, "InsufficientPending: pendingRedeem is 0");
+    //     require(
+    //         maxApproval <= pendingRedeem,
+    //         "ExceedsPending: approval exceeds pending redeem"
+    //     );
 
-        hub_approveRedeems(epochId, maxApproval);
-        hub_revokeShares(epochId, navPerShare);
-    }
+    //     hub_approveRedeems(epochId, maxApproval);
+    //     hub_revokeShares(epochId, navPerShare);
+    // }
 
     // ═══════════════════════════════════════════════════════════════
     // TRANSIENT VALUATION

--- a/test/integration/recon-end-to-end/TargetFunctions.sol
+++ b/test/integration/recon-end-to-end/TargetFunctions.sol
@@ -576,26 +576,26 @@ abstract contract TargetFunctions is
     //     vault_claimCancelRedeemRequest(toEntropy);
     // }
 
-    // // ═══════════════════════════════════════════════════════════════
-    // // POOL ADMIN SHORTCUTS
-    // // ═══════════════════════════════════════════════════════════════
-    // function shortcut_approve_and_issue_shares(
-    //     uint128 maxApproval,
-    //     uint32 nowDepositEpochId,
-    //     uint128 navPerShare
-    // ) public {
-    //     hub_approveDeposits(nowDepositEpochId, maxApproval);
-    //     hub_issueShares(nowDepositEpochId, navPerShare);
-    // }
+    // ═══════════════════════════════════════════════════════════════
+    // POOL ADMIN SHORTCUTS
+    // ═══════════════════════════════════════════════════════════════
+    function shortcut_approve_and_issue_shares(
+        uint128 maxApproval,
+        uint32 nowDepositEpochId,
+        uint128 navPerShare
+    ) public {
+        hub_approveDeposits(nowDepositEpochId, maxApproval);
+        hub_issueShares(nowDepositEpochId, navPerShare);
+    }
 
-    // function shortcut_approve_and_revoke_shares(
-    //     uint128 maxApproval,
-    //     uint32 epochId,
-    //     uint128 navPerShare
-    // ) public {
-    //     hub_approveRedeems(epochId, maxApproval);
-    //     hub_revokeShares(epochId, navPerShare);
-    // }
+    function shortcut_approve_and_revoke_shares(
+        uint128 maxApproval,
+        uint32 epochId,
+        uint128 navPerShare
+    ) public {
+        hub_approveRedeems(epochId, maxApproval);
+        hub_revokeShares(epochId, navPerShare);
+    }
 
     // // ═══════════════════════════════════════════════════════════════
     // // SAFE APPROVAL SHORTCUTS (WITH EXPLICIT REVERTS)


### PR DESCRIPTION
This PR removes the shortcut functions to reduce the number of broken properties that break through the same path. Without this multiple properties can execute the similar shortcuts and break the same properties.

The only shortcut function maintained is the `shortcut_deployNewTokenPoolAndShare` which is key for getting coverage as it deploys the system that gets targeted.