### PR TITLE
feat: deploy LayerZero to Hyperliquid Testnet

### DIFF
--- a/env/connections/testnet.json
+++ b/env/connections/testnet.json
@@ -10,8 +10,8 @@
         },
         {
             "chains": [["hyper-evm-testnet"], "ALL"],
-            "adapters": [],
-            "threshold": 0
+            "adapters": ["layerZero"],
+            "threshold": 1
         }
     ]
 }

--- a/env/hyper-evm-testnet.json
+++ b/env/hyper-evm-testnet.json
@@ -7,7 +7,24 @@
     "opsAdmin": "0xc1A929CBc122Ddb8794287D05Bf890E41f23c8cb",
     "baseRpcUrl": "https://hyperliquid-testnet.g.alchemy.com/v2/"
   },
+  "adapters": {
+    "layerZero": {
+      "endpoint": "0xf9e1815F151024bDE4B7C10BAC10e8Ba9F6b53E1",
+      "layerZeroEid": 40362,
+      "deploy": true,
+      "blockConfirmations": 5,
+      "DVNs": [
+        "0x91e698871030d0e1b6c9268c20bb57e2720618dd"
+      ]
+    }
+  },
   "contracts": {
+    "layerZeroAdapter": {
+      "address": "0x24f3192d46869609F8F6605e662b8146CA4240d3",
+      "blockNumber": 47348915,
+      "txHash": "0xb7cf5653c3244134455117a3ef2b190102eeb32fd83e8196362f57d65f8be8f1",
+      "version": "v3.1"
+    },
     "root": {
       "address": "0x1Fa8a2fe2eAE2373B03Fa313E016605EB86cBae8",
       "blockNumber": 43580306,

--- a/env/hyper-evm-testnet.json
+++ b/env/hyper-evm-testnet.json
@@ -280,7 +280,7 @@
   },
   "deploymentInfo": {
     "deploy:protocol": {
-      "gitCommit": "e0294708",
+      "gitCommit": "24032569",
       "timestamp": "2026-01-21T07:45:00Z",
       "suffix": "rev2",
       "startBlock": 43580227


### PR DESCRIPTION
### Product requirements

Ref: https://kflabs.slack.com/archives/C07PG2EUR9C/p1772438424422329

* Enable cross-chain messaging between HyperEvm Testnet and existing Sepolia deployments (Ethereum, Base, Arbitrum) via LayerZero
* Allow whitelabel customers building on HyperEvm to test the Centrifuge protocol cross-chain

### Design notes

* Added LayerZero adapter config to `env/hyper-evm-testnet.json`: endpoint `0xf9e1...`, EID 40362, LZ Labs DVN, 5 block confirmations (based on https://docs.layerzero.network/v2/deployments/deployed-contracts)
<img width="730" height="828" alt="image" src="https://github.com/user-attachments/assets/a88b135b-075b-4434-ad23-1440ce7232a6" />

* Registered deployed LayerZero adapter contract ( `0x24f3..` ) at block 47348915 on HyperEvm Testnet
* Updated `env/connections/testnet.json` to route HyperEvm connections through LayerZero only (threshold 1), overriding the default multi-adapter rule via last-match-wins
* LayerZero is the only supported adapter on HyperEvm Testnet; Axelar, Wormhole, and Chainlink are not available on this chain


### Verification

Confirm bidirectional wiring between HyperEvm Testnet (centrifugeId 9) and each Sepolia chain:

```bash
# HyperEvm to Sepolia (centrifugeId 1), Base Sepolia (2), Arbitrum Sepolia (3)
cast call 0x59436331823AdEC8b4dDd00cE7F319b24664d79D "quorum(uint16,uint64)(uint8)" 1 0 --rpc-url https://rpc.hyperliquid-testnet.xyz/evm
cast call 0x59436331823AdEC8b4dDd00cE7F319b24664d79D "quorum(uint16,uint64)(uint8)" 2 0 --rpc-url https://rpc.hyperliquid-testnet.xyz/evm
cast call 0x59436331823AdEC8b4dDd00cE7F319b24664d79D "quorum(uint16,uint64)(uint8)" 3 0 --rpc-url https://rpc.hyperliquid-testnet.xyz/evm
# All should return 1

# Sepolia chains to HyperEvm (centrifugeId 9)
cast call 0x59436331823AdEC8b4dDd00cE7F319b24664d79D "quorum(uint16,uint64)(uint8)" 9 0 --rpc-url https://eth-sepolia.g.alchemy.com/v2/$ALCHEMY_API_KEY
cast call 0x59436331823AdEC8b4dDd00cE7F319b24664d79D "quorum(uint16,uint64)(uint8)" 9 0 --rpc-url https://sepolia.base.org
cast call 0x59436331823AdEC8b4dDd00cE7F319b24664d79D "quorum(uint16,uint64)(uint8)" 9 0 --rpc-url https://sepolia-rollup.arbitrum.io/rpc
# All should return 1

# Confirm LZ adapter is wired on each chain
cast call 0x24f3192d46869609F8F6605e662b8146CA4240d3 "isWired(uint16)(bool)" 1 --rpc-url https://rpc.hyperliquid-testnet.xyz/evm
cast call 0x953716F877ee85522b34B8A85Fd9560AAEBBee39 "isWired(uint16)(bool)" 9 --rpc-url https://eth-sepolia.g.alchemy.com/v2/$ALCHEMY_API_KEY
cast call 0x953716F877ee85522b34B8A85Fd9560AAEBBee39 "isWired(uint16)(bool)" 9 --rpc-url https://sepolia.base.org
cast call 0x953716F877ee85522b34B8A85Fd9560AAEBBee39 "isWired(uint16)(bool)" 9 --rpc-url https://sepolia-rollup.arbitrum.io/rpc
# All should return true
```

Cross-chain asset registration was tested (Base Sepolia to HyperEvm via LayerZero):

```bash
# Verify Base Sepolia USDC (assetId 2,2) is registered on HyperEvm hub
cast call 0x19258C46573Ba48aB9752A7479AaAb0C00d1674C "isRegistered(uint128)(bool)" $(python3 -c "print((2 << 112) | 2)") --rpc-url https://rpc.hyperliquid-testnet.xyz/evm
# Should return true
```

* [LayerZero scan: delivered tx](https://testnet.layerzeroscan.com/tx/0x62d5699d173e81c53a58d90506aa6d93fd0dd9a7bc0ec293c63ca115cab76bcd)