### PR TITLE
fix: duplicate import lines edge-case

### DIFF
--- a/script/utils/fix_imports.py
+++ b/script/utils/fix_imports.py
@@ -82,6 +82,157 @@ def parse_import_statement(import_stmt: str) -> Tuple[List[str], str]:
 
     return [], path
 
+def resolve_import_path(import_path: str, current_file: str) -> str:
+    """Resolve an import path to an actual file on disk, returns None if unresolvable"""
+    current_file_clean = current_file.replace('\\', '/').lstrip('./')
+    current_dir = os.path.dirname(current_file_clean)
+
+    if import_path.startswith('./') or import_path.startswith('../'):
+        # Relative path
+        resolved = os.path.normpath(os.path.join(current_dir, import_path))
+        return resolved.replace('\\', '/')
+    elif import_path.startswith('src/') or import_path.startswith('test/') or import_path.startswith('script/'):
+        # Project-absolute path
+        return import_path
+    elif import_path.startswith('centrifuge-v3/'):
+        return import_path[len('centrifuge-v3/'):]
+    else:
+        # Library or other path (e.g. forge-std) - can't resolve
+        return None
+
+
+def strip_comments(content: str) -> str:
+    """Strip single-line and multi-line comments from Solidity source code."""
+    # Remove multi-line comments (/* ... */ and /** ... */)
+    result = re.sub(r'/\*.*?\*/', '', content, flags=re.DOTALL)
+    # Remove single-line comments (// ...)
+    result = re.sub(r'//[^\n]*', '', result)
+    return result
+
+
+def get_exported_symbols(file_path: str) -> Set[str]:
+    """Get all symbols exported by a Solidity file via named import.
+
+    This includes:
+    - Top-level definitions (contracts, interfaces, libraries, structs, enums, errors, types)
+    - Symbols explicitly named-imported (import {X} from ...)
+
+    NOTE: Symbols from bare imports (import "file.sol") in the target file are NOT included,
+    because Solidity does not re-export them for named import from other files.
+    """
+
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+    except (FileNotFoundError, IOError):
+        return set()
+
+    symbols = set()
+
+    # Strip comments to avoid matching keywords in NatSpec/comments
+    # (e.g. "Vault contract before the" would falsely match \bcontract\s+(\w+))
+    code_only = strip_comments(content)
+
+    # Pre-compute brace depth at each position to distinguish file-level from nested declarations
+    brace_depth = []
+    depth = 0
+    for ch in code_only:
+        brace_depth.append(depth)
+        if ch == '{':
+            depth += 1
+        elif ch == '}':
+            depth -= 1
+
+    # contract/interface/library are always file-level in Solidity (can't be nested)
+    for pattern in [
+        r'\bcontract\s+(\w+)',
+        r'\binterface\s+(\w+)',
+        r'\blibrary\s+(\w+)',
+    ]:
+        for match in re.finditer(pattern, code_only):
+            symbols.add(match.group(1))
+
+    # struct, enum, error, type, function can appear both at file level and inside contracts.
+    # Only include file-level ones (brace depth 0) since nested ones aren't importable directly.
+    for pattern in [
+        r'\bstruct\s+(\w+)',
+        r'\benum\s+(\w+)',
+        r'\berror\s+(\w+)',
+        r'\btype\s+(\w+)\s+is\s+',
+        r'\bfunction\s+(\w+)',
+    ]:
+        for match in re.finditer(pattern, code_only):
+            if match.start() < len(brace_depth) and brace_depth[match.start()] == 0:
+                symbols.add(match.group(1))
+
+    # Symbols from named imports are re-exported by the file (use original content, not stripped)
+    for match in re.finditer(r'import\s+\{([^}]+)\}\s+from\s+"([^"]+)"', content):
+        imported_symbols_str = match.group(1)
+        for sym in imported_symbols_str.split(','):
+            sym = sym.strip()
+            if ' as ' in sym:
+                symbols.add(sym.split(' as ')[1].strip())
+            else:
+                symbols.add(sym)
+
+    # NOTE: We intentionally do NOT recurse into bare imports (import "file.sol")
+    # in the target file. In Solidity, bare imports make symbols available within
+    # the importing file, but those symbols are NOT re-exportable via named imports.
+    # i.e., if A.sol has `import "B.sol"` and B.sol defines Foo, then
+    # `import {Foo} from "A.sol"` will FAIL — Foo is not a declared symbol of A.sol.
+    # Only symbols defined in A.sol or explicitly named-imported by A.sol are available.
+
+    return symbols
+
+
+def convert_bare_imports_to_named(imports: List[str], current_file: str, content_without_imports: str) -> List[str]:
+    """Convert bare imports (import "path") to named imports (import {X, Y} from "path")
+    by resolving what symbols they provide and checking which are actually used."""
+    result = []
+
+    for import_stmt in imports:
+        symbols, path = parse_import_statement(import_stmt)
+
+        if symbols or not path:
+            # Already a named import or couldn't parse - keep as-is
+            result.append(import_stmt)
+            continue
+
+        # This is a bare import - try to resolve its symbols
+        resolved_path = resolve_import_path(path, current_file)
+        if not resolved_path or not os.path.exists(resolved_path):
+            # Can't resolve the file (e.g. forge-std) - keep as bare import
+            result.append(import_stmt)
+            continue
+
+        # Get all symbols exported by the target file
+        available_symbols = get_exported_symbols(resolved_path)
+
+        if not available_symbols:
+            # Couldn't determine symbols - keep as bare import
+            result.append(import_stmt)
+            continue
+
+        # Find which symbols are actually used in the current file
+        used_symbols = []
+        for sym in sorted(available_symbols):
+            pattern = r'\b' + re.escape(sym) + r'\b'
+            if re.search(pattern, content_without_imports):
+                used_symbols.append(sym)
+
+        if not used_symbols:
+            # No symbols appear used - keep as bare import
+            # (unused import removal can deal with it later)
+            result.append(import_stmt)
+            continue
+
+        # Convert to named import with only the used symbols
+        symbols_str = ", ".join(used_symbols)
+        result.append(f'import {{{symbols_str}}} from "{path}";')
+
+    return result
+
+
 def find_duplicate_imports(imports: List[str]) -> List[str]:
     """Find duplicate imports: multiple imports from the same path where one is a subset of another"""
     duplicates = []
@@ -248,8 +399,11 @@ def fix_unused_imports_in_file(file_path: str) -> Tuple[bool, int]:
         for import_stmt in original_imports:
             content_without_imports = content_without_imports.replace(import_stmt, '')
 
+        # Convert bare imports to named imports before merging
+        named_imports = convert_bare_imports_to_named(original_imports, file_path, content_without_imports)
+
         # Merge duplicate imports from the same path
-        imports, merge_removed = merge_duplicate_imports(original_imports)
+        imports, merge_removed = merge_duplicate_imports(named_imports)
 
         new_imports = []
         removed_count = merge_removed
@@ -497,12 +651,15 @@ def fix_file_imports(file_path: str, convert_to_relative: bool = True) -> bool:
         if not imports:
             return False  # No imports to fix
 
-        # Merge duplicate imports from the same path
-        imports, _ = merge_duplicate_imports(imports)
-
         # Remove all imports using regex pattern (handles both single-line and multi-line)
         import_removal_pattern = r'import\s+.*?;'
         content_without_imports = re.sub(import_removal_pattern, '', content, flags=re.MULTILINE | re.DOTALL)
+
+        # Convert bare imports to named imports before merging
+        imports = convert_bare_imports_to_named(imports, file_path, content_without_imports)
+
+        # Merge duplicate imports from the same path
+        imports, _ = merge_duplicate_imports(imports)
 
         # Convert to relative imports if requested
         if convert_to_relative:

--- a/script/utils/fix_imports.py
+++ b/script/utils/fix_imports.py
@@ -82,10 +82,108 @@ def parse_import_statement(import_stmt: str) -> Tuple[List[str], str]:
 
     return [], path
 
+def find_duplicate_imports(imports: List[str]) -> List[str]:
+    """Find duplicate imports: multiple imports from the same path where one is a subset of another"""
+    duplicates = []
+
+    # Group imports by path
+    path_to_imports: Dict[str, List[Tuple[int, List[str], str]]] = {}
+    for idx, import_stmt in enumerate(imports):
+        symbols, path = parse_import_statement(import_stmt)
+        if path:
+            if path not in path_to_imports:
+                path_to_imports[path] = []
+            path_to_imports[path].append((idx, symbols, import_stmt))
+
+    for path, import_group in path_to_imports.items():
+        if len(import_group) <= 1:
+            continue
+
+        # Multiple imports from the same path - find redundant ones
+        for i, (idx_i, symbols_i, stmt_i) in enumerate(import_group):
+            symbols_set_i = set(symbols_i) if symbols_i else set()
+            for j, (idx_j, symbols_j, stmt_j) in enumerate(import_group):
+                if i >= j:
+                    continue
+                symbols_set_j = set(symbols_j) if symbols_j else set()
+
+                # If i's symbols are a subset of j's, i is redundant
+                if symbols_set_i and symbols_set_j and symbols_set_i <= symbols_set_j:
+                    duplicates.append(f"Duplicate import '{stmt_i}' (all symbols already in '{stmt_j}')")
+                # If j's symbols are a subset of i's, j is redundant
+                elif symbols_set_i and symbols_set_j and symbols_set_j <= symbols_set_i:
+                    duplicates.append(f"Duplicate import '{stmt_j}' (all symbols already in '{stmt_i}')")
+
+    return duplicates
+
+
+def merge_duplicate_imports(imports: List[str]) -> Tuple[List[str], int]:
+    """Merge duplicate imports from the same path, returning merged list and count of removed imports"""
+    # Group imports by path
+    path_to_imports: Dict[str, List[Tuple[int, List[str], str]]] = {}
+    path_order: List[str] = []  # Track first occurrence order
+    non_path_imports: List[Tuple[int, str]] = []
+
+    for idx, import_stmt in enumerate(imports):
+        symbols, path = parse_import_statement(import_stmt)
+        if path:
+            if path not in path_to_imports:
+                path_to_imports[path] = []
+                path_order.append(path)
+            path_to_imports[path].append((idx, symbols, import_stmt))
+        else:
+            non_path_imports.append((idx, import_stmt))
+
+    merged = []
+    removed_count = 0
+
+    for path in path_order:
+        import_group = path_to_imports[path]
+        if len(import_group) == 1:
+            merged.append(import_group[0][2])
+            continue
+
+        # Multiple imports from same path - merge symbols
+        all_symbols: List[str] = []
+        seen_symbols: Set[str] = set()
+        has_direct_import = False
+
+        for _, symbols, stmt in import_group:
+            if not symbols:
+                has_direct_import = True
+            for s in symbols:
+                if s not in seen_symbols:
+                    all_symbols.append(s)
+                    seen_symbols.add(s)
+
+        if has_direct_import and not all_symbols:
+            # Only direct imports (no symbols) - keep just one
+            merged.append(import_group[0][2])
+            removed_count += len(import_group) - 1
+        elif all_symbols:
+            # Reconstruct a single merged import with all symbols
+            symbols_str = ", ".join(all_symbols)
+            merged.append(f'import {{{symbols_str}}} from "{path}";')
+            removed_count += len(import_group) - 1
+        else:
+            merged.append(import_group[0][2])
+            removed_count += len(import_group) - 1
+
+    # Add non-path imports
+    for _, stmt in non_path_imports:
+        merged.append(stmt)
+
+    return merged, removed_count
+
+
 def find_unused_imports(file_path: str, content: str) -> List[str]:
     """Find unused imports in a Solidity file"""
     imports = extract_imports(content)
     unused_imports = []
+
+    # Check for duplicate imports first
+    duplicates = find_duplicate_imports(imports)
+    unused_imports.extend(duplicates)
 
     # Remove import statements from content for analysis
     content_without_imports = content
@@ -141,17 +239,20 @@ def fix_unused_imports_in_file(file_path: str) -> Tuple[bool, int]:
         with open(file_path, 'r', encoding='utf-8') as f:
             content = f.read()
 
-        imports = extract_imports(content)
-        if not imports:
+        original_imports = extract_imports(content)
+        if not original_imports:
             return False, 0
 
-        # Remove import statements from content for analysis
+        # Remove import statements from content for analysis (using originals)
         content_without_imports = content
-        for import_stmt in imports:
+        for import_stmt in original_imports:
             content_without_imports = content_without_imports.replace(import_stmt, '')
 
+        # Merge duplicate imports from the same path
+        imports, merge_removed = merge_duplicate_imports(original_imports)
+
         new_imports = []
-        removed_count = 0
+        removed_count = merge_removed
 
         for import_stmt in imports:
             symbols, path = parse_import_statement(import_stmt)
@@ -183,11 +284,10 @@ def fix_unused_imports_in_file(file_path: str) -> Tuple[bool, int]:
                 # No unused symbols, keep import as is
                 new_imports.append(import_stmt)
 
-        # Replace old imports with new ones
-        new_content = content
-        for old_import in imports:
-            new_content = new_content.replace(old_import + '\n', '')
-            new_content = new_content.replace(old_import, '')
+        # Remove all original import statements from content using regex
+        # (string replacement fails on multi-line imports due to whitespace normalization)
+        import_removal_pattern = r'import\s+.*?;'
+        new_content = re.sub(import_removal_pattern, '', content, flags=re.MULTILINE | re.DOTALL)
 
         # Add new imports back
         if new_imports:
@@ -396,6 +496,9 @@ def fix_file_imports(file_path: str, convert_to_relative: bool = True) -> bool:
         imports = extract_imports(content)
         if not imports:
             return False  # No imports to fix
+
+        # Merge duplicate imports from the same path
+        imports, _ = merge_duplicate_imports(imports)
 
         # Remove all imports using regex pattern (handles both single-line and multi-line)
         import_removal_pattern = r'import\s+.*?;'

--- a/src/vaults/AsyncRequestManager.sol
+++ b/src/vaults/AsyncRequestManager.sol
@@ -2,15 +2,15 @@
 pragma solidity 0.8.28;
 
 import {IBaseVault} from "./interfaces/IBaseVault.sol";
-import {IRedeemManager} from "./interfaces/IVaultManagers.sol";
-import {IDepositManager} from "./interfaces/IVaultManagers.sol";
-import {IAsyncRedeemManager} from "./interfaces/IVaultManagers.sol";
 import {RequestMessageLib} from "./libraries/RequestMessageLib.sol";
-import {IAsyncDepositManager} from "./interfaces/IVaultManagers.sol";
 import {IBaseRequestManager} from "./interfaces/IBaseRequestManager.sol";
 import {IAsyncVault, IAsyncRedeemVault} from "./interfaces/IAsyncVault.sol";
 import {RequestCallbackType, RequestCallbackMessageLib} from "./libraries/RequestCallbackMessageLib.sol";
 import {
+    IRedeemManager,
+    IDepositManager,
+    IAsyncRedeemManager,
+    IAsyncDepositManager,
     IAsyncRequestManager,
     AsyncInvestmentState,
     REASON_DEPOSIT,

--- a/src/vaults/AsyncVault.sol
+++ b/src/vaults/AsyncVault.sol
@@ -1,15 +1,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {BaseVault} from "./BaseVaults.sol";
-import {BaseAsyncRedeemVault} from "./BaseVaults.sol";
 import {IAsyncVault} from "./interfaces/IAsyncVault.sol";
+import {BaseVault, BaseAsyncRedeemVault} from "./BaseVaults.sol";
 import {IAsyncRequestManager} from "./interfaces/IVaultManagers.sol";
 
-import "../misc/interfaces/IERC7540.sol";
-import "../misc/interfaces/IERC7575.sol";
 import {IERC20} from "../misc/interfaces/IERC20.sol";
+import {IERC165, IERC7575} from "../misc/interfaces/IERC7575.sol";
 import {SafeTransferLib} from "../misc/libraries/SafeTransferLib.sol";
+import {IERC7540Deposit, IERC7887Deposit} from "../misc/interfaces/IERC7540.sol";
 
 import {PoolId} from "../core/types/PoolId.sol";
 import {ShareClassId} from "../core/types/ShareClassId.sol";

--- a/src/vaults/BaseVaults.sol
+++ b/src/vaults/BaseVaults.sol
@@ -3,19 +3,17 @@ pragma solidity 0.8.28;
 
 import {IBaseVault} from "./interfaces/IBaseVault.sol";
 import {IAsyncRedeemVault} from "./interfaces/IAsyncVault.sol";
-import {IAsyncRedeemManager} from "./interfaces/IVaultManagers.sol";
-import {ISyncDepositManager} from "./interfaces/IVaultManagers.sol";
 import {IBaseRequestManager} from "./interfaces/IBaseRequestManager.sol";
+import {IAsyncRedeemManager, ISyncDepositManager} from "./interfaces/IVaultManagers.sol";
 
 import {Auth} from "../misc/Auth.sol";
-import "../misc/interfaces/IERC7540.sol";
-import "../misc/interfaces/IERC7575.sol";
 import {Recoverable} from "../misc/Recoverable.sol";
-import {IERC7575} from "../misc/interfaces/IERC7575.sol";
 import {EIP712Lib} from "../misc/libraries/EIP712Lib.sol";
 import {IERC20Metadata} from "../misc/interfaces/IERC20.sol";
 import {SignatureLib} from "../misc/libraries/SignatureLib.sol";
+import {IERC165, IERC7575} from "../misc/interfaces/IERC7575.sol";
 import {SafeTransferLib} from "../misc/libraries/SafeTransferLib.sol";
+import {IERC7540Operator, IERC7540Redeem, IERC7714, IERC7741, IERC7887Redeem} from "../misc/interfaces/IERC7540.sol";
 
 import {PoolId} from "../core/types/PoolId.sol";
 import {IVault} from "../core/spoke/interfaces/IVault.sol";

--- a/src/vaults/SyncDepositVault.sol
+++ b/src/vaults/SyncDepositVault.sol
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {BaseVault} from "./BaseVaults.sol";
-import {IAsyncRedeemManager} from "./interfaces/IVaultManagers.sol";
-import {ISyncDepositManager} from "./interfaces/IVaultManagers.sol";
 import {IBaseRequestManager} from "./interfaces/IBaseRequestManager.sol";
-import {BaseAsyncRedeemVault, BaseSyncDepositVault} from "./BaseVaults.sol";
+import {BaseVault, BaseAsyncRedeemVault, BaseSyncDepositVault} from "./BaseVaults.sol";
+import {IAsyncRedeemManager, ISyncDepositManager} from "./interfaces/IVaultManagers.sol";
 
 import {IERC165} from "../misc/interfaces/IERC7575.sol";
 

--- a/src/vaults/SyncManager.sol
+++ b/src/vaults/SyncManager.sol
@@ -2,9 +2,12 @@
 pragma solidity 0.8.28;
 
 import {IBaseVault} from "./interfaces/IBaseVault.sol";
-import {IDepositManager} from "./interfaces/IVaultManagers.sol";
-import {ISyncDepositManager} from "./interfaces/IVaultManagers.sol";
-import {ISyncManager, ISyncDepositValuation} from "./interfaces/IVaultManagers.sol";
+import {
+    IDepositManager,
+    ISyncDepositManager,
+    ISyncManager,
+    ISyncDepositValuation
+} from "./interfaces/IVaultManagers.sol";
 
 import {Auth} from "../misc/Auth.sol";
 import {D18} from "../misc/types/D18.sol";

--- a/src/vaults/factories/SyncDepositVaultFactory.sol
+++ b/src/vaults/factories/SyncDepositVaultFactory.sol
@@ -11,8 +11,7 @@ import {IShareToken} from "../../core/spoke/interfaces/IShareToken.sol";
 import {IVaultFactory} from "../../core/spoke/factories/interfaces/IVaultFactory.sol";
 
 import {SyncDepositVault} from "../SyncDepositVault.sol";
-import {IAsyncRedeemManager} from "../interfaces/IVaultManagers.sol";
-import {ISyncDepositManager} from "../interfaces/IVaultManagers.sol";
+import {IAsyncRedeemManager, ISyncDepositManager} from "../interfaces/IVaultManagers.sol";
 
 /// @title  Sync Vault Factory
 /// @dev    Utility for deploying new vault contracts

--- a/test/core/hub/integration/BatchingAndPayment.t.sol
+++ b/test/core/hub/integration/BatchingAndPayment.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import "./BaseTest.sol";
+import {BaseTest, IAdapter, PoolId} from "./BaseTest.sol";
 
 contract TestBatchingAndPayment is BaseTest {
     /// Test the following:

--- a/test/core/hub/integration/Cases.t.sol
+++ b/test/core/hub/integration/Cases.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import "./BaseTest.sol";
+import {BaseTest, D18, IAdapter, IHubRequestManager, PoolId, d18} from "./BaseTest.sol";
 
 import {D18, d18} from "../../../../src/misc/types/D18.sol";
 import {CastLib} from "../../../../src/misc/libraries/CastLib.sol";
@@ -10,9 +10,8 @@ import {MathLib} from "../../../../src/misc/libraries/MathLib.sol";
 import {PoolId} from "../../../../src/core/types/PoolId.sol";
 import {PricingLib} from "../../../../src/core/libraries/PricingLib.sol";
 import {ShareClassId} from "../../../../src/core/types/ShareClassId.sol";
-import {MessageLib} from "../../../../src/core/messaging/libraries/MessageLib.sol";
-import {VaultUpdateKind} from "../../../../src/core/messaging/libraries/MessageLib.sol";
 import {IHubRequestManager} from "../../../../src/core/hub/interfaces/IHubRequestManager.sol";
+import {MessageLib, VaultUpdateKind} from "../../../../src/core/messaging/libraries/MessageLib.sol";
 
 import {RequestCallbackMessageLib} from "../../../../src/vaults/libraries/RequestCallbackMessageLib.sol";
 

--- a/test/core/mocks/MockAdapter.sol
+++ b/test/core/mocks/MockAdapter.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "./Mock.sol";
+import {Mock} from "./Mock.sol";
 
 import {IAdapter} from "../../../src/core/messaging/interfaces/IAdapter.sol";
 import {IMessageHandler} from "../../../src/core/messaging/interfaces/IMessageHandler.sol";

--- a/test/core/mocks/MockRoot.sol
+++ b/test/core/mocks/MockRoot.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "./Mock.sol";
+import {Mock} from "./Mock.sol";
 
 contract MockRoot is Mock {
     function endorsed(address) public view returns (bool) {

--- a/test/core/spoke/integration/AssetShareConversion.t.sol
+++ b/test/core/spoke/integration/AssetShareConversion.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "./BaseTest.sol";
+import {AssetId, AsyncVault, BaseTest, ERC20, IShareToken, PoolId, ShareClassId, VaultKind} from "./BaseTest.sol";
 
 contract AssetShareConversionTest is BaseTest {
     function testAssetShareConversion(bytes16 scId) public {

--- a/test/core/spoke/integration/BaseTest.sol
+++ b/test/core/spoke/integration/BaseTest.sol
@@ -7,10 +7,9 @@ import "../../../../src/misc/interfaces/IERC20.sol";
 import {ERC20} from "../../../../src/misc/ERC20.sol";
 import {IERC6909Fungible} from "../../../../src/misc/interfaces/IERC6909.sol";
 
-import {AssetId} from "../../../../src/core/types/AssetId.sol";
-import {newAssetId} from "../../../../src/core/types/AssetId.sol";
 import {PoolId, newPoolId} from "../../../../src/core/types/PoolId.sol";
 import {ShareClassId} from "../../../../src/core/types/ShareClassId.sol";
+import {AssetId, newAssetId} from "../../../../src/core/types/AssetId.sol";
 import {VaultKind} from "../../../../src/core/spoke/interfaces/IVault.sol";
 import {IAdapter} from "../../../../src/core/messaging/interfaces/IAdapter.sol";
 import {IShareToken} from "../../../../src/core/spoke/interfaces/IShareToken.sol";

--- a/test/core/spoke/integration/Burn.t.sol
+++ b/test/core/spoke/integration/Burn.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "./BaseTest.sol";
+import {AsyncVault, BaseTest, IShareToken, VaultKind} from "./BaseTest.sol";
 
 import {IAuth} from "../../../../src/misc/interfaces/IAuth.sol";
 import {IERC20} from "../../../../src/misc/interfaces/IERC20.sol";

--- a/test/core/spoke/integration/Mint.t.sol
+++ b/test/core/spoke/integration/Mint.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "./BaseTest.sol";
+import {AsyncVault, BaseTest, IShareToken, VaultKind} from "./BaseTest.sol";
 
 import {IAuth} from "../../../../src/misc/interfaces/IAuth.sol";
 

--- a/test/core/spoke/integration/Spoke.t.sol
+++ b/test/core/spoke/integration/Spoke.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "./BaseTest.sol";
+import {AssetId, AsyncVault, BaseTest, IShareToken, MessageLib, PoolId, ShareClassId, VaultKind} from "./BaseTest.sol";
 
 import {CastLib} from "../../../../src/misc/libraries/CastLib.sol";
 import {BytesLib} from "../../../../src/misc/libraries/BytesLib.sol";

--- a/test/core/spoke/mocks/MockFullRestrictions.sol
+++ b/test/core/spoke/mocks/MockFullRestrictions.sol
@@ -5,7 +5,7 @@ import {HookData} from "../../../../src/core/spoke/interfaces/ITransferHook.sol"
 
 import {FullRestrictions} from "../../../../src/hooks/FullRestrictions.sol";
 
-import "../../mocks/Mock.sol";
+import {Mock} from "../../mocks/Mock.sol";
 
 contract MockFullRestrictions is FullRestrictions, Mock {
     constructor(

--- a/test/core/spoke/unit/ShareToken.t.sol
+++ b/test/core/spoke/unit/ShareToken.t.sol
@@ -3,9 +3,9 @@ pragma solidity 0.8.28;
 
 import {ERC20} from "../../../../src/misc/ERC20.sol";
 import "../../../../src/misc/interfaces/IERC7540.sol";
-import "../../../../src/misc/interfaces/IERC7575.sol";
 import {IAuth} from "../../../../src/misc/interfaces/IAuth.sol";
 import {IERC20} from "../../../../src/misc/interfaces/IERC20.sol";
+import {IERC165, IERC7575Share} from "../../../../src/misc/interfaces/IERC7575.sol";
 
 import {ShareToken} from "../../../../src/core/spoke/ShareToken.sol";
 import {ITransferHook} from "../../../../src/core/spoke/interfaces/ITransferHook.sol";

--- a/test/hooks/integration/FreelyTransferable.t.sol
+++ b/test/hooks/integration/FreelyTransferable.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.28;
 
 import {CastLib} from "../../../src/misc/libraries/CastLib.sol";
 
-import "../../core/spoke/integration/BaseTest.sol";
+import {AsyncVault, BaseTest, IShareToken, VaultKind} from "../../core/spoke/integration/BaseTest.sol";
 
 import {FreelyTransferable} from "../../../src/hooks/FreelyTransferable.sol";
 

--- a/test/hooks/integration/FreezeOnly.t.sol
+++ b/test/hooks/integration/FreezeOnly.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.28;
 
 import {CastLib} from "../../../src/misc/libraries/CastLib.sol";
 
-import "../../core/spoke/integration/BaseTest.sol";
+import {AsyncVault, BaseTest, IShareToken, VaultKind} from "../../core/spoke/integration/BaseTest.sol";
 
 import {ITransferHook} from "../../../src/core/spoke/interfaces/ITransferHook.sol";
 

--- a/test/hooks/integration/RedemptionRestrictions.t.sol
+++ b/test/hooks/integration/RedemptionRestrictions.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.28;
 
 import {CastLib} from "../../../src/misc/libraries/CastLib.sol";
 
-import "../../core/spoke/integration/BaseTest.sol";
+import {AsyncVault, BaseTest, IShareToken, VaultKind} from "../../core/spoke/integration/BaseTest.sol";
 
 import {RedemptionRestrictions} from "../../../src/hooks/RedemptionRestrictions.sol";
 

--- a/test/integration/Create3Addresses.t.sol
+++ b/test/integration/Create3Addresses.t.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.28;
 
 import {BaseDeployer} from "../../script/BaseDeployer.s.sol";
+
 import "forge-std/Test.sol";
 
 contract SimpleContract {

--- a/test/integration/EndToEnd.t.sol
+++ b/test/integration/EndToEnd.t.sol
@@ -55,11 +55,10 @@ import {IdentityValuation} from "../../src/valuations/IdentityValuation.sol";
 import {SyncManager} from "../../src/vaults/SyncManager.sol";
 import {VaultRouter} from "../../src/vaults/VaultRouter.sol";
 import {IBaseVault} from "../../src/vaults/interfaces/IBaseVault.sol";
-import {IAsyncVault} from "../../src/vaults/interfaces/IAsyncVault.sol";
 import {ISyncManager} from "../../src/vaults/interfaces/IVaultManagers.sol";
 import {AsyncRequestManager} from "../../src/vaults/AsyncRequestManager.sol";
 import {BatchRequestManager} from "../../src/vaults/BatchRequestManager.sol";
-import {IAsyncRedeemVault} from "../../src/vaults/interfaces/IAsyncVault.sol";
+import {IAsyncVault, IAsyncRedeemVault} from "../../src/vaults/interfaces/IAsyncVault.sol";
 
 import {FullDeployer, DeployerInput, noAdaptersInput, defaultTxLimits} from "../../script/FullDeployer.s.sol";
 

--- a/test/integration/spell/V2Cleanings.t.sol
+++ b/test/integration/spell/V2Cleanings.t.sol
@@ -6,7 +6,6 @@ import {IERC20} from "../../../src/misc/interfaces/IERC20.sol";
 
 import "forge-std/Test.sol";
 
-import {V2CleaningsSpell} from "../../../src/spell/V2CleaningsSpell.sol";
 import {
     V2CleaningsSpell,
     ROOT_V2,

--- a/test/integration/spell/utils/validation/InvestmentFlowExecutor.sol
+++ b/test/integration/spell/utils/validation/InvestmentFlowExecutor.sol
@@ -20,9 +20,8 @@ import {MessageLib} from "../../../../../src/core/messaging/libraries/MessageLib
 import {UpdateRestrictionMessageLib} from "../../../../../src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
 import {IBaseVault} from "../../../../../src/vaults/interfaces/IBaseVault.sol";
-import {IAsyncVault} from "../../../../../src/vaults/interfaces/IAsyncVault.sol";
 import {ISyncManager} from "../../../../../src/vaults/interfaces/IVaultManagers.sol";
-import {IAsyncRedeemVault} from "../../../../../src/vaults/interfaces/IAsyncVault.sol";
+import {IAsyncVault, IAsyncRedeemVault} from "../../../../../src/vaults/interfaces/IAsyncVault.sol";
 import {RequestCallbackMessageLib} from "../../../../../src/vaults/libraries/RequestCallbackMessageLib.sol";
 
 import {NonCoreReport} from "../../../../../script/FullDeployer.s.sol";

--- a/test/managers/hub/integration/NAVManager.t.sol
+++ b/test/managers/hub/integration/NAVManager.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.28;
 
 import {d18} from "../../../../src/misc/types/D18.sol";
 
-import "../../../core/hub/integration/BaseTest.sol";
+import {AssetId, BaseTest, IAdapter, PoolId, d18, newAssetId} from "../../../core/hub/integration/BaseTest.sol";
 
 import {PoolId} from "../../../../src/core/types/PoolId.sol";
 import {ShareClassId} from "../../../../src/core/types/ShareClassId.sol";

--- a/test/managers/spoke/integration/MerkleProofManager.t.sol
+++ b/test/managers/spoke/integration/MerkleProofManager.t.sol
@@ -5,7 +5,7 @@ import {IAuth} from "../../../../src/misc/Auth.sol";
 import {D18, d18} from "../../../../src/misc/types/D18.sol";
 import {CastLib} from "../../../../src/misc/libraries/CastLib.sol";
 
-import "../../../core/spoke/integration/BaseTest.sol";
+import {AssetId, BaseTest, ERC20, ShareClassId} from "../../../core/spoke/integration/BaseTest.sol";
 
 import {AssetId} from "../../../../src/core/types/AssetId.sol";
 import {BalanceSheet} from "../../../../src/core/spoke/BalanceSheet.sol";

--- a/test/managers/spoke/integration/OnOfframpManager.t.sol
+++ b/test/managers/spoke/integration/OnOfframpManager.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.28;
 import {D18, d18} from "../../../../src/misc/types/D18.sol";
 import {CastLib} from "../../../../src/misc/libraries/CastLib.sol";
 
-import "../../../core/spoke/integration/BaseTest.sol";
+import {AssetId, BaseTest, ShareClassId} from "../../../core/spoke/integration/BaseTest.sol";
 
 import {AssetId} from "../../../../src/core/types/AssetId.sol";
 import {ShareClassId} from "../../../../src/core/types/ShareClassId.sol";

--- a/test/managers/spoke/integration/QueueManager.t.sol
+++ b/test/managers/spoke/integration/QueueManager.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.28;
 
 import {CastLib} from "../../../../src/misc/libraries/CastLib.sol";
 
-import "../../../core/spoke/integration/BaseTest.sol";
+import {AssetId, BaseTest, ERC20, ShareClassId, VaultKind} from "../../../core/spoke/integration/BaseTest.sol";
 
 import {AssetId} from "../../../../src/core/types/AssetId.sol";
 import {ShareClassId} from "../../../../src/core/types/ShareClassId.sol";

--- a/test/misc/unit/EIP712Lib.t.sol
+++ b/test/misc/unit/EIP712Lib.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "../../../src/misc/libraries/EIP712Lib.sol";
+import {EIP712Lib} from "../../../src/misc/libraries/EIP712Lib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/SignatureLib.t.sol
+++ b/test/misc/unit/SignatureLib.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "../../../src/misc/libraries/EIP712Lib.sol";
-import "../../../src/misc/libraries/SignatureLib.sol";
+import {EIP712Lib} from "../../../src/misc/libraries/EIP712Lib.sol";
+import {IERC1271, SignatureLib} from "../../../src/misc/libraries/SignatureLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/libraries/D18.t.sol
+++ b/test/misc/unit/libraries/D18.t.sol
@@ -1,8 +1,23 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.28;
 
-import "../../../../src/misc/types/D18.sol";
-import "../../../../src/misc/libraries/MathLib.sol";
+import {MathLib} from "../../../../src/misc/libraries/MathLib.sol";
+import {
+    D18,
+    MathLib,
+    d18,
+    divD18,
+    eq,
+    isNotZero,
+    isZero,
+    mulD18,
+    mulUint128,
+    mulUint256,
+    raw,
+    reciprocal,
+    reciprocalMulUint128,
+    reciprocalMulUint256
+} from "../../../../src/misc/types/D18.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/libraries/ExcessivelySafeCallLib.t.sol
+++ b/test/misc/unit/libraries/ExcessivelySafeCallLib.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.7.6;
 
-import "../../../../src/misc/libraries/ExcessivelySafeCallLib.sol";
+import {ExcessivelySafeCallLib} from "../../../../src/misc/libraries/ExcessivelySafeCallLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/libraries/MathLib.t.sol
+++ b/test/misc/unit/libraries/MathLib.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.28;
 
-import "../../../../src/misc/libraries/MathLib.sol";
+import {MathLib} from "../../../../src/misc/libraries/MathLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/libraries/StringLib.t.sol
+++ b/test/misc/unit/libraries/StringLib.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "../../../../src/misc/libraries/StringLib.sol";
+import {StringLib} from "../../../../src/misc/libraries/StringLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/vaults/integration/AsyncRequestManager.t.sol
+++ b/test/vaults/integration/AsyncRequestManager.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.28;
 pragma abicoder v2;
 
-import "../../core/spoke/integration/BaseTest.sol";
+import {BaseTest, IShareToken, VaultKind} from "../../core/spoke/integration/BaseTest.sol";
 
 import {IBaseVault} from "../../../src/vaults/interfaces/IBaseVault.sol";
 import {IAsyncVault} from "../../../src/vaults/interfaces/IAsyncVault.sol";

--- a/test/vaults/integration/AsyncVault.t.sol
+++ b/test/vaults/integration/AsyncVault.t.sol
@@ -1,12 +1,27 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "../../../src/misc/interfaces/IERC7540.sol";
-import "../../../src/misc/interfaces/IERC7575.sol";
 import {IAuth} from "../../../src/misc/interfaces/IAuth.sol";
 import {MathLib} from "../../../src/misc/libraries/MathLib.sol";
+import {IERC165, IERC7575} from "../../../src/misc/interfaces/IERC7575.sol";
+import {
+    IERC7540Deposit,
+    IERC7540Operator,
+    IERC7540Redeem,
+    IERC7714,
+    IERC7741,
+    IERC7887Deposit,
+    IERC7887Redeem
+} from "../../../src/misc/interfaces/IERC7540.sol";
 
-import "../../core/spoke/integration/BaseTest.sol";
+import {
+    AsyncVault,
+    BaseTest,
+    IShareToken,
+    PoolId,
+    ShareClassId,
+    VaultKind
+} from "../../core/spoke/integration/BaseTest.sol";
 
 import {IBaseVault} from "../../../src/vaults/interfaces/IBaseVault.sol";
 import {IAsyncRequestManager} from "../../../src/vaults/interfaces/IVaultManagers.sol";

--- a/test/vaults/integration/Deposit.t.sol
+++ b/test/vaults/integration/Deposit.t.sol
@@ -6,7 +6,18 @@ import {CastLib} from "../../../src/misc/libraries/CastLib.sol";
 import {MathLib} from "../../../src/misc/libraries/MathLib.sol";
 import {IERC7751} from "../../../src/misc/interfaces/IERC7751.sol";
 
-import "../../core/spoke/integration/BaseTest.sol";
+import {
+    AssetId,
+    AsyncVault,
+    BaseTest,
+    ERC20,
+    IShareToken,
+    MessageLib,
+    MockAdapter,
+    PoolId,
+    ShareClassId,
+    VaultKind
+} from "../../core/spoke/integration/BaseTest.sol";
 
 import {PoolId} from "../../../src/core/types/PoolId.sol";
 import {AssetId} from "../../../src/core/types/AssetId.sol";

--- a/test/vaults/integration/DepositRedeem.t.sol
+++ b/test/vaults/integration/DepositRedeem.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.28;
 
 import {D18} from "../../../src/misc/types/D18.sol";
 
-import "../../core/spoke/integration/BaseTest.sol";
+import {AssetId, AsyncVault, BaseTest, ERC20, IShareToken, VaultKind} from "../../core/spoke/integration/BaseTest.sol";
 
 contract DepositRedeem is BaseTest {
     function testPartialDepositAndRedeemExecutions(bytes16 scId) public {

--- a/test/vaults/integration/Operator.t.sol
+++ b/test/vaults/integration/Operator.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.28;
 
 import {IERC20} from "../../../src/misc/interfaces/IERC20.sol";
 
-import "../../core/spoke/integration/BaseTest.sol";
+import {AsyncVault, BaseTest, IShareToken, VaultKind} from "../../core/spoke/integration/BaseTest.sol";
 
 import {IBaseVault} from "../../../src/vaults/interfaces/IBaseVault.sol";
 import {IAsyncVault} from "../../../src/vaults/interfaces/IAsyncVault.sol";

--- a/test/vaults/integration/Redeem.t.sol
+++ b/test/vaults/integration/Redeem.t.sol
@@ -5,7 +5,17 @@ import {D18} from "../../../src/misc/types/D18.sol";
 import {IERC20} from "../../../src/misc/interfaces/IERC20.sol";
 import {CastLib} from "../../../src/misc/libraries/CastLib.sol";
 
-import "../../core/spoke/integration/BaseTest.sol";
+import {
+    AssetId,
+    AsyncVault,
+    BaseTest,
+    ERC20,
+    IShareToken,
+    MessageLib,
+    PoolId,
+    ShareClassId,
+    VaultKind
+} from "../../core/spoke/integration/BaseTest.sol";
 
 import {PoolId} from "../../../src/core/types/PoolId.sol";
 import {AssetId} from "../../../src/core/types/AssetId.sol";

--- a/test/vaults/integration/SyncDeposit.t.sol
+++ b/test/vaults/integration/SyncDeposit.t.sol
@@ -1,15 +1,30 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "../../../src/misc/interfaces/IERC7540.sol";
-import "../../../src/misc/interfaces/IERC7575.sol";
 import {D18, d18} from "../../../src/misc/types/D18.sol";
 import {IAuth} from "../../../src/misc/interfaces/IAuth.sol";
 import {CastLib} from "../../../src/misc/libraries/CastLib.sol";
 import {MathLib} from "../../../src/misc/libraries/MathLib.sol";
 import {IERC7751} from "../../../src/misc/interfaces/IERC7751.sol";
+import {IERC165, IERC7575} from "../../../src/misc/interfaces/IERC7575.sol";
+import {
+    IERC7540Operator,
+    IERC7540Redeem,
+    IERC7714,
+    IERC7741,
+    IERC7887Redeem
+} from "../../../src/misc/interfaces/IERC7540.sol";
 
-import "../../core/spoke/integration/BaseTest.sol";
+import {
+    AssetId,
+    BaseTest,
+    IShareToken,
+    MessageLib,
+    PoolId,
+    ShareClassId,
+    SyncDepositVault,
+    VaultKind
+} from "../../core/spoke/integration/BaseTest.sol";
 
 import {PoolId} from "../../../src/core/types/PoolId.sol";
 import {AssetId} from "../../../src/core/types/AssetId.sol";

--- a/test/vaults/integration/SyncManager.t.sol
+++ b/test/vaults/integration/SyncManager.t.sol
@@ -5,13 +5,20 @@ import {D18, d18} from "../../../src/misc/types/D18.sol";
 import {IAuth} from "../../../src/misc/interfaces/IAuth.sol";
 import {MathLib} from "../../../src/misc/libraries/MathLib.sol";
 
-import "../../core/spoke/integration/BaseTest.sol";
+import {
+    AssetId,
+    BaseTest,
+    MessageLib,
+    PoolId,
+    ShareClassId,
+    SyncDepositVault,
+    VaultKind
+} from "../../core/spoke/integration/BaseTest.sol";
 
 import {MessageLib} from "../../../src/core/messaging/libraries/MessageLib.sol";
 
 import {IBaseVault} from "../../../src/vaults/interfaces/IBaseVault.sol";
 import {SyncDepositVault} from "../../../src/vaults/SyncDepositVault.sol";
-import {ISyncManager} from "../../../src/vaults/interfaces/IVaultManagers.sol";
 import {IBaseRequestManager} from "../../../src/vaults/interfaces/IBaseRequestManager.sol";
 import {ISyncManager, ISyncDepositValuation} from "../../../src/vaults/interfaces/IVaultManagers.sol";
 

--- a/test/vaults/integration/VaultRouter.t.sol
+++ b/test/vaults/integration/VaultRouter.t.sol
@@ -1,14 +1,25 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "../../../src/misc/interfaces/IERC20.sol";
-import "../../../src/misc/interfaces/IERC7540.sol";
 import "../../../src/misc/interfaces/IERC7575.sol";
+import {IERC20} from "../../../src/misc/interfaces/IERC20.sol";
 import {CastLib} from "../../../src/misc/libraries/CastLib.sol";
 import {MathLib} from "../../../src/misc/libraries/MathLib.sol";
 import {IERC7751} from "../../../src/misc/interfaces/IERC7751.sol";
+import {IERC7540Deposit} from "../../../src/misc/interfaces/IERC7540.sol";
 
-import "../../core/spoke/integration/BaseTest.sol";
+import {
+    AssetId,
+    AsyncVault,
+    BaseTest,
+    ERC20,
+    IShareToken,
+    MessageLib,
+    MockAdapter,
+    PoolId,
+    SyncDepositVault,
+    VaultKind
+} from "../../core/spoke/integration/BaseTest.sol";
 
 import {ISpoke} from "../../../src/core/spoke/interfaces/ISpoke.sol";
 import {MessageLib} from "../../../src/core/messaging/libraries/MessageLib.sol";


### PR DESCRIPTION
### Product requirements

* Fix the `fix_imports.py` script to handle duplicate import lines from the same path, where multiple imports pull overlapping symbols from a single file
* Prevent broken Solidity files caused by the script failing to properly remove and reconstruct multi-line imports which was caught in https://github.com/centrifuge/protocol/pull/795#discussion_r2858414985

### Design notes

* Added `find_duplicate_imports()` to detect when multiple import statements reference the same path with overlapping symbol sets
* Added `merge_duplicate_imports()` to consolidate duplicate imports into a single statement per path, preserving symbol order and deduplicating
* Switched import removal from string replacement to regex (`re.sub` with `re.MULTILINE | re.DOTALL`), which correctly handles whitespace normalization differences in multi-line imports